### PR TITLE
docs: fix critical trigger config error in cross-database replication guide

### DIFF
--- a/cognition/docs/cross-database-replication.md
+++ b/cognition/docs/cross-database-replication.md
@@ -11,7 +11,7 @@ In some deployments, agents may have their own dedicated databases (e.g., `grayb
 Without proper trigger configuration, agents using replicated data experience:
 
 - **Missing notifications**: Agents don't receive `NOTIFY` events for replicated messages
-- **Embedding conflicts**: Duplicate key violations when embedding triggers fire on replicated data
+- **Replication failures**: Embedding triggers that reference columns not present on the subscriber crash the apply worker
 
 ## Architecture Example
 
@@ -43,19 +43,41 @@ CREATE PUBLICATION agent_chat_pub FOR TABLE agent_chat;
 SELECT * FROM pg_publication_tables WHERE pubname = 'agent_chat_pub';
 ```
 
-### 2. Create Subscription (Target Database)  
+### 2. Create Subscription (Target Database)
 
 On the target database (e.g., `graybeard_memory`):
 
 ```sql
--- Create subscription to replicate agent_chat
+-- Normal subscription (use this if it doesn't hang)
 CREATE SUBSCRIPTION agent_chat_from_nova
-CONNECTION 'host=localhost port=5432 dbname=nova_memory user=replication_user'
+CONNECTION 'host=localhost port=5432 dbname=nova_memory user=replication_user password=<password>'
 PUBLICATION agent_chat_pub;
 
 -- Verify subscription
 SELECT * FROM pg_subscription WHERE subname = 'agent_chat_from_nova';
 ```
+
+> **Note on connection strings**: Even for localhost connections, a real password is required if
+> `pg_hba.conf` uses `scram-sha-256` for local connections. Unix socket peer auth is **not**
+> the default on all systems. Always include a `password=` in the connection string.
+
+> **If `CREATE SUBSCRIPTION` hangs**: Use `connect = false` to create the subscription without
+> immediately connecting, then refresh manually:
+> ```sql
+> CREATE SUBSCRIPTION agent_chat_from_nova
+> CONNECTION 'host=localhost port=5432 dbname=nova_memory user=replication_user password=<password>'
+> PUBLICATION agent_chat_pub
+> WITH (connect = false);
+>
+> -- REQUIRED: without this step, pg_subscription_rel stays empty and no data flows
+> ALTER SUBSCRIPTION agent_chat_from_nova REFRESH PUBLICATION WITH (copy_data = false);
+>
+> -- Then enable
+> ALTER SUBSCRIPTION agent_chat_from_nova ENABLE;
+> ```
+
+> **If recreating a subscription for an existing table** (data already partially synced), always
+> use `copy_data = false` to avoid duplicate key conflicts from the initial table copy.
 
 ### 3. Configure Triggers (Automatic)
 
@@ -66,21 +88,39 @@ The `agent-install.sh` script automatically detects logical replication subscrip
 ```
 
 This will:
-- Detect `agent_chat` subscriptions  
+- Detect `agent_chat` subscriptions
 - Configure notification trigger: `ENABLE ALWAYS TRIGGER`
-- Configure embedding trigger: `ENABLE REPLICA TRIGGER`
+- Configure embedding trigger: `DISABLE TRIGGER`
 
 ### 4. Manual Trigger Configuration
 
-If needed, you can manually configure triggers:
+If needed, you can manually configure triggers on the **subscriber database**:
 
 ```sql
 -- Notification trigger: fire ALWAYS (including replicated rows)
 ALTER TABLE agent_chat ENABLE ALWAYS TRIGGER trg_notify_agent_chat;
 
--- Embedding trigger: fire REPLICA only (skip replicated rows)  
-ALTER TABLE agent_chat ENABLE REPLICA TRIGGER trg_embed_chat_message;
+-- Embedding trigger: DISABLE — embeddings are generated on the source;
+-- the trigger function also references columns (e.g. content_hash in memory_embeddings)
+-- that may not exist on the subscriber
+ALTER TABLE agent_chat DISABLE TRIGGER trg_embed_chat_message;
+
+-- Enforce-function-use trigger: leave at default ORIGIN — correctly skipped during replication
+-- (no action needed; O is the default)
 ```
+
+### Trigger Configuration Summary (Subscriber Databases)
+
+| Trigger | Mode | Reason |
+|---|---|---|
+| `trg_notify_agent_chat` | `A` (ALWAYS) | Must fire on replicated rows so the agent receives NOTIFY events |
+| `trg_embed_chat_message` | `D` (DISABLED) | Embeddings are generated on the source. The trigger function also references columns (e.g. `content_hash` in `memory_embeddings`) that may not exist on the subscriber — if set to REPLICA it will crash the apply worker |
+| `trg_enforce_function_use` | `O` (ORIGIN) | Only blocks direct INSERT from normal sessions; correctly skipped during replication |
+
+> ⚠️ **Critical**: Do **not** use `ENABLE REPLICA TRIGGER trg_embed_chat_message` on subscriber
+> databases. This causes the replication apply worker to crash with:
+> `ERROR: column "content_hash" of relation "memory_embeddings" does not exist`
+> The `apply_error_count` in `pg_stat_subscription_stats` will increment silently.
 
 ## Verification
 
@@ -106,12 +146,13 @@ WHERE c.relname = 'agent_chat'
 ORDER BY triggername;
 ```
 
-Expected output:
+Expected output on a **subscriber** database:
 ```
- schemaname | tablename  |      triggername       | trigger_mode
-------------+------------+------------------------+--------------
- public     | agent_chat | trg_embed_chat_message | REPLICA
- public     | agent_chat | trg_notify_agent_chat  | ALWAYS
+ schemaname | tablename  |         triggername          | trigger_mode
+------------+------------+------------------------------+--------------
+ public     | agent_chat | trg_embed_chat_message       | DISABLED
+ public     | agent_chat | trg_enforce_function_use     | ORIGIN
+ public     | agent_chat | trg_notify_agent_chat        | ALWAYS
 ```
 
 ### Test Replication
@@ -130,6 +171,37 @@ SELECT * FROM agent_chat ORDER BY id DESC LIMIT 1;
 
 3. Check that Graybeard agent receives `NOTIFY agent_chat` event
 
+## Monitoring
+
+### Check for Silent Replication Failures
+
+The fastest way to diagnose silent replication failures is `pg_stat_subscription_stats`:
+
+```sql
+-- On the subscriber database
+SELECT 
+    subname,
+    apply_error_count,
+    sync_error_count
+FROM pg_stat_subscription_stats;
+```
+
+A non-zero `apply_error_count` means the apply worker is crashing and retrying. Check
+`pg_stat_activity` and PostgreSQL logs for the underlying error.
+
+```sql
+-- Check apply worker status
+SELECT * FROM pg_stat_subscription;
+
+-- Check replication lag
+SELECT 
+    subname,
+    received_lsn,
+    latest_end_lsn,
+    latest_end_time
+FROM pg_stat_subscription;
+```
+
 ## Troubleshooting
 
 ### Notifications Not Received
@@ -141,13 +213,64 @@ SELECT * FROM agent_chat ORDER BY id DESC LIMIT 1;
 ALTER TABLE agent_chat ENABLE ALWAYS TRIGGER trg_notify_agent_chat;
 ```
 
-### Duplicate Key Violations  
+### Apply Worker Crashes / Replication Stalls
 
-**Symptom**: `duplicate key value violates unique constraint "memory_embeddings_pkey"`
-**Solution**: Ensure embedding trigger only fires on REPLICA:
+**Symptom**: `apply_error_count` incrementing in `pg_stat_subscription_stats`; replication appears
+connected but rows stop flowing
+**Common cause**: `trg_embed_chat_message` is set to REPLICA instead of DISABLED
+**Solution**:
 
 ```sql
-ALTER TABLE agent_chat ENABLE REPLICA TRIGGER trg_embed_chat_message;
+-- Check current trigger mode
+SELECT triggername, tgenabled FROM pg_trigger t
+JOIN pg_class c ON t.tgrelid = c.oid
+WHERE c.relname = 'agent_chat' AND NOT t.tgisinternal;
+
+-- Fix: disable the embedding trigger
+ALTER TABLE agent_chat DISABLE TRIGGER trg_embed_chat_message;
+```
+
+### No Data Flowing (Worker Appears Connected)
+
+**Symptom**: `pg_stat_subscription` shows a connected worker, but `pg_subscription_rel` is empty
+and no rows replicate
+**Cause**: Subscription was created with `connect = false` but `REFRESH PUBLICATION` was never run
+**Solution**:
+
+```sql
+ALTER SUBSCRIPTION agent_chat_from_nova REFRESH PUBLICATION WITH (copy_data = false);
+```
+
+### Duplicate Key Violations During Initial Sync
+
+**Symptom**: `duplicate key value violates unique constraint` during subscription creation
+**Solution**: Use `copy_data = false` when recreating a subscription for a table that already has data:
+
+```sql
+CREATE SUBSCRIPTION agent_chat_from_nova
+CONNECTION '...'
+PUBLICATION agent_chat_pub
+WITH (copy_data = false);
+```
+
+### Orphaned Replication Slot
+
+**Symptom**: `CREATE SUBSCRIPTION` fails because a slot with the same name already exists, or
+disk space is filling up from a retained WAL slot
+**Solution**: Drop the orphaned slot on the publisher:
+
+```sql
+-- On nova_memory (publisher)
+-- If the walsender is active, terminate it first:
+SELECT pg_terminate_backend(pid) 
+FROM pg_stat_activity 
+WHERE application_name = 'agent_chat_from_nova';
+
+-- Then drop the slot
+SELECT pg_drop_replication_slot('agent_chat_from_nova');
+
+-- Verify
+SELECT slot_name, active FROM pg_replication_slots;
 ```
 
 ### Subscription Issues
@@ -255,6 +378,9 @@ SELECT * FROM pg_publication_tables WHERE pubname = 'agent_chat_pub';
 -- On graybeard_memory: check subscription lag
 SELECT subname, subenabled FROM pg_subscription;
 SELECT * FROM pg_stat_subscription;
+
+-- Check for apply errors
+SELECT subname, apply_error_count FROM pg_stat_subscription_stats;
 ```
 
 #### 7. Reconfigure triggers
@@ -264,7 +390,7 @@ After re-enabling, ensure triggers are set correctly (see [Configure Triggers](#
 ```sql
 -- On graybeard_memory
 ALTER TABLE agent_chat ENABLE ALWAYS TRIGGER trg_notify_agent_chat;
-ALTER TABLE agent_chat ENABLE REPLICA TRIGGER trg_embed_chat_message;
+ALTER TABLE agent_chat DISABLE TRIGGER trg_embed_chat_message;
 ```
 
 ## Related Files


### PR DESCRIPTION
Fixes incorrect recommendation to use ENABLE REPLICA TRIGGER for trg_embed_chat_message — this actually breaks replication because the trigger function references a non-existent column. Changed to DISABLE TRIGGER. Also adds monitoring guidance, subscription creation clarifications, and new troubleshooting entries.