### PR TITLE
feat: Channel transcript storage, memory reinforcement, and source pointers (#165, #138, #170)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,6 +219,8 @@ Return entity + profile for personalization
 | `agent_turn_context` | Memory/Cognition | Per‑turn critical context injection | `context_type`, `domain_name`, `content` (≤500 chars) |
 | `agent_bootstrap_context` | Cognition | Session‑level initialization context | `context_type`, `domain_name`, `file_key`, `content` |
 | `memory_embeddings` | Memory | Vector embeddings for semantic search | `source_type`, `source_id`, `embedding` (vector(1024)) |
+| `channel_sessions` | Memory | Structured chat session records (replaces deprecated `conversations` table) | `provider`, `external_chat_id`, `chat_type`, `message_count`, `last_message_at` |
+| `channel_transcripts` | Memory | Individual message transcripts with FK source pointers to `entity_facts` | `session_id`, `external_message_id`, `sender_entity_id`, `content` |
 | `certificates` | Relationships | Client certificates for agent auth | `common_name`, `certificate`, `issued_at`, `expires_at` |
 
 **Note:** The complete schema (`database/schema.sql`) contains ~100 tables; the above highlights the core inter‑subsystem tables.
@@ -231,7 +233,7 @@ nova‑mind integrates with OpenClaw via hooks that run on gateway events:
 
 | Hook | Event | Purpose |
 |------|-------|---------|
-| `memory‑extract` | `message:received` | Extract structured memories from natural language using Claude |
+| `memory‑extract` | `message:received` | Extract structured memories from natural language using Claude. Real-time upserts `channel_sessions`/`channel_transcripts` rows and passes FK IDs as env vars to the extraction pipeline for source attribution. |
 | `semantic‑recall` | `message:received` | Search vector embeddings for relevant memories; inject into context |
 | `session‑init` | `session:init` | Generate privacy‑filtered context when sessions start |
 | `agent‑turn‑context` | `message:received` | Inject high‑priority context from `agent_turn_context` table (cached 5‑min) |

--- a/database/schema-reference.md
+++ b/database/schema-reference.md
@@ -1,6 +1,6 @@
 # Database Schema Reference
 
-*Auto-generated: 2026-05-07T09:32:37.433518*
+*Auto-generated: 2026-05-09T11:03:00.000000*
 
 ## Tables
 
@@ -24,7 +24,8 @@
 | bootstrap_context_config | Configuration for bootstrap system behavior | 4 |
 | certificates | Client certificates issued by NOVA CA. Security-sensitive. Verify before modifications. | 12 |
 | channel_activity | Tracks last message per channel for idle detection. Read/write: NOVA, Newhart. | 3 |
-| conversations | Conversation session tracking. Logs chat sessions with metadata for analysis and continuity. | 6 |
+| channel_sessions | Structured chat session records. Replaces legacy conversations table. One row per provider+chat+thread. | 15 |
+| channel_transcripts | Individual message transcripts linked to channel_sessions. FK source for entity_facts. | 15 |
 | entities | People, AIs, organizations. NOVA has full access. Use entity_facts for attributes. | 20 |
 | entity_fact_conflicts | Conflicts between entity facts requiring resolution. Part of the truth reconciliation system. | 13 |
 | entity_facts | Key-value facts about entities. Check current_timezone for I)ruid before time-based actions. | 19 |
@@ -41,7 +42,7 @@
 | gambling_logs | High-level gambling session summaries. Groups multiple gambling_entries by session. | 8 |
 | git_issue_queue | Issue queue for git-based workflows. NOTIFY triggers dispatch work automatically. | 16 |
 | job_messages | Message log per job for conversation threading | 5 |
-| lessons | Lessons and insights learned. Update when learning something worth remembering. | 11 |
+| lessons | Lessons and insights learned. Update when learning something worth remembering. | 12 |
 | lessons_archive | Archived lessons and insights. Historical record of previously stored learnings. | 13 |
 | library_authors | Library domain: normalized author records. Managed by Athena (librarian agent). | 4 |
 | library_tags | Library domain: subject/genre/topic tags for works. Managed by Athena. | 3 |

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -6560,13 +6560,13 @@ CREATE OR REPLACE VIEW workflow_steps_detail AS
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
+REVOKE SELECT ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_actions FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6674,13 +6674,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_bootstrap_context FROM iris;
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6716,13 +6716,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat_processed FROM newhart;
+REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat_processed FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6764,13 +6764,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM iris;
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
+REVOKE SELECT ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_domains FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6794,13 +6794,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6998,13 +6998,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agents FROM iris;
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agents FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
+REVOKE SELECT ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7094,25 +7094,25 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
-
---
--- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE asset_classes FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
+
+--
+-- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7286,13 +7286,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE gambling_logs FROM nova;
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE git_issue_queue FROM coder;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
+REVOKE SELECT ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: job_messages; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7316,13 +7316,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7382,13 +7382,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7580,13 +7580,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_relationships FROM ticker;
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
+REVOKE SELECT ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7754,13 +7754,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7838,13 +7838,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7880,13 +7880,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE preferences FROM nova;
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
+REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: project_entities; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8366,13 +8366,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tags FROM nova;
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
+REVOKE SELECT ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tags FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8432,13 +8432,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tasks FROM nova;
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
+REVOKE SELECT ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tasks FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8504,13 +8504,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE tasks FROM nova;
 -- Name: ticker_portfolio; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ticker_portfolio FROM ticker;
+REVOKE SELECT ON TABLE ticker_portfolio FROM ticker;
 
 --
 -- Name: ticker_portfolio; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ticker_portfolio FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ticker_portfolio FROM ticker;
 
 --
 -- Name: tools; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8570,13 +8570,13 @@ REVOKE SELECT ON TABLE workflow_runs FROM erato;
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE workflow_runs FROM gem;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM gem;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM gem;
+REVOKE SELECT ON TABLE workflow_runs FROM gem;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8600,13 +8600,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM iris;
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM newhart;
+REVOKE SELECT ON TABLE workflow_runs FROM newhart;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE workflow_runs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM newhart;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -6560,13 +6560,13 @@ CREATE OR REPLACE VIEW workflow_steps_detail AS
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_actions FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
+REVOKE SELECT ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6872,13 +6872,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM ticker;
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_spawns FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
+REVOKE SELECT ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6920,13 +6920,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM iris;
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_system_config FROM newhart;
+REVOKE SELECT ON TABLE agent_system_config FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_system_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_system_config FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6950,13 +6950,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7064,13 +7064,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM iris;
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ai_models FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
+REVOKE SELECT ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7106,13 +7106,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
+REVOKE SELECT ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE asset_classes FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7154,13 +7154,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7286,13 +7286,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE gambling_logs FROM nova;
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
+REVOKE SELECT ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE git_issue_queue FROM coder;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: job_messages; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7316,13 +7316,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7382,13 +7382,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7448,13 +7448,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7646,13 +7646,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_tags FROM ticker;
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_works FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
+REVOKE SELECT ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7754,25 +7754,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
-
---
--- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE music_library FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
+
+--
+-- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE music_library FROM iris;
 
 --
 -- Name: place_properties; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7802,13 +7802,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FRO
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
+REVOKE SELECT ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_history FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7826,19 +7826,13 @@ REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
-
---
--- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7847,10 +7841,10 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 
 --
--- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
+-- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7859,16 +7853,22 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
 
 --
--- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
+-- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE positions FROM ticker;
+
+--
+-- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
 
 --
 -- Name: preferences; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7880,13 +7880,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE preferences FROM nova;
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
+REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: project_entities; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7970,13 +7970,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_citations FROM nova;
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
+REVOKE SELECT ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_citations FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8036,13 +8036,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8102,13 +8102,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_findings FROM nova;
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
+REVOKE SELECT ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_findings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8234,13 +8234,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8300,13 +8300,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8366,13 +8366,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tags FROM nova;
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tags FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
+REVOKE SELECT ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8504,13 +8504,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE tasks FROM nova;
 -- Name: ticker_portfolio; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ticker_portfolio FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ticker_portfolio FROM ticker;
 
 --
 -- Name: ticker_portfolio; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ticker_portfolio FROM ticker;
+REVOKE SELECT ON TABLE ticker_portfolio FROM ticker;
 
 --
 -- Name: tools; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8558,25 +8558,25 @@ REVOKE DELETE ON TABLE workflow_runs FROM coder;
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM erato;
-
---
--- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE SELECT ON TABLE workflow_runs FROM erato;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM gem;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM erato;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE workflow_runs FROM gem;
+
+--
+-- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM gem;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -225,6 +225,7 @@ CREATE TABLE IF NOT EXISTS agent_bootstrap_context (
     agent_name text,
     CONSTRAINT agent_bootstrap_context_pkey PRIMARY KEY (id),
     CONSTRAINT agent_bootstrap_context_context_type_check CHECK (context_type IN ('UNIVERSAL'::text, 'GLOBAL'::text, 'DOMAIN'::text, 'AGENT'::text)),
+    CONSTRAINT chk_domain_no_agent_name CHECK (context_type <> 'DOMAIN'::text OR agent_name IS NULL),
     CONSTRAINT chk_universal_global_no_names CHECK ((context_type <> ALL (ARRAY['UNIVERSAL'::text, 'GLOBAL'::text])) OR agent_name IS NULL AND domain_name IS NULL)
 );
 
@@ -3666,26 +3667,62 @@ BEGIN
 
         UNION ALL
 
-        -- 4. WORKFLOW — inject workflows the agent participates in (by domain overlap)
+        -- 4. WORKFLOW — inject workflow SUMMARIES with agent role context
         SELECT
             'WORKFLOW_' || upper(replace(w.name, '-', '_')) || '.md' AS filename,
             w.name || ': ' || w.description ||
-            CASE WHEN steps_text IS NOT NULL
-                 THEN E'\n\nSteps:\n' || steps_text
-                 ELSE ''
-            END AS content,
+            E'\n\n' ||
+            -- Orchestrator note
+            CASE WHEN EXISTS (
+                SELECT 1 FROM agent_domains ad
+                WHERE ad.agent_id = v_agent_id
+                  AND ad.domain_topic = w.orchestrator_domain
+            )
+            THEN 'You are the **orchestrator** of this workflow (via ' || w.orchestrator_domain || ' domain). '
+                 || 'You are responsible for reading and understanding the entire workflow, maintaining state, delegating to domain-appropriate agents, and tracking progress.'
+                 || E'\n\n'
+            ELSE ''
+            END ||
+            -- Agent's steps
+            'Your steps: ' || COALESCE(agent_steps.step_list, 'none directly assigned') ||
+            E'\n' ||
+            -- All domains
+            'All domains involved: ' || COALESCE(all_domains.domain_list, 'none') ||
+            ' (' || COALESCE(step_count.cnt, 0) || ' steps total).' ||
+            E'\n\n' ||
+            '> When you are employed to participate in this workflow, understand your role and what is expected of you in the steps you own before beginning. ' ||
+            'Query your steps for full details:' ||
+            E'\n> ```sql' ||
+            E'\n> SELECT step_order, domain, requires_discussion, requires_authorization, description' ||
+            E'\n> FROM workflow_steps WHERE workflow_id = ' || w.id || ' ORDER BY step_order;' ||
+            E'\n> ```'
+            AS content,
             'workflow:' || w.name AS source,
             4 AS priority
         FROM workflows w
+        -- Agent's specific steps (by domain match)
         LEFT JOIN LATERAL (
             SELECT string_agg(
-                ws.step_order || '. ' || ws.description ||
-                COALESCE(' [domain: ' || ws.domain || ']', ''),
-                E'\n' ORDER BY ws.step_order
-            ) AS steps_text
+                'Step ' || ws.step_order || ' (' || ws.domain || ')',
+                ', ' ORDER BY ws.step_order
+            ) AS step_list
+            FROM workflow_steps ws
+            JOIN agent_domains ad ON ad.agent_id = v_agent_id
+            WHERE ws.workflow_id = w.id
+              AND (ad.domain_topic = ws.domain OR ad.domain_topic = ANY(ws.domains))
+        ) agent_steps ON true
+        -- All domains across all steps
+        LEFT JOIN LATERAL (
+            SELECT string_agg(DISTINCT ws.domain, ', ' ORDER BY ws.domain) AS domain_list
             FROM workflow_steps ws
             WHERE ws.workflow_id = w.id
-        ) ws_agg ON true
+        ) all_domains ON true
+        -- Step count
+        LEFT JOIN LATERAL (
+            SELECT count(*)::int AS cnt
+            FROM workflow_steps ws
+            WHERE ws.workflow_id = w.id
+        ) step_count ON true
         WHERE w.status = 'active'
           AND (
             -- Workflow's orchestrator domain matches one of the agent's domains
@@ -3716,6 +3753,12 @@ BEGIN
     ORDER BY subq.filename, subq.priority;
 END;
 $$;
+
+--
+-- Name: get_agent_bootstrap(text); Type: FUNCTION; Schema: -; Owner: -
+--
+
+COMMENT ON FUNCTION get_agent_bootstrap(text) IS 'Get all bootstrap files for an agent: UNIVERSAL + GLOBAL + DOMAIN-matched + WORKFLOW summaries (matched by orchestrator_domain or workflow_steps.domain/domains[] overlap with agent_domains) + AGENT-specific. Domain-based workflow matching (orchestrator_agent_id and workflow_steps.agent_id were dropped). See nova-mind#171 / 5b20b40.';
 
 --
 -- Name: get_agent_skills(text); Type: FUNCTION; Schema: -; Owner: -
@@ -4726,6 +4769,76 @@ END;
 $$;
 
 --
+-- Name: protect_bootstrap_context_writes_v2(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION protect_bootstrap_context_writes_v2()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+DECLARE
+  -- File keys agents are allowed to self-manage on their own AGENT records
+  self_managed_keys TEXT[] := ARRAY[
+    'identity', 'IDENTITY',
+    'AGENTS',
+    'TOOLS',
+    'HEARTBEAT',
+    'MEMORY'
+  ];
+BEGIN
+  -- Superuser and Newhart always pass (full access)
+  IF current_user IN ('newhart', 'postgres') THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  -- === INSERT: agents can create their own AGENT records with self-managed file_keys ===
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.context_type = 'AGENT'
+       AND NEW.agent_name = current_user
+       AND NEW.file_key = ANY(self_managed_keys)
+    THEN
+      RETURN NEW;
+    END IF;
+
+    RAISE EXCEPTION
+      'agent_bootstrap_context INSERT denied for user "%". '
+      'Agents may only insert their own AGENT records with self-managed file_keys '
+      '(identity, IDENTITY, AGENTS, TOOLS, HEARTBEAT, MEMORY). '
+      'Contact Newhart for other changes.',
+      current_user;
+  END IF;
+
+  -- === UPDATE: agents can update their own AGENT records with self-managed file_keys ===
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.context_type = 'AGENT'
+       AND NEW.file_key = ANY(self_managed_keys)
+       AND NEW.agent_name = current_user
+       -- Prevent mutating the structural columns
+       AND NEW.agent_name = OLD.agent_name
+       AND NEW.file_key   = OLD.file_key
+       AND NEW.context_type = OLD.context_type
+    THEN
+      RETURN NEW;
+    END IF;
+
+    RAISE EXCEPTION
+      'agent_bootstrap_context UPDATE denied for user "%". '
+      'Agents may only update their own AGENT records with self-managed file_keys '
+      '(identity, IDENTITY, AGENTS, TOOLS, HEARTBEAT, MEMORY). '
+      'Contact Newhart for other changes.',
+      current_user;
+  END IF;
+
+  -- === DELETE: only newhart/postgres (already returned above) ===
+  RAISE EXCEPTION
+    'agent_bootstrap_context DELETE denied for user "%". '
+    'Only Newhart can delete bootstrap context records.',
+    current_user;
+END;
+$$;
+
+--
 -- Name: protect_library_writes(); Type: FUNCTION; Schema: -; Owner: -
 --
 
@@ -4739,6 +4852,28 @@ BEGIN
         RAISE EXCEPTION 'Library tables are managed by the Library domain (athena). Contact the Library domain for changes.';
     END IF;
     RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+--
+-- Name: protect_peer_agent_model_changes(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION protect_peer_agent_model_changes()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    -- Peer agents: model and fallback_models changes require postgres user
+    IF OLD.name IN ('nova', 'graybeard', 'newhart') THEN
+        IF (OLD.model IS DISTINCT FROM NEW.model) OR (OLD.fallback_models IS DISTINCT FROM NEW.fallback_models) THEN
+            IF current_user != 'postgres' THEN
+                RAISE EXCEPTION 'Model changes to peer agents (nova, graybeard, newhart) require human authorization. Use postgres user or contact I)ruid.';
+            END IF;
+        END IF;
+    END IF;
+    RETURN NEW;
 END;
 $$;
 
@@ -5689,7 +5824,7 @@ CREATE OR REPLACE TRIGGER protect_agents_update
 CREATE OR REPLACE TRIGGER protect_bootstrap_context
     BEFORE INSERT OR UPDATE OR DELETE ON agent_bootstrap_context
     FOR EACH ROW
-    EXECUTE FUNCTION protect_bootstrap_context_writes();
+    EXECUTE FUNCTION protect_bootstrap_context_writes_v2();
 
 --
 -- Name: protect_library_authors; Type: TRIGGER; Schema: -; Owner: -
@@ -5744,6 +5879,15 @@ CREATE OR REPLACE TRIGGER protect_library_works
     BEFORE INSERT OR UPDATE OR DELETE ON library_works
     FOR EACH ROW
     EXECUTE FUNCTION protect_library_writes();
+
+--
+-- Name: protect_peer_models; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER protect_peer_models
+    BEFORE UPDATE ON agents
+    FOR EACH ROW
+    EXECUTE FUNCTION protect_peer_agent_model_changes();
 
 --
 -- Name: protect_research_citations; Type: TRIGGER; Schema: -; Owner: -
@@ -6416,13 +6560,13 @@ CREATE OR REPLACE VIEW workflow_steps_detail AS
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_actions FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
+REVOKE SELECT ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6464,13 +6608,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_aliases FROM iris;
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_aliases FROM newhart;
+REVOKE SELECT ON TABLE agent_aliases FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_aliases FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_aliases FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6650,13 +6794,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6776,13 +6920,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM iris;
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_system_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_system_config FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_system_config FROM newhart;
+REVOKE SELECT ON TABLE agent_system_config FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6920,13 +7064,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM iris;
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
+REVOKE SELECT ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ai_models FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6962,13 +7106,13 @@ REVOKE SELECT ON TABLE artwork FROM iris;
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
+REVOKE SELECT ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE asset_classes FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7010,13 +7154,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7172,13 +7316,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7304,13 +7448,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7370,13 +7514,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_authors FROM ticker;
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_relationships FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
+REVOKE SELECT ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7610,13 +7754,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7658,25 +7802,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FRO
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_history FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
-
---
--- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
+REVOKE SELECT ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
+
+--
+-- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7694,13 +7838,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7736,13 +7880,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE preferences FROM nova;
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
+REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: project_entities; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7826,13 +7970,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_citations FROM nova;
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_citations FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
+REVOKE SELECT ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7892,13 +8036,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7958,13 +8102,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_findings FROM nova;
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_findings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
+REVOKE SELECT ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8090,13 +8234,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8156,13 +8300,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8414,19 +8558,13 @@ REVOKE DELETE ON TABLE workflow_runs FROM coder;
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE workflow_runs FROM erato;
-
---
--- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM erato;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM gem;
+REVOKE SELECT ON TABLE workflow_runs FROM erato;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8438,19 +8576,25 @@ REVOKE SELECT ON TABLE workflow_runs FROM gem;
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM gem;
+
+--
+-- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
 REVOKE DELETE ON TABLE workflow_runs FROM gidget;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM iris;
+REVOKE SELECT ON TABLE workflow_runs FROM iris;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE workflow_runs FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM iris;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -6560,13 +6560,13 @@ CREATE OR REPLACE VIEW workflow_steps_detail AS
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
+REVOKE SELECT ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_actions FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6704,25 +6704,25 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_bootstrap_context FROM ticker;
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_chat FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
-
---
--- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
+REVOKE SELECT ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat_processed FROM newhart;
+
+--
+-- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6764,13 +6764,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM iris;
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_domains FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
+REVOKE SELECT ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6998,13 +6998,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agents FROM iris;
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
+REVOKE SELECT ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agents FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7064,13 +7064,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM iris;
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
+REVOKE SELECT ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ai_models FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7094,25 +7094,25 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
-
---
--- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE asset_classes FROM ticker;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
+
+--
+-- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7154,13 +7154,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7286,13 +7286,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE gambling_logs FROM nova;
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE git_issue_queue FROM coder;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
+REVOKE SELECT ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: job_messages; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7316,13 +7316,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7382,13 +7382,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7754,25 +7754,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
-
---
--- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE music_library FROM iris;
+
+--
+-- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
 
 --
 -- Name: place_properties; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7802,13 +7802,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FRO
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_history FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
+REVOKE SELECT ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7826,25 +7826,25 @@ REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
+REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
-
---
--- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
+
+--
+-- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8036,13 +8036,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8102,13 +8102,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_findings FROM nova;
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_findings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
+REVOKE SELECT ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8234,13 +8234,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8300,13 +8300,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8432,13 +8432,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tasks FROM nova;
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tasks FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
+REVOKE SELECT ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8570,13 +8570,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM erato;
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE workflow_runs FROM gem;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM gem;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM gem;
+REVOKE SELECT ON TABLE workflow_runs FROM gem;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8600,13 +8600,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM iris;
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE workflow_runs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM newhart;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM newhart;
+REVOKE SELECT ON TABLE workflow_runs FROM newhart;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8636,13 +8636,13 @@ REVOKE DELETE ON TABLE workflow_runs FROM scout;
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE workflow_runs FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM ticker;
 
 --
 -- Name: workflow_runs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE workflow_runs FROM ticker;
+REVOKE SELECT ON TABLE workflow_runs FROM ticker;
 
 --
 -- Name: workflow_steps; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/memory/ARCHITECTURE.md
+++ b/memory/ARCHITECTURE.md
@@ -50,7 +50,7 @@ This is the source of truth for persistent information.
 | Table | Purpose |
 |-------|---------|
 | `entities` | People, AIs, organizations — things with agency |
-| `entity_facts` | Key-value facts about entities (includes `visibility`, `privacy_scope`, `data_type` for access control — see note below) |
+| `entity_facts` | Key-value facts about entities (includes `visibility`, `privacy_scope`, `data_type` for access control — see note below). Now includes `source_channel_transcript_id` and `source_channel_session_id` FK columns linking facts back to their source chat messages. |
 | `entity_relationships` | Connections between entities |
 | `places` | Locations, networks, venues |
 | `projects` | Active efforts with goals |
@@ -62,6 +62,8 @@ This is the source of truth for persistent information.
 | `preferences` | User and system preferences |
 | `agent_turn_context` | Per-turn context injected before every agent response (UNIVERSAL → GLOBAL → DOMAIN → AGENT priority) |
 | `memory_type_priorities` | Priority weights for semantic recall by source_type |
+| `channel_sessions` | Structured chat session records — one row per provider+chat+thread. Replaces legacy JSONL file storage and the deprecated `conversations` table. |
+| `channel_transcripts` | Individual message transcripts linked to `channel_sessions`. FK source for `entity_facts.source_channel_transcript_id`. |
 
 #### Entity Facts Access Control Columns
 
@@ -199,14 +201,21 @@ WHERE me.source_type = 'entity_fact' AND ef.id IS NULL;
 
 ## Memory Extraction Pipeline
 
-A cron job runs every minute to extract memories from chat:
+A cron job runs every minute to extract memories from chat. The pipeline now also ingests session transcripts into structured database tables:
 
 ```
-Chat transcript → memory-catchup.sh (every 1 min)
-               → extract-memories.sh (Claude extracts 8 categories)
-               → store-memories.sh (inserts to PostgreSQL)
+Session JSONL files → memory-catchup.sh (every 1 min)
+                    → channel_sessions + channel_transcripts (DB ingest)
+                    → delete source JSONL files
+                    
+and separately:
+
+Chat transcript → extract-memories.sh (Claude extracts 8 categories)
+               → store-memories.sh (inserts to PostgreSQL, sets source FK pointers)
                → New vocabulary? → STT service restarts
 ```
+
+**Transcript ingestion:** JSONL files from `~/.openclaw/agents/*/sessions/*.jsonl` are parsed, upserted into `channel_sessions` and `channel_transcripts`, then the source files are deleted. Rich metadata (sender names, IDs, group info, providers) is extracted from the JSONL structure. The `memory-extract` hook also does real-time upserts during message processing, passing FK IDs (`SOURCE_CHANNEL_TRANSCRIPT_ID`, `SOURCE_CHANNEL_SESSION_ID`) to `store-memories.sh` so `entity_facts` rows link back to their source transcripts.
 
 ### Extraction Categories
 

--- a/memory/CHANGELOG.md
+++ b/memory/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+- **Structured chat transcript storage** (#165, #138, #170) — New `channel_sessions` and `channel_transcripts` tables replace the deprecated `conversations` table and JSONL file storage. Migration 067 creates both tables, adds `source_channel_transcript_id` and `source_channel_session_id` FK columns to `entity_facts`, and drops the legacy `conversations` table.
+- **JSONL → DB ingest in `memory-catchup.sh`** (#165, #138, #170) — The catchup script now ingests JSONL session transcripts from `~/.openclaw/agents/*/sessions/*.jsonl` into `channel_sessions` + `channel_transcripts` during each run. Source files are deleted after successful DB commit. Extraction failures no longer block transcript ingestion.
+- **Real-time channel transcript upsert in `memory-extract` hook** (#170) — `handler.ts` now does a lightweight upsert of `channel_sessions`/`channel_transcripts` during message processing, then passes the FK IDs (`SOURCE_CHANNEL_TRANSCRIPT_ID`, `SOURCE_CHANNEL_SESSION_ID`) as env vars to the extraction pipeline.
+- **`store-memories.sh`: FK source pointers on `entity_facts`** (#170) — During fact insertion and reinforcement, `source_channel_transcript_id` and `source_channel_session_id` are populated on `entity_facts` rows. SQL injection fix in `fact_exists()` (ILIKE → exact LOWER equality).
+
 ### Changed
 - **Semantic-recall handler: channel-aware entity routing** (#8, #159, #164) — The `extractIdentifiers()` function maps provider-specific sender IDs (`discord`, `telegram`, `slack`, `signal`) to the correct `EntityIdentifiers` fields. Uses `resolveEntityByIdentifiers()` for conflict detection — logs a data integrity warning and skips entity injection if identifiers match different entities.
 - **Semantic-recall handler: fixed field paths** (#8, #159, #164) — Message text now reads from `event.context.content` (was `event.context.message`). Sender metadata reads from `event.context.metadata.senderId`/`.senderName`/`.provider`/`.senderE164` (was `event.context.senderId`). Legacy paths retained as fallbacks.

--- a/memory/README.md
+++ b/memory/README.md
@@ -165,7 +165,7 @@ This system allows an AI to:
 The schema (`schema/schema.sql`) includes tables for:
 
 - **entities** - People, AIs, organizations, pets, stuffed animals
-- **entity_facts** - Key-value facts about entities
+- **entity_facts** - Key-value facts about entities. Includes FK source pointers (`source_channel_transcript_id`, `source_channel_session_id`) linking facts back to their source chat transcript (#170).
 - **entity_relationships** - Connections between entities
 - **places** - Locations, restaurants, venues, networks
 - **projects** - Active projects with tasks, status, and Git configuration
@@ -174,6 +174,8 @@ The schema (`schema/schema.sql`) includes tables for:
 - **preferences** - User/system preferences
 - **agents** - Registry of AI agent instances for delegation
 - **agent_turn_context** - Per-turn context records injected into every agent message (UNIVERSAL, GLOBAL, DOMAIN, AGENT scopes; 500-char per record / 2000-char total budget)
+- **channel_sessions** - Structured chat session records (one per provider+chat+thread), replaces legacy `conversations` table and JSONL file storage
+- **channel_transcripts** - Individual message transcripts linked to `channel_sessions`, FK source for `entity_facts`
 
 ### Access Control Architecture
 
@@ -1051,6 +1053,9 @@ The catch-up script:
 - Tracks last processed timestamp to avoid duplicates
 - Rate-limits to 3 messages per run
 - Runs extraction asynchronously
+- **Ingests JSONL session files** into `channel_sessions` + `channel_transcripts` tables with provider detection (Discord, Signal, generic) and rich metadata parsing
+- **Ingests daily memory `*.md` files** into `entity_facts` on the NOVA entity
+- **Deletes source files** after successful DB commit (both JSONL and `.md` files)
 
 State is stored in `~/.openclaw/memory-catchup-state.json`.
 

--- a/memory/docs/memory-extraction-pipeline.md
+++ b/memory/docs/memory-extraction-pipeline.md
@@ -5,11 +5,17 @@ The memory extraction pipeline automatically transforms natural language convers
 ## Overview
 
 ```
-Chat Message → memory-catchup.sh → extract-memories.sh → store-memories.sh → PostgreSQL
-     ↓               ↓                    ↓                    ↓
-Every message   Every minute      Claude API           Structured data
-received        (cron job)        extraction           with deduplication
+Session JSONL → memory-catchup.sh ──→ channel_sessions/transcripts (DB)
+     ↓                                    ↓
+  extract-memories.sh ──→ store-memories.sh ──→ PostgreSQL (entity_facts + FK source pointers)
+     ↓                        ↓
+  Claude API             Structured data
+  extraction             with deduplication
 ```
+
+The pipeline now has two parallel paths:
+1. **Transcript ingestion:** JSONL session files are parsed and upserted into `channel_sessions`/`channel_transcripts` tables, then source files are deleted
+2. **Memory extraction:** Messages are sent to Claude for structured data extraction, and results are stored with FK pointers back to the source `channel_transcripts` row
 
 **Key Features:**
 - 20-message rolling context window for reference resolution
@@ -17,6 +23,7 @@ received        (cron job)        extraction           with deduplication
 - Real-time deduplication to prevent data corruption
 - Automatic vocabulary extraction for STT improvement
 - Rate limiting and error recovery
+- JSONL → DB ingest with provider detection (Discord, Signal, Telegram, generic)
 
 ## Components
 
@@ -31,6 +38,9 @@ received        (cron job)        extraction           with deduplication
 2. Tracks last processed timestamp in `~/.openclaw/memory-catchup-state.json`
 3. Rate-limits to 3 messages per run to avoid API overload
 4. Builds 20-message context window for each extraction
+5. **Ingests JSONL files into DB:** Parses session files from `~/.openclaw/agents/*/sessions/*.jsonl` and upserts into `channel_sessions` + `channel_transcripts` with provider detection, rich metadata parsing (sender names, IDs, group info), and deduplication via composite unique indexes
+6. **Deletes source files:** After successful DB commit, source JSONL files are removed. Extraction failures do NOT block transcript ingestion.
+7. **Ingests daily memory `*.md` files:** Content is stored as `entity_facts` on the NOVA entity, then source files are deleted
 
 **State file structure:**
 ```json
@@ -40,6 +50,12 @@ received        (cron job)        extraction           with deduplication
   "last_session": "2026-02-08.jsonl"
 }
 ```
+
+**Transcript ingest fields parsed from JSONL:**
+- `chat_id` → `provider` detection (channel: → discord, group: → signal)
+- `is_group_chat`, `group_subject`, `group_space` → session metadata
+- `sender_id`, `sender`, `sender_username`, `sender_tag` → transcript sender fields
+- `session_key` → channel_sessions.session_key
 
 **Troubleshooting:**
 
@@ -107,12 +123,17 @@ Context: [Last 20 messages for reference resolution]
 - **Layer 1 (Prompt):** Existing facts queried and shown to Claude
 - **Layer 2 (Storage):** Database checks before every insert
 
+**Source FK pointer wiring:** When `SOURCE_CHANNEL_TRANSCRIPT_ID` and `SOURCE_CHANNEL_SESSION_ID` env vars are set (passed by `memory-catchup.sh` or the `memory-extract` hook), they populate `entity_facts.source_channel_transcript_id` and `.source_channel_session_id` on both new inserts and reinforced facts. The `reinforce_fact()` function uses `COALESCE` to only upgrade from NULL (never downgrade).
+
+**SQL injection fix:** `fact_exists()` uses exact LOWER equality matching instead of `ILIKE` interpolation, preventing SQL injection via fact values.
+
 **Storage flow:**
 1. Parse and validate JSON
 2. For each category, check existing records
-3. Skip duplicates, insert new records
-4. Update vocabulary table for STT
-5. Log insertion results
+3. Skip duplicates (reinforce with vote_count++), insert new records
+4. Set FK source pointers from env vars on facts/opinions/preferences
+5. Update vocabulary table for STT
+6. Log insertion results
 
 **Troubleshooting:**
 

--- a/memory/docs/semantic-recall.md
+++ b/memory/docs/semantic-recall.md
@@ -11,7 +11,7 @@ The semantic recall system searches embedded memories when messages arrive and i
 ```
 ┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
 │ Incoming        │────▶│ Embed Query      │────▶│ Vector Search   │
-│ Message         │     │ (OpenAI)         │     │ (pgvector)      │
+│ Message         │     │ (Ollama)         │     │ (pgvector)      │
 └─────────────────┘     └──────────────────┘     └─────────────────┘
                                                           │
 ┌─────────────────┐     ┌──────────────────┐              │
@@ -114,7 +114,7 @@ CREATE TABLE memory_embeddings (
     source_type VARCHAR(50) NOT NULL,
     source_id TEXT,
     content TEXT NOT NULL,
-    embedding vector(1536),
+    embedding vector(1024),
     created_at TIMESTAMPTZ DEFAULT now()
 );
 
@@ -132,7 +132,7 @@ To use in an OpenClaw installation:
 1. Copy `scripts/proactive-recall.py` to your scripts directory
 2. Copy `hooks/semantic-recall/` to your hooks directory
 3. Ensure pgvector extension and memory_embeddings table exist
-4. Set OPENAI_API_KEY environment variable
+4. Ensure Ollama is running with `mxbai-embed-large` model loaded
 
 ## OpenClaw Session Memory Indexing (2026.2.6+)
 
@@ -178,15 +178,17 @@ Stored in per-agent SQLite index
 memory_search queries both memory + sessions
 ```
 
+**Note:** In addition to OpenClaw's native JSONL indexing, the NOVA Memory pipeline also ingests JSONL transcripts into the database (`channel_sessions` / `channel_transcripts` tables) via `memory-catchup.sh`, where they serve as structured source references for extracted entity facts. See [memory-extraction-pipeline.md](memory-extraction-pipeline.md) for details.
+
 ### Relationship to NOVA Memory
 
 This OpenClaw feature is **complementary** to the NOVA Memory database:
 
 | Feature | NOVA Memory DB | OpenClaw Session Index |
 |---------|---------------|----------------------|
-| Storage | PostgreSQL + pgvector | SQLite + embeddings |
-| Content | Curated facts, entities, events | Raw session transcripts |
-| Extraction | Explicit (memory-extract hook) | Automatic (all turns) |
+| Storage | PostgreSQL + pgvector (including `channel_sessions`/`channel_transcripts` for structured transcripts) | SQLite + embeddings |
+| Content | Curated facts, entities, events, structured transcripts | Raw session transcripts |
+| Extraction | Explicit (memory-extract hook, batch ingest via memory-catchup.sh) | Automatic (all turns) |
 | Query | `proactive-recall.py`, direct SQL | `memory_search` tool |
 
 **Best practice**: Use both. NOVA Memory for structured, curated knowledge. OpenClaw session indexing for conversational context and recall.

--- a/memory/hooks/memory-extract/handler.ts
+++ b/memory/hooks/memory-extract/handler.ts
@@ -1,6 +1,9 @@
-import { spawn } from "child_process";
+import { spawn, execFile } from "child_process";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
 
 interface ActivityState {
   activeMinutesToday: number;
@@ -121,11 +124,89 @@ const handler = async (event) => {
   const sessionId = event.sessionKey ?? '';
   const messageTimestamp = new Date().toISOString();  // Current time as extraction timestamp
 
-  // Pass DB-level channel transcript / session FK ids when available (#170)
-  // These are populated by the transcript ingest pipeline (migration 067) and allow
-  // entity_facts rows to carry proper FK pointers back to the source message.
-  const channelTranscriptId = String(ctx.channelTranscriptId ?? ctx.channel_transcript_id ?? '');
-  const channelSessionId = String(ctx.channelSessionId ?? ctx.channel_session_id ?? '');
+  // Resolve DB-level channel transcript / session FK ids (C1 fix — #170).
+  // OpenClaw may populate these in ctx when the channel plugin has already persisted
+  // the message. When they are absent (real-time path before batch ingest), we do a
+  // lightweight upsert here so entity_facts always has valid FK pointers.
+  let channelTranscriptId = String(ctx.channelTranscriptId ?? ctx.channel_transcript_id ?? '');
+  let channelSessionId = String(ctx.channelSessionId ?? ctx.channel_session_id ?? '');
+
+  if (!channelTranscriptId || channelTranscriptId === '0') {
+    try {
+      // Derive provider from chat_id format
+      const chatId = String(ctx.chatId ?? ctx.chat_id ?? '');
+      let provider = 'openclaw';
+      if (chatId.startsWith('channel:')) provider = 'discord';
+      else if (chatId.startsWith('group:') || chatId.startsWith('+')) provider = 'signal';
+
+      const externalChatId = chatId || sessionId || 'unknown';
+      const externalMessageId = String(ctx.messageId ?? ctx.message_id ?? '');
+      const isGroupBool = Boolean(ctx.isGroup ?? false);
+      const chatType = isGroupBool ? 'group' : 'direct';
+      const groupSubject = String(ctx.groupSubject ?? ctx.group_subject ?? '');
+      const groupSpace = String(ctx.groupSpace ?? ctx.group_space ?? '');
+      const senderTag = String(ctx.senderTag ?? ctx.sender_tag ?? '');
+
+      // Only attempt upsert when psql is available and we have minimal identifying info
+      if (externalMessageId || rawBody.length > 0) {
+        // Upsert session row
+        const sessArgs = [
+          'nova_memory', '-t', '-A', '-c',
+          `INSERT INTO channel_sessions (session_key, agent_id, provider, external_chat_id, chat_type` +
+          (groupSubject ? ', group_subject, title' : '') +
+          (groupSpace ? ', group_space_id' : '') +
+          `) VALUES (` +
+          `'${sessionId.replace(/'/g, "''")}', 'main', ` +
+          `'${provider.replace(/'/g, "''")}', ` +
+          `'${externalChatId.replace(/'/g, "''")}', ` +
+          `'${chatType}'` +
+          (groupSubject ? `, '${groupSubject.replace(/'/g, "''")}', '${groupSubject.replace(/'/g, "''")}' ` : '') +
+          (groupSpace ? `, '${groupSpace.replace(/'/g, "''")}' ` : '') +
+          `) ON CONFLICT (provider, external_chat_id, COALESCE(external_thread_id, '')) DO UPDATE SET updated_at = NOW() RETURNING id;`
+        ];
+
+        const { stdout: sessOut } = await execFileAsync('psql', sessArgs).catch(() => ({ stdout: '' }));
+        const resolvedSessionId = sessOut.trim();
+        if (resolvedSessionId && /^\d+$/.test(resolvedSessionId)) {
+          channelSessionId = resolvedSessionId;
+        }
+
+        // Upsert transcript row when we have a session and a message id or can derive one
+        if (channelSessionId) {
+          const msgId = externalMessageId || `${messageTimestamp}_rt`;
+          const contentSnippet = rawBody.substring(0, 65535).replace(/'/g, "''");
+          const senderNameEsc = senderName.replace(/'/g, "''");
+          const senderIdEsc = senderId.replace(/'/g, "''");
+          const senderTagEsc = senderTag.replace(/'/g, "''");
+
+          const txArgs = [
+            'nova_memory', '-t', '-A', '-c',
+            `INSERT INTO channel_transcripts (session_id, external_message_id, timestamp, role, content` +
+            (senderId ? ', sender_id' : '') +
+            (senderName && senderName !== 'unknown' ? ', sender_name' : '') +
+            (senderTag ? ', sender_tag' : '') +
+            `) VALUES (` +
+            `${channelSessionId}, '${msgId.replace(/'/g, "''")}', ` +
+            `'${messageTimestamp}', 'user', '${contentSnippet}'` +
+            (senderId ? `, '${senderIdEsc}'` : '') +
+            (senderName && senderName !== 'unknown' ? `, '${senderNameEsc}'` : '') +
+            (senderTag ? `, '${senderTagEsc}'` : '') +
+            `) ON CONFLICT (session_id, external_message_id) DO NOTHING RETURNING id;`
+          ];
+
+          const { stdout: txOut } = await execFileAsync('psql', txArgs).catch(() => ({ stdout: '' }));
+          const resolvedTranscriptId = txOut.trim();
+          if (resolvedTranscriptId && /^\d+$/.test(resolvedTranscriptId)) {
+            channelTranscriptId = resolvedTranscriptId;
+          }
+        }
+      }
+    } catch (err) {
+      console.warn('[memory-extract] Could not upsert channel_transcripts for FK wiring', {
+        error: (err as Error).message
+      });
+    }
+  }
 
   const child = spawn(scriptPath, [], {
     stdio: ['pipe', 'pipe', 'pipe'],

--- a/memory/hooks/memory-extract/handler.ts
+++ b/memory/hooks/memory-extract/handler.ts
@@ -120,7 +120,13 @@ const handler = async (event) => {
   // When chat logs move to DB (#170), this maps directly to the session record
   const sessionId = event.sessionKey ?? '';
   const messageTimestamp = new Date().toISOString();  // Current time as extraction timestamp
-  
+
+  // Pass DB-level channel transcript / session FK ids when available (#170)
+  // These are populated by the transcript ingest pipeline (migration 067) and allow
+  // entity_facts rows to carry proper FK pointers back to the source message.
+  const channelTranscriptId = String(ctx.channelTranscriptId ?? ctx.channel_transcript_id ?? '');
+  const channelSessionId = String(ctx.channelSessionId ?? ctx.channel_session_id ?? '');
+
   const child = spawn(scriptPath, [], {
     stdio: ['pipe', 'pipe', 'pipe'],
     env: {
@@ -129,7 +135,10 @@ const handler = async (event) => {
       SENDER_ID: senderId,
       IS_GROUP: String(isGroup),
       SOURCE_SESSION_ID: sessionId,
-      SOURCE_TIMESTAMP: messageTimestamp
+      SOURCE_TIMESTAMP: messageTimestamp,
+      // DB-level source pointers for entity_facts FK columns (may be empty string when not yet ingested)
+      SOURCE_CHANNEL_TRANSCRIPT_ID: channelTranscriptId,
+      SOURCE_CHANNEL_SESSION_ID: channelSessionId
     }
   });
 

--- a/memory/migrations/067_channel_sessions_transcripts.sql
+++ b/memory/migrations/067_channel_sessions_transcripts.sql
@@ -1,0 +1,94 @@
+-- Migration 067: channel_sessions and channel_transcripts tables
+-- Implements structured chat transcript storage (#165, #138, #170)
+-- Replaces conversations table with properly normalised session/transcript schema.
+-- entity_facts gains FK source pointers to channel_transcripts.
+
+-- ============================================================
+-- Table: channel_sessions
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS channel_sessions (
+    id                      BIGSERIAL PRIMARY KEY,
+    session_key             TEXT,
+    agent_id                TEXT NOT NULL DEFAULT 'main',
+    provider                TEXT NOT NULL,
+    external_chat_id        TEXT NOT NULL,
+    external_thread_id      TEXT,
+    chat_type               TEXT NOT NULL,
+    title                   TEXT,
+    group_subject           TEXT,
+    group_space_id          TEXT,
+    started_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_message_at         TIMESTAMPTZ,
+    message_count           INTEGER DEFAULT 0,
+    raw_metadata            JSONB,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_sessions_provider_chat
+    ON channel_sessions (provider, external_chat_id, COALESCE(external_thread_id, ''));
+
+CREATE INDEX IF NOT EXISTS idx_channel_sessions_session_key
+    ON channel_sessions (session_key);
+
+CREATE INDEX IF NOT EXISTS idx_channel_sessions_last_msg
+    ON channel_sessions (last_message_at DESC);
+
+-- ============================================================
+-- Table: channel_transcripts
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS channel_transcripts (
+    id                          BIGSERIAL PRIMARY KEY,
+    session_id                  BIGINT NOT NULL REFERENCES channel_sessions(id) ON DELETE CASCADE,
+    external_message_id         TEXT NOT NULL,
+    timestamp                   TIMESTAMPTZ NOT NULL,
+    sender_id                   TEXT,
+    sender_name                 TEXT,
+    sender_username             TEXT,
+    sender_tag                  TEXT,
+    sender_entity_id            BIGINT REFERENCES entities(id),
+    role                        TEXT NOT NULL DEFAULT 'user',
+    content                     TEXT,
+    content_type                TEXT DEFAULT 'text',
+    raw_metadata                JSONB,
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_channel_transcripts_session_time
+    ON channel_transcripts (session_id, timestamp);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_transcripts_provider_msg
+    ON channel_transcripts (session_id, external_message_id);
+
+CREATE INDEX IF NOT EXISTS idx_channel_transcripts_sender_entity
+    ON channel_transcripts (sender_entity_id, timestamp);
+
+CREATE INDEX IF NOT EXISTS idx_channel_transcripts_external_sender
+    ON channel_transcripts (sender_id, timestamp);
+
+-- ============================================================
+-- entity_facts: add FK source pointers to channel tables
+-- ============================================================
+
+ALTER TABLE entity_facts
+    ADD COLUMN IF NOT EXISTS source_channel_transcript_id BIGINT REFERENCES channel_transcripts(id),
+    ADD COLUMN IF NOT EXISTS source_channel_session_id BIGINT REFERENCES channel_sessions(id);
+
+COMMENT ON COLUMN entity_facts.source_channel_transcript_id IS 'FK to channel_transcripts row that triggered this fact extraction (#170)';
+COMMENT ON COLUMN entity_facts.source_channel_session_id IS 'FK to channel_sessions row (denormalised for fast session-level queries)';
+
+CREATE INDEX IF NOT EXISTS idx_entity_facts_channel_transcript
+    ON entity_facts (source_channel_transcript_id)
+    WHERE source_channel_transcript_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_entity_facts_channel_session
+    ON entity_facts (source_channel_session_id)
+    WHERE source_channel_session_id IS NOT NULL;
+
+-- ============================================================
+-- Drop legacy conversations table (superseded by channel_sessions)
+-- ============================================================
+
+DROP TABLE IF EXISTS conversations CASCADE;

--- a/memory/scripts/memory-catchup.sh
+++ b/memory/scripts/memory-catchup.sh
@@ -276,11 +276,8 @@ if command -v psql >/dev/null 2>&1; then
         while IFS= read -r jsonl_file; do
             [ -f "$jsonl_file" ] || continue
 
-            # Derive provider / agent_id from path: agents/<agent_id>/sessions/<file>.jsonl
+            # Derive agent_id from path: agents/<agent_id>/sessions/<file>.jsonl
             agent_id=$(echo "$jsonl_file" | sed -E 's|.*/agents/([^/]+)/sessions/.*|\1|')
-            provider='openclaw'
-            # Use filename stem as external_chat_id (stable per session file)
-            external_chat_id=$(basename "$jsonl_file" .jsonl)
 
             # Extract first-message timestamp for started_at
             started_at=$(jq -r 'select(.timestamp) | .timestamp' "$jsonl_file" 2>/dev/null | head -1)
@@ -288,19 +285,69 @@ if command -v psql >/dev/null 2>&1; then
 
             # Extract session_key from any line that has it
             session_key=$(jq -r 'select(.session_key) | .session_key' "$jsonl_file" 2>/dev/null | head -1)
+
+            # Parse rich metadata from the first message line that has a chat_id
+            # This drives provider detection and proper session fields (M1)
+            first_meta_line=$(jq -c 'select(.chat_id) | .' "$jsonl_file" 2>/dev/null | head -1)
+            file_stem=$(basename "$jsonl_file" .jsonl)
+
+            if [ -n "$first_meta_line" ]; then
+                raw_chat_id=$(echo "$first_meta_line" | jq -r '.chat_id // empty' 2>/dev/null)
+                raw_is_group=$(echo "$first_meta_line" | jq -r '.is_group_chat // false' 2>/dev/null)
+                raw_group_subject=$(echo "$first_meta_line" | jq -r '.group_subject // empty' 2>/dev/null)
+                raw_group_space=$(echo "$first_meta_line" | jq -r '.group_space // empty' 2>/dev/null)
+
+                # Detect provider from chat_id format
+                if [[ "$raw_chat_id" == channel:* ]]; then
+                    provider='discord'
+                elif [[ "$raw_chat_id" == group:* ]] || [[ "$raw_chat_id" == +* ]]; then
+                    provider='signal'
+                elif [ -n "$raw_chat_id" ]; then
+                    provider='openclaw'
+                else
+                    provider='openclaw'
+                fi
+
+                external_chat_id="${raw_chat_id:-$file_stem}"
+                [ "$raw_is_group" = 'true' ] && chat_type='group' || chat_type='direct'
+                group_subject_val="$raw_group_subject"
+                group_space_val="$raw_group_space"
+                title_val="${raw_group_subject:-$file_stem}"
+            else
+                # Fallback: use filename stem as external_chat_id with openclaw provider
+                provider='openclaw'
+                external_chat_id="$file_stem"
+                chat_type='direct'
+                group_subject_val=''
+                group_space_val=''
+                title_val=''
+            fi
+
             [ -z "$session_key" ] && session_key="$external_chat_id"
 
-            # Upsert channel_sessions row
+            # Build optional session columns
+            sess_extra_cols=''
+            sess_extra_vals=''
+            if [ -n "$group_subject_val" ]; then
+                sess_extra_cols=", group_subject, title"
+                sess_extra_vals=", '$(echo "$group_subject_val" | sed "s/'/''/g")', '$(echo "$title_val" | sed "s/'/''/g")'"
+            fi
+            if [ -n "$group_space_val" ]; then
+                sess_extra_cols="$sess_extra_cols, group_space_id"
+                sess_extra_vals="$sess_extra_vals, '$(echo "$group_space_val" | sed "s/'/''/g")'"
+            fi
+
+            # Upsert channel_sessions row with rich metadata
             session_db_id=$(psql nova_memory -t -A -c "
                 INSERT INTO channel_sessions
-                    (session_key, agent_id, provider, external_chat_id, chat_type, started_at)
+                    (session_key, agent_id, provider, external_chat_id, chat_type, started_at${sess_extra_cols})
                 VALUES
                     ('$(echo "$session_key" | sed "s/'/''/g")',
                      '$(echo "$agent_id" | sed "s/'/''/g")',
                      '$(echo "$provider" | sed "s/'/''/g")',
                      '$(echo "$external_chat_id" | sed "s/'/''/g")',
-                     'direct',
-                     '$(echo "$started_at" | sed "s/'/''/g")')
+                     '$(echo "$chat_type" | sed "s/'/''/g")',
+                     '$(echo "$started_at" | sed "s/'/''/g")'${sess_extra_vals})
                 ON CONFLICT (provider, external_chat_id, COALESCE(external_thread_id, ''))
                 DO UPDATE SET
                     updated_at = NOW()
@@ -339,13 +386,11 @@ if command -v psql >/dev/null 2>&1; then
 
                 role=$(echo "$line" | jq -r '.message.role // "user"' 2>/dev/null)
 
-                # Parse rich metadata fields from JSONL content
-                chat_id=$(echo "$line" | jq -r '.chat_id // empty' 2>/dev/null)
+                # Parse rich metadata fields from JSONL content (M1)
                 sender_id=$(echo "$line" | jq -r '.sender_id // empty' 2>/dev/null)
                 sender_name=$(echo "$line" | jq -r '.sender // empty' 2>/dev/null)
                 sender_username=$(echo "$line" | jq -r '.sender_username // empty' 2>/dev/null)
-                is_group=$(echo "$line" | jq -r '.is_group_chat // false' 2>/dev/null)
-                group_subject=$(echo "$line" | jq -r '.group_subject // empty' 2>/dev/null)
+                sender_tag=$(echo "$line" | jq -r '.sender_tag // empty' 2>/dev/null)
 
                 content=$(echo "$line" | jq -r '
                     if (.message.content | type) == "array" then
@@ -358,12 +403,13 @@ if command -v psql >/dev/null 2>&1; then
 
                 raw_meta=$(echo "$line" | jq -c '.' 2>/dev/null | head -c 65535 | sed "s/'/''/g")
 
-                # Build dynamic column list for rich metadata
+                # Build dynamic column list for rich metadata (M1)
                 ct_cols="session_id, external_message_id, timestamp, role, content, raw_metadata"
                 ct_vals="$session_db_id, '$(echo "$ext_msg_id" | sed "s/'/''/g")', '$(echo "$msg_ts" | sed "s/'/''/g")', '$(echo "$role" | sed "s/'/''/g")', '$(echo "$content" | sed "s/'/''/g")', '$(echo "$raw_meta")'::jsonb"
                 [ -n "$sender_id" ] && ct_cols="$ct_cols, sender_id" && ct_vals="$ct_vals, '$(echo "$sender_id" | sed "s/'/''/g")'"
                 [ -n "$sender_name" ] && ct_cols="$ct_cols, sender_name" && ct_vals="$ct_vals, '$(echo "$sender_name" | sed "s/'/''/g")'"
                 [ -n "$sender_username" ] && ct_cols="$ct_cols, sender_username" && ct_vals="$ct_vals, '$(echo "$sender_username" | sed "s/'/''/g")'"
+                [ -n "$sender_tag" ] && ct_cols="$ct_cols, sender_tag" && ct_vals="$ct_vals, '$(echo "$sender_tag" | sed "s/'/''/g")'"
 
                 transcript_db_id=$(psql nova_memory -t -A -c "
                     INSERT INTO channel_transcripts ($ct_cols)

--- a/memory/scripts/memory-catchup.sh
+++ b/memory/scripts/memory-catchup.sh
@@ -320,14 +320,32 @@ if command -v psql >/dev/null 2>&1; then
                 msg_type=$(echo "$line" | jq -r '.type // empty' 2>/dev/null)
                 [ "$msg_type" = 'message' ] || continue
 
+                # Validate JSON line
+                if ! echo "$line" | jq -e '.' >/dev/null 2>&1; then
+                    echo "[memory-catchup] WARNING: Malformed JSON in $(basename "$jsonl_file"), skipping line" >&2
+                    continue
+                fi
+
                 ext_msg_id=$(echo "$line" | jq -r '.id // .message_id // empty' 2>/dev/null)
-                [ -z "$ext_msg_id" ] && ext_msg_id=$(echo "$line" | jq -r '.timestamp // empty' 2>/dev/null)
+                # Timestamp fallback with counter suffix to prevent collisions
+                if [ -z "$ext_msg_id" ]; then
+                    raw_ts=$(echo "$line" | jq -r '.timestamp // empty' 2>/dev/null)
+                    [ -n "$raw_ts" ] && ext_msg_id="${raw_ts}_${msg_count}"
+                fi
                 [ -z "$ext_msg_id" ] && continue
 
                 msg_ts=$(echo "$line" | jq -r '.timestamp // empty' 2>/dev/null)
                 [ -z "$msg_ts" ] && continue
 
                 role=$(echo "$line" | jq -r '.message.role // "user"' 2>/dev/null)
+
+                # Parse rich metadata fields from JSONL content
+                chat_id=$(echo "$line" | jq -r '.chat_id // empty' 2>/dev/null)
+                sender_id=$(echo "$line" | jq -r '.sender_id // empty' 2>/dev/null)
+                sender_name=$(echo "$line" | jq -r '.sender // empty' 2>/dev/null)
+                sender_username=$(echo "$line" | jq -r '.sender_username // empty' 2>/dev/null)
+                is_group=$(echo "$line" | jq -r '.is_group_chat // false' 2>/dev/null)
+                group_subject=$(echo "$line" | jq -r '.group_subject // empty' 2>/dev/null)
 
                 content=$(echo "$line" | jq -r '
                     if (.message.content | type) == "array" then
@@ -340,37 +358,47 @@ if command -v psql >/dev/null 2>&1; then
 
                 raw_meta=$(echo "$line" | jq -c '.' 2>/dev/null | head -c 65535 | sed "s/'/''/g")
 
-                psql nova_memory -q -c "
-                    INSERT INTO channel_transcripts
-                        (session_id, external_message_id, timestamp, role, content, raw_metadata)
-                    VALUES
-                        ($session_db_id,
-                         '$(echo "$ext_msg_id" | sed "s/'/''/g")',
-                         '$(echo "$msg_ts" | sed "s/'/''/g")',
-                         '$(echo "$role" | sed "s/'/''/g")',
-                         '$(echo "$content" | sed "s/'/''/g")',
-                         '$(echo "$raw_meta")'::jsonb)
-                    ON CONFLICT (session_id, external_message_id) DO NOTHING;
-                " 2>/dev/null || true
+                # Build dynamic column list for rich metadata
+                ct_cols="session_id, external_message_id, timestamp, role, content, raw_metadata"
+                ct_vals="$session_db_id, '$(echo "$ext_msg_id" | sed "s/'/''/g")', '$(echo "$msg_ts" | sed "s/'/''/g")', '$(echo "$role" | sed "s/'/''/g")', '$(echo "$content" | sed "s/'/''/g")', '$(echo "$raw_meta")'::jsonb"
+                [ -n "$sender_id" ] && ct_cols="$ct_cols, sender_id" && ct_vals="$ct_vals, '$(echo "$sender_id" | sed "s/'/''/g")'"
+                [ -n "$sender_name" ] && ct_cols="$ct_cols, sender_name" && ct_vals="$ct_vals, '$(echo "$sender_name" | sed "s/'/''/g")'"
+                [ -n "$sender_username" ] && ct_cols="$ct_cols, sender_username" && ct_vals="$ct_vals, '$(echo "$sender_username" | sed "s/'/''/g")'"
+
+                transcript_db_id=$(psql nova_memory -t -A -c "
+                    INSERT INTO channel_transcripts ($ct_cols)
+                    VALUES ($ct_vals)
+                    ON CONFLICT (session_id, external_message_id) DO NOTHING
+                    RETURNING id;
+                " 2>/dev/null | tr -d '[:space:]')
 
                 msg_count=$((msg_count + 1))
+
+                # Pass transcript/session FK ids to extraction pipeline
+                if [ -n "$transcript_db_id" ]; then
+                    export SOURCE_CHANNEL_TRANSCRIPT_ID="$transcript_db_id"
+                    export SOURCE_CHANNEL_SESSION_ID="$session_db_id"
+                fi
             done < "$jsonl_file"
 
-            # Update message_count and last_message_at on session
-            if [ "$msg_count" -gt 0 ]; then
-                psql nova_memory -q -c "
-                    UPDATE channel_sessions SET
-                        message_count = (SELECT COUNT(*) FROM channel_transcripts WHERE session_id = $session_db_id),
-                        last_message_at = (SELECT MAX(timestamp) FROM channel_transcripts WHERE session_id = $session_db_id),
-                        updated_at = NOW()
-                    WHERE id = $session_db_id;
-                " 2>/dev/null || true
-                INGEST_COUNT=$((INGEST_COUNT + msg_count))
-            fi
+            # Always recompute message_count and last_message_at from actual DB state
+            psql nova_memory -q -c "
+                UPDATE channel_sessions SET
+                    message_count = (SELECT COUNT(*) FROM channel_transcripts WHERE session_id = $session_db_id),
+                    last_message_at = (SELECT MAX(timestamp) FROM channel_transcripts WHERE session_id = $session_db_id),
+                    updated_at = NOW()
+                WHERE id = $session_db_id;
+            " 2>/dev/null || true
 
-            # Delete the source JSONL after successful DB commit
-            rm -f "$jsonl_file"
-            echo "[memory-catchup] Ingested $msg_count messages from $(basename "$jsonl_file") → channel_transcripts (session $session_db_id)"
+            INGEST_COUNT=$((INGEST_COUNT + msg_count))
+
+            # Only delete source JSONL if psql session upsert succeeded (session_db_id is set)
+            if [ -n "$session_db_id" ]; then
+                rm -f "$jsonl_file"
+                echo "[memory-catchup] Ingested $msg_count messages from $(basename "$jsonl_file") → channel_transcripts (session $session_db_id)"
+            else
+                echo "[memory-catchup] WARNING: Skipped deletion of $(basename "$jsonl_file") — session upsert failed" >&2
+            fi
 
         done < <(find "$ALL_SESSIONS_DIR" -path '*/sessions/*.jsonl' -type f 2>/dev/null)
 
@@ -395,16 +423,25 @@ if [ -d "$MEMORY_MD_DIR" ]; then
         # Store the file content as an entity fact on the 'NOVA' entity (agent notes)
         md_key="daily_memory_note"
         md_date=$(date -u +"%Y-%m-%d")
-        psql nova_memory -q -c "
+
+        # Warn if content is being truncated
+        md_len=${#md_content}
+        if [ "$md_len" -gt 4000 ]; then
+            echo "[memory-catchup] WARNING: $(basename "$md_file") is $md_len chars, truncating to 4000" >&2
+        fi
+
+        if psql nova_memory -q -c "
             INSERT INTO entity_facts (entity_id, key, value, source)
             SELECT id, '$(echo "$md_key" | sed "s/'/''/g")',
                    '$(echo "$md_content" | sed "s/'/''/g" | head -c 4000)',
                    'memory-catchup:$(echo "$md_date" | sed "s/'/''/g")'
             FROM entities WHERE LOWER(name) = 'nova'
             ON CONFLICT DO NOTHING;
-        " 2>/dev/null || true
-
-        echo "[memory-catchup] Ingested memory MD: $(basename "$md_file")"
-        rm -f "$md_file"
+        " 2>/dev/null; then
+            echo "[memory-catchup] Ingested memory MD: $(basename "$md_file")"
+            rm -f "$md_file"
+        else
+            echo "[memory-catchup] WARNING: Failed to ingest $(basename "$md_file"), keeping file" >&2
+        fi
     done < <(find "$MEMORY_MD_DIR" -maxdepth 1 -name '*.md' -type f 2>/dev/null)
 fi

--- a/memory/scripts/memory-catchup.sh
+++ b/memory/scripts/memory-catchup.sh
@@ -2,6 +2,7 @@
 # memory-catchup.sh - Process unprocessed messages from session transcripts
 # Processes BOTH user AND assistant messages for memory extraction
 # Maintains a rolling cache of 20 messages for context
+# Also ingests JSONL session transcripts and daily memory/*.md files into the DB.
 # Usage: memory-catchup.sh [--log]   # --log enables detailed extraction logging
 
 set -e
@@ -251,3 +252,159 @@ fi
 
 echo "[memory-catchup] Processed $PROCESSED messages (total: $NEW_TOTAL)"
 echo "[memory-catchup] Cache: $(cat "$CACHE_FILE" | jq 'length') messages"
+
+# ─────────────────────────────────────────────────────────────
+# Ingest JSONL session files → channel_sessions + channel_transcripts
+# ─────────────────────────────────────────────────────────────
+
+# Load PostgreSQL env so psql works without explicit credentials
+PG_ENV="${HOME}/.openclaw/lib/pg-env.sh"
+[ -f "$PG_ENV" ] && source "$PG_ENV" && load_pg_env 2>/dev/null || true
+
+ALL_SESSIONS_DIR="${HOME}/.openclaw/agents"
+INGEST_COUNT=0
+INGEST_ERRORS=0
+
+if command -v psql >/dev/null 2>&1; then
+    # Check that channel_sessions table exists before attempting ingest
+    TABLE_EXISTS=$(psql nova_memory -t -A -c \
+        "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name='channel_sessions');" \
+        2>/dev/null || echo 'f')
+
+    if [ "$TABLE_EXISTS" = 't' ]; then
+        # Find all JSONL session files across all agents
+        while IFS= read -r jsonl_file; do
+            [ -f "$jsonl_file" ] || continue
+
+            # Derive provider / agent_id from path: agents/<agent_id>/sessions/<file>.jsonl
+            agent_id=$(echo "$jsonl_file" | sed -E 's|.*/agents/([^/]+)/sessions/.*|\1|')
+            provider='openclaw'
+            # Use filename stem as external_chat_id (stable per session file)
+            external_chat_id=$(basename "$jsonl_file" .jsonl)
+
+            # Extract first-message timestamp for started_at
+            started_at=$(jq -r 'select(.timestamp) | .timestamp' "$jsonl_file" 2>/dev/null | head -1)
+            [ -z "$started_at" ] && started_at=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+
+            # Extract session_key from any line that has it
+            session_key=$(jq -r 'select(.session_key) | .session_key' "$jsonl_file" 2>/dev/null | head -1)
+            [ -z "$session_key" ] && session_key="$external_chat_id"
+
+            # Upsert channel_sessions row
+            session_db_id=$(psql nova_memory -t -A -c "
+                INSERT INTO channel_sessions
+                    (session_key, agent_id, provider, external_chat_id, chat_type, started_at)
+                VALUES
+                    ('$(echo "$session_key" | sed "s/'/''/g")',
+                     '$(echo "$agent_id" | sed "s/'/''/g")',
+                     '$(echo "$provider" | sed "s/'/''/g")',
+                     '$(echo "$external_chat_id" | sed "s/'/''/g")',
+                     'direct',
+                     '$(echo "$started_at" | sed "s/'/''/g")')
+                ON CONFLICT (provider, external_chat_id, COALESCE(external_thread_id, ''))
+                DO UPDATE SET
+                    updated_at = NOW()
+                RETURNING id;
+            " 2>/dev/null | tr -d '[:space:]')
+
+            if [ -z "$session_db_id" ]; then
+                echo "[memory-catchup] WARNING: Could not upsert session for $jsonl_file" >&2
+                INGEST_ERRORS=$((INGEST_ERRORS + 1))
+                continue
+            fi
+
+            # Upsert each message into channel_transcripts
+            msg_count=0
+            while IFS= read -r line; do
+                # Only process message-type entries
+                msg_type=$(echo "$line" | jq -r '.type // empty' 2>/dev/null)
+                [ "$msg_type" = 'message' ] || continue
+
+                ext_msg_id=$(echo "$line" | jq -r '.id // .message_id // empty' 2>/dev/null)
+                [ -z "$ext_msg_id" ] && ext_msg_id=$(echo "$line" | jq -r '.timestamp // empty' 2>/dev/null)
+                [ -z "$ext_msg_id" ] && continue
+
+                msg_ts=$(echo "$line" | jq -r '.timestamp // empty' 2>/dev/null)
+                [ -z "$msg_ts" ] && continue
+
+                role=$(echo "$line" | jq -r '.message.role // "user"' 2>/dev/null)
+
+                content=$(echo "$line" | jq -r '
+                    if (.message.content | type) == "array" then
+                        (.message.content[] | select(.type=="text") | .text) // ""
+                    elif (.message.content | type) == "string" then
+                        .message.content
+                    else ""
+                    end
+                ' 2>/dev/null | head -c 65535)
+
+                raw_meta=$(echo "$line" | jq -c '.' 2>/dev/null | head -c 65535 | sed "s/'/''/g")
+
+                psql nova_memory -q -c "
+                    INSERT INTO channel_transcripts
+                        (session_id, external_message_id, timestamp, role, content, raw_metadata)
+                    VALUES
+                        ($session_db_id,
+                         '$(echo "$ext_msg_id" | sed "s/'/''/g")',
+                         '$(echo "$msg_ts" | sed "s/'/''/g")',
+                         '$(echo "$role" | sed "s/'/''/g")',
+                         '$(echo "$content" | sed "s/'/''/g")',
+                         '$(echo "$raw_meta")'::jsonb)
+                    ON CONFLICT (session_id, external_message_id) DO NOTHING;
+                " 2>/dev/null || true
+
+                msg_count=$((msg_count + 1))
+            done < "$jsonl_file"
+
+            # Update message_count and last_message_at on session
+            if [ "$msg_count" -gt 0 ]; then
+                psql nova_memory -q -c "
+                    UPDATE channel_sessions SET
+                        message_count = (SELECT COUNT(*) FROM channel_transcripts WHERE session_id = $session_db_id),
+                        last_message_at = (SELECT MAX(timestamp) FROM channel_transcripts WHERE session_id = $session_db_id),
+                        updated_at = NOW()
+                    WHERE id = $session_db_id;
+                " 2>/dev/null || true
+                INGEST_COUNT=$((INGEST_COUNT + msg_count))
+            fi
+
+            # Delete the source JSONL after successful DB commit
+            rm -f "$jsonl_file"
+            echo "[memory-catchup] Ingested $msg_count messages from $(basename "$jsonl_file") → channel_transcripts (session $session_db_id)"
+
+        done < <(find "$ALL_SESSIONS_DIR" -path '*/sessions/*.jsonl' -type f 2>/dev/null)
+
+        echo "[memory-catchup] Transcript ingest: $INGEST_COUNT messages, $INGEST_ERRORS errors"
+    else
+        echo "[memory-catchup] channel_sessions table not found — skipping transcript ingest (run migration 067 first)"
+    fi
+else
+    echo "[memory-catchup] psql not available — skipping transcript ingest"
+fi
+
+# ─────────────────────────────────────────────────────────────
+# Ingest daily memory/*.md files into DB (content only), then delete
+# ─────────────────────────────────────────────────────────────
+MEMORY_MD_DIR="${HOME}/.openclaw/memory"
+if [ -d "$MEMORY_MD_DIR" ]; then
+    while IFS= read -r md_file; do
+        [ -f "$md_file" ] || continue
+        md_content=$(cat "$md_file" 2>/dev/null)
+        [ -z "$md_content" ] && rm -f "$md_file" && continue
+
+        # Store the file content as an entity fact on the 'NOVA' entity (agent notes)
+        md_key="daily_memory_note"
+        md_date=$(date -u +"%Y-%m-%d")
+        psql nova_memory -q -c "
+            INSERT INTO entity_facts (entity_id, key, value, source)
+            SELECT id, '$(echo "$md_key" | sed "s/'/''/g")',
+                   '$(echo "$md_content" | sed "s/'/''/g" | head -c 4000)',
+                   'memory-catchup:$(echo "$md_date" | sed "s/'/''/g")'
+            FROM entities WHERE LOWER(name) = 'nova'
+            ON CONFLICT DO NOTHING;
+        " 2>/dev/null || true
+
+        echo "[memory-catchup] Ingested memory MD: $(basename "$md_file")"
+        rm -f "$md_file"
+    done < <(find "$MEMORY_MD_DIR" -maxdepth 1 -name '*.md' -type f 2>/dev/null)
+fi

--- a/memory/scripts/memory-catchup.sh
+++ b/memory/scripts/memory-catchup.sh
@@ -204,9 +204,9 @@ while IFS= read -r line; do
     
     # Run extraction (API key must be in environment, inherited from OpenClaw)
     if [ -z "$ANTHROPIC_API_KEY" ]; then
-        echo "ERROR: ANTHROPIC_API_KEY not set in environment" >&2
-        echo "This script should be run from OpenClaw hooks which inherit the API key" >&2
-        exit 1
+        echo "[memory-catchup] WARNING: ANTHROPIC_API_KEY not set — skipping LLM extraction (transcript ingest will still run)" >&2
+        rm -f "$MESSAGES_TO_PROCESS" "$ALL_MESSAGES"
+        break
     fi
     
     if [ "$VERBOSE_LOG" = true ]; then
@@ -216,7 +216,7 @@ while IFS= read -r line; do
         echo "$CONTEXT" | head -60 >> "$EXTRACT_LOG"
         echo "..." >> "$EXTRACT_LOG"
         
-        RESULT=$("$EXTRACT_SCRIPT" "$CONTEXT" 2>&1)
+        RESULT=$("$EXTRACT_SCRIPT" "$CONTEXT" 2>&1) || true
         echo "$RESULT" | tail -25 >> "$EXTRACT_LOG"
         echo "" >> "$EXTRACT_LOG"
     else

--- a/memory/scripts/store-memories.sh
+++ b/memory/scripts/store-memories.sh
@@ -66,7 +66,9 @@ reinforce_fact() {
     local value="$3"
     local src_session_id="${SOURCE_SESSION_ID:-}"
     local src_timestamp="${SOURCE_TIMESTAMP:-}"
-    
+    local src_channel_transcript_id="${SOURCE_CHANNEL_TRANSCRIPT_ID:-}"
+    local src_channel_session_id="${SOURCE_CHANNEL_SESSION_ID:-}"
+
     # Build source pointer update clause (only overwrite if new timestamp is newer)
     local source_update=""
     if [ -n "$src_session_id" ] && [ -n "$src_timestamp" ]; then
@@ -74,7 +76,13 @@ reinforce_fact() {
             source_session_id = CASE WHEN source_timestamp IS NULL OR source_timestamp < '$(sql_escape "$src_timestamp")'::timestamptz THEN '$(sql_escape "$src_session_id")' ELSE source_session_id END,
             source_timestamp = CASE WHEN source_timestamp IS NULL OR source_timestamp < '$(sql_escape "$src_timestamp")'::timestamptz THEN '$(sql_escape "$src_timestamp")'::timestamptz ELSE source_timestamp END"
     fi
-    
+    # Update channel FK pointers if provided (only upgrade from NULL, never downgrade to NULL)
+    if [ -n "$src_channel_transcript_id" ] && [[ "$src_channel_transcript_id" =~ ^[0-9]+$ ]]; then
+        source_update="$source_update,
+            source_channel_transcript_id = COALESCE(source_channel_transcript_id, $src_channel_transcript_id),
+            source_channel_session_id    = COALESCE(source_channel_session_id,    $([ -n "$src_channel_session_id" ] && echo "$src_channel_session_id" || echo 'NULL'))"
+    fi
+
     psql -t -A -c "
         UPDATE entity_facts ef
         SET vote_count = vote_count + 1,
@@ -219,25 +227,33 @@ echo "$JSON_DATA" | jq -c '.facts[]? // empty' | while read -r fact; do
     source_entity_id=$(resolve_source_entity_id "$source_person")
     src_session_id="${SOURCE_SESSION_ID:-}"
     src_timestamp="${SOURCE_TIMESTAMP:-}"
-    
+    src_channel_transcript_id="${SOURCE_CHANNEL_TRANSCRIPT_ID:-}"
+    src_channel_session_id="${SOURCE_CHANNEL_SESSION_ID:-}"
+
     actual_subject=$(find_entity "$subject")
     [ -z "$actual_subject" ] && actual_subject="$subject"
-    
+
     # Check for duplicate and reinforce if exists
     if fact_exists "$actual_subject" "$predicate" "$value"; then
         reinforce_fact "$actual_subject" "$predicate" "$value"
         echo "  ✓ Fact reinforced: $actual_subject.$predicate = $value (vote_count++)"
         continue
     fi
-    
+
     cols="entity_id, key, value, source, visibility"
     vals="id, '$(sql_escape "$predicate")', '$(sql_escape "$value")', '$(sql_escape "$source_person")', '$(sql_escape "$visibility")'"
-    
+
     [ -n "$source_entity_id" ] && cols="$cols, source_entity_id" && vals="$vals, $source_entity_id"
     [ -n "$visibility_reason" ] && cols="$cols, visibility_reason" && vals="$vals, '$(sql_escape "$visibility_reason")'"
     [ -n "$src_session_id" ] && cols="$cols, source_session_id" && vals="$vals, '$(sql_escape "$src_session_id")'"
     [ -n "$src_timestamp" ] && cols="$cols, source_timestamp" && vals="$vals, '$(sql_escape "$src_timestamp")'::timestamptz"
-    
+    if [ -n "$src_channel_transcript_id" ] && [[ "$src_channel_transcript_id" =~ ^[0-9]+$ ]]; then
+        cols="$cols, source_channel_transcript_id" && vals="$vals, $src_channel_transcript_id"
+    fi
+    if [ -n "$src_channel_session_id" ] && [[ "$src_channel_session_id" =~ ^[0-9]+$ ]]; then
+        cols="$cols, source_channel_session_id" && vals="$vals, $src_channel_session_id"
+    fi
+
     echo "INSERT INTO entity_facts ($cols) SELECT $vals
           FROM entities WHERE name = '$(sql_escape "$actual_subject")'
           ON CONFLICT DO NOTHING;" | psql -q 2>/dev/null || true
@@ -255,27 +271,35 @@ echo "$JSON_DATA" | jq -c '.opinions[]? // empty' | while read -r opinion; do
     source_entity_id=$(resolve_source_entity_id "$source_person")
     src_session_id="${SOURCE_SESSION_ID:-}"
     src_timestamp="${SOURCE_TIMESTAMP:-}"
-    
+    src_channel_transcript_id="${SOURCE_CHANNEL_TRANSCRIPT_ID:-}"
+    src_channel_session_id="${SOURCE_CHANNEL_SESSION_ID:-}"
+
     actual_holder=$(find_entity "$holder")
     [ -z "$actual_holder" ] && actual_holder="$holder"
-    
+
     key="opinion_$subject"
-    
+
     # Check for duplicate and reinforce if exists
     if fact_exists "$actual_holder" "$key" "$opinion_text"; then
         reinforce_fact "$actual_holder" "$key" "$opinion_text"
         echo "  ✓ Opinion reinforced: $actual_holder on $subject (vote_count++)"
         continue
     fi
-    
+
     cols="entity_id, key, value, source, visibility"
     vals="id, '$(sql_escape "$key")', '$(sql_escape "$opinion_text")', '$(sql_escape "$source_person")', '$(sql_escape "$visibility")'"
-    
+
     [ -n "$source_entity_id" ] && cols="$cols, source_entity_id" && vals="$vals, $source_entity_id"
     [ -n "$visibility_reason" ] && cols="$cols, visibility_reason" && vals="$vals, '$(sql_escape "$visibility_reason")'"
     [ -n "$src_session_id" ] && cols="$cols, source_session_id" && vals="$vals, '$(sql_escape "$src_session_id")'"
     [ -n "$src_timestamp" ] && cols="$cols, source_timestamp" && vals="$vals, '$(sql_escape "$src_timestamp")'::timestamptz"
-    
+    if [ -n "$src_channel_transcript_id" ] && [[ "$src_channel_transcript_id" =~ ^[0-9]+$ ]]; then
+        cols="$cols, source_channel_transcript_id" && vals="$vals, $src_channel_transcript_id"
+    fi
+    if [ -n "$src_channel_session_id" ] && [[ "$src_channel_session_id" =~ ^[0-9]+$ ]]; then
+        cols="$cols, source_channel_session_id" && vals="$vals, $src_channel_session_id"
+    fi
+
     echo "INSERT INTO entity_facts ($cols) SELECT $vals
           FROM entities WHERE name = '$(sql_escape "$actual_holder")'
           ON CONFLICT DO NOTHING;" | psql -q 2>/dev/null || true
@@ -293,27 +317,35 @@ echo "$JSON_DATA" | jq -c '.preferences[]? // empty' | while read -r pref; do
     source_entity_id=$(resolve_source_entity_id "$source_person")
     src_session_id="${SOURCE_SESSION_ID:-}"
     src_timestamp="${SOURCE_TIMESTAMP:-}"
-    
+    src_channel_transcript_id="${SOURCE_CHANNEL_TRANSCRIPT_ID:-}"
+    src_channel_session_id="${SOURCE_CHANNEL_SESSION_ID:-}"
+
     actual_person=$(find_entity "$person")
     [ -z "$actual_person" ] && actual_person="$person"
-    
+
     key="preference_$category"
-    
+
     # Check for duplicate and reinforce if exists
     if fact_exists "$actual_person" "$key" "$preference"; then
         reinforce_fact "$actual_person" "$key" "$preference"
         echo "  ✓ Preference reinforced: $actual_person prefers $preference (vote_count++)"
         continue
     fi
-    
+
     cols="entity_id, key, value, source, visibility"
     vals="id, '$(sql_escape "$key")', '$(sql_escape "$preference")', '$(sql_escape "$source_person")', '$(sql_escape "$visibility")'"
-    
+
     [ -n "$source_entity_id" ] && cols="$cols, source_entity_id" && vals="$vals, $source_entity_id"
     [ -n "$visibility_reason" ] && cols="$cols, visibility_reason" && vals="$vals, '$(sql_escape "$visibility_reason")'"
     [ -n "$src_session_id" ] && cols="$cols, source_session_id" && vals="$vals, '$(sql_escape "$src_session_id")'"
     [ -n "$src_timestamp" ] && cols="$cols, source_timestamp" && vals="$vals, '$(sql_escape "$src_timestamp")'::timestamptz"
-    
+    if [ -n "$src_channel_transcript_id" ] && [[ "$src_channel_transcript_id" =~ ^[0-9]+$ ]]; then
+        cols="$cols, source_channel_transcript_id" && vals="$vals, $src_channel_transcript_id"
+    fi
+    if [ -n "$src_channel_session_id" ] && [[ "$src_channel_session_id" =~ ^[0-9]+$ ]]; then
+        cols="$cols, source_channel_session_id" && vals="$vals, $src_channel_session_id"
+    fi
+
     echo "INSERT INTO entity_facts ($cols) SELECT $vals
           FROM entities WHERE name = '$(sql_escape "$actual_person")'
           ON CONFLICT DO NOTHING;" | psql -q 2>/dev/null || true

--- a/memory/scripts/store-memories.sh
+++ b/memory/scripts/store-memories.sh
@@ -119,12 +119,18 @@ resolve_source_entity_id() {
     
     # First try matching by sender_id (phone number) in entity_facts
     if [ -n "$sender_id" ] && [ "$sender_id" != "unknown" ]; then
-        local id_match=$(psql -t -A -c "
-            SELECT DISTINCT entity_id FROM entity_facts 
-            WHERE (key IN ('phone', 'has_phone_number', 'signal', 'signal_id') 
-                   AND REPLACE(REPLACE(value, '-', ''), ' ', '') LIKE '%$(echo "$sender_id" | tr -d '+-  ')%')
-            LIMIT 1;
-        " 2>/dev/null | head -1)
+        # Normalise to digits only for comparison — avoids LIKE injection via sender_id (C4)
+        local sender_digits
+        sender_digits=$(echo "$sender_id" | tr -dc '0-9')
+        local id_match
+        if [ -n "$sender_digits" ]; then
+            id_match=$(psql -t -A -c "
+                SELECT DISTINCT entity_id FROM entity_facts
+                WHERE key IN ('phone', 'has_phone_number', 'signal', 'signal_id')
+                  AND REGEXP_REPLACE(value, '[^0-9]', '', 'g') = '$(sql_escape "$sender_digits")'
+                LIMIT 1;
+            " 2>/dev/null | head -1)
+        fi
         
         if [ -n "$id_match" ]; then
             echo "$id_match"

--- a/memory/scripts/store-memories.sh
+++ b/memory/scripts/store-memories.sh
@@ -37,13 +37,13 @@ sql_escape() {
     echo "$1" | sed "s/'/''/g"
 }
 
-# Function to check if a fact already exists (fuzzy match)
+# Function to check if a fact already exists (exact match to prevent SQL injection)
 fact_exists() {
     local entity_name="$1"
     local key="$2"
     local value="$3"
     
-    # Check for exact or similar match
+    # Use exact equality matching — avoids ILIKE interpolation injection risk
     local count=$(psql -t -A -c "
         SELECT COUNT(*) FROM entity_facts ef
         JOIN entities e ON e.id = ef.entity_id
@@ -51,9 +51,7 @@ fact_exists() {
                OR LOWER(e.full_name) = LOWER('$(sql_escape "$entity_name")')
                OR LOWER('$(sql_escape "$entity_name")') = ANY(SELECT LOWER(unnest(e.nicknames))))
           AND LOWER(ef.key) = LOWER('$(sql_escape "$key")')
-          AND (LOWER(ef.value) = LOWER('$(sql_escape "$value")')
-               OR ef.value ILIKE '%$(sql_escape "$value")%'
-               OR '$(sql_escape "$value")' ILIKE '%' || ef.value || '%');
+          AND LOWER(ef.value) = LOWER('$(sql_escape "$value")');
     " 2>/dev/null || echo "0")
     
     [ "$count" -gt 0 ]
@@ -95,9 +93,7 @@ reinforce_fact() {
                OR LOWER(e.full_name) = LOWER('$(sql_escape "$entity_name")')
                OR LOWER('$(sql_escape "$entity_name")') = ANY(SELECT LOWER(unnest(e.nicknames))))
           AND LOWER(ef.key) = LOWER('$(sql_escape "$key")')
-          AND (LOWER(ef.value) = LOWER('$(sql_escape "$value")')
-               OR ef.value ILIKE '%$(sql_escape "$value")%'
-               OR '$(sql_escape "$value")' ILIKE '%' || ef.value || '%');
+          AND LOWER(ef.value) = LOWER('$(sql_escape "$value")');
     " 2>/dev/null >/dev/null
 }
 

--- a/tests/TEST-CASES-ISSUE-165-138-170.md
+++ b/tests/TEST-CASES-ISSUE-165-138-170.md
@@ -1,0 +1,230 @@
+# Test Cases: Issues #165, #138, #170 — Channel Transcripts + Memory Reinforcement
+
+**Branch:** `feature/issue-165-138-memory-reinforcement`
+**Migration:** `memory/migrations/067_channel_sessions_transcripts.sql`
+
+---
+
+## TC-001: Happy Path — Discord Message Ingestion
+
+**Input:** JSONL file containing a Discord message with full untrusted metadata:
+```json
+{
+  "chat_id": "channel:1492386247862390824",
+  "message_id": "1502589947721547817",
+  "sender_id": "330189773371080716",
+  "conversation_label": "#software-engineering channel id:1492386247862390824",
+  "sender": "I)ruid",
+  "timestamp": "Sat 2026-05-09 08:36 UTC",
+  "group_subject": "#software-engineering",
+  "group_channel": "#software-engineering",
+  "group_space": "1492385947927445524",
+  "is_group_chat": true
+}
+```
+
+**Expected:**
+- `channel_sessions` row created with `provider='discord'`, `external_chat_id='channel:1492386247862390824'`, `chat_type='group'`
+- `channel_transcripts` row created with `external_message_id='1502589947721547817'`, full `raw_metadata` JSONB stored
+- `sender_id`, `sender_name`, `sender_username`, `sender_tag` populated from sender block
+- `message_count` and `last_message_at` updated on session
+
+---
+
+## TC-002: Happy Path — Signal Group Message
+
+**Input:** Signal-style inbound metadata (no `group_space`, different `chat_id` format):
+```json
+{
+  "chat_id": "group:abc123def456",
+  "message_id": "signal-msg-001",
+  "sender_id": "+15551234567",
+  "sender": "Neva",
+  "timestamp": "2026-05-08T14:30:00.000Z",
+  "group_subject": "SE Workflow with Neva",
+  "is_group_chat": true
+}
+```
+
+**Expected:**
+- `channel_sessions` row with `provider='signal'`, `external_chat_id='group:abc123def456'`, no `group_space_id`, `chat_type='group'`
+- `channel_transcripts` row with full metadata preserved
+- No errors from missing `group_space` field
+
+---
+
+## TC-003: Session Reconstruction from Single Message
+
+**Given:** A `channel_transcripts` row with `id=42`, `session_id=7`
+**Query:**
+```sql
+SELECT * FROM channel_transcripts
+WHERE session_id = (SELECT session_id FROM channel_transcripts WHERE id = 42)
+ORDER BY timestamp;
+```
+**Expected:** Returns the full ordered conversation for that session regardless of provider.
+
+---
+
+## TC-004: Idempotent Upsert — Same Message Twice
+
+**Action:** Run `memory-catchup.sh` against the same JSONL file twice.
+**Expected:**
+- Second run produces no duplicate `channel_transcripts` rows
+- `ON CONFLICT (session_id, external_message_id) DO NOTHING` fires silently
+- `channel_sessions.message_count` remains accurate (not double-counted)
+
+---
+
+## TC-005: Idempotent Upsert — Minor Metadata Change
+
+**Action:** Re-import same `external_message_id` with a slight difference in `raw_metadata`.
+**Expected:** Current implementation uses `DO NOTHING` — the original row is preserved. Document whether this is acceptable or if `DO UPDATE` is preferred for metadata freshness.
+
+---
+
+## TC-006: Daily Memory File Ingestion + Deletion
+
+**Input:** `memory/2026-05-09.md` containing daily session notes.
+**Action:** `memory-catchup.sh` processes the file.
+**Expected:**
+- Content stored as entity_fact on the NOVA entity
+- Source file deleted ONLY after successful DB insert
+- Re-running after deletion is a no-op (file gone)
+
+---
+
+## TC-007: Deletion Safety — DB Insert Fails
+
+**Scenario:** Database is unavailable or INSERT fails.
+**Expected:** Source file (`*.jsonl` or `*.md`) is NOT deleted. Script logs a warning and continues.
+**Review:** Check that `rm -f` only executes after confirmed successful psql exit.
+
+---
+
+## TC-008: Missing Sender Fields
+
+**Input:** Message with no sender block (only `sender_id` in chat metadata).
+**Expected:**
+- `sender_name`, `sender_username`, `sender_tag` are NULL
+- Row still inserts successfully
+- No crash in `memory-catchup.sh` or downstream hooks
+
+---
+
+## TC-009: Null or Missing external_message_id
+
+**Input:** JSONL line with no `id`, `message_id`, or `timestamp` field.
+**Expected:** Row is skipped (not inserted). Script does not crash. Logged as warning.
+
+---
+
+## TC-010: Corrupt/Malformed JSON in raw_metadata
+
+**Input:** JSONL line with invalid JSON structure.
+**Expected:** `jq` parsing fails gracefully. Row is skipped. Script continues processing remaining lines.
+
+---
+
+## TC-011: Very Long Session — Performance
+
+**Setup:** 500+ messages in a single `channel_sessions` row.
+**Verification:**
+- `EXPLAIN ANALYZE` on reconstruction query uses `idx_channel_transcripts_session_time` index
+- Query returns 500 messages in < 80 ms
+- `message_count` accurately reflects total
+
+---
+
+## TC-012: Concurrent Import Safety
+
+**Scenario:** Two `memory-catchup.sh` processes run simultaneously on overlapping JSONL files.
+**Expected:**
+- Unique constraint `(session_id, external_message_id)` prevents duplicates
+- No deadlocks
+- Final state is consistent
+
+---
+
+## TC-013: Backfill of Old JSONL Files
+
+**Setup:** Historical JSONL files from before migration 067.
+**Action:** Run `memory-catchup.sh` against them.
+**Expected:** All historical transcripts land in `channel_transcripts` with proper session grouping. Files deleted after successful import.
+
+---
+
+## TC-014: entity_facts Source Pointers — New Fact
+
+**Scenario:** Memory extraction creates a new `entity_facts` row from a message already in `channel_transcripts`.
+**Expected:**
+- `source_channel_transcript_id` populated with the correct `channel_transcripts.id`
+- `source_channel_session_id` populated with the correct `channel_sessions.id`
+
+---
+
+## TC-015: entity_facts Source Pointers — Reinforcement
+
+**Scenario:** A duplicate fact is extracted from a newer message.
+**Expected:**
+- `vote_count` incremented
+- `source_channel_transcript_id` updated to the newer message (COALESCE — never overwrite with NULL)
+- Old pointer preserved if new pointer is NULL
+
+---
+
+## TC-016: sender_entity_id Population
+
+**Scenario:** Transcript row imported with raw sender fields but no `sender_entity_id`.
+**Action:** Entity resolver runs later and maps `sender_id='330189773371080716'` to `entities.id` for I)ruid.
+**Expected:** `sender_entity_id` FK is updated. JOIN to `entities` table works.
+
+---
+
+## TC-017: memory-extract Hook — Context Passing
+
+**Verification:** `memory/hooks/memory-extract/handler.ts` reads `channelTranscriptId` and `channelSessionId` from event context and passes them as `SOURCE_CHANNEL_TRANSCRIPT_ID` and `SOURCE_CHANNEL_SESSION_ID` env vars.
+**Expected:** Extraction subprocess receives the env vars. `store-memories.sh` uses them for FK columns.
+
+---
+
+## TC-018: Schema Migration — conversations Table Dropped
+
+**Verification:**
+```sql
+SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name='conversations');
+-- Expected: false
+```
+**Also verify:** `DROP TABLE IF EXISTS conversations CASCADE;` in migration 067.
+
+---
+
+## TC-019: Legacy Code Audit — No conversations References
+
+**Verification:**
+```bash
+git grep -n 'conversations' -- '*.ts' '*.sh' '*.sql' ':!**/node_modules/**' ':!**/TEST-CASES*' ':!**/CHANGELOG*' | grep -v 'DROP TABLE' | grep -v '-- '
+```
+**Expected:** Zero hits in active codepaths. Only acceptable in migration DROP statement and historical test/doc files.
+
+---
+
+## TC-020: Daily .md File Format — Unknown Format Fallback
+
+**Input:** A `memory/*.md` file with no structured chat references (just plain prose notes).
+**Expected:** Content ingested as-is into entity_facts. No crash. File deleted after successful insert.
+
+---
+
+## TC-021: SQL Injection Safety
+
+**Review:** All shell-to-SQL paths in `memory-catchup.sh` and `store-memories.sh` use proper escaping.
+**Check:** `sed "s/'/''/g"` applied to all user-controlled values before interpolation into SQL strings.
+**Flag:** Any path where raw content reaches `psql -c` without escaping.
+
+---
+
+## TC-022: Additional Happy Path — Discord Message (message_id 1502593273334599721)
+
+**Input:** Second real Discord message from the #software-engineering channel.
+**Expected:** Attaches to the existing `channel_sessions` row (same `external_chat_id`). `message_count` increments. `last_message_at` updates. Full `raw_metadata` preserved.


### PR DESCRIPTION
## Summary

Implements database-backed chat transcript storage, fixes memory reinforcement, and adds proper source pointers from entity_facts to the originating messages.

### New Tables
- **`channel_sessions`** — One row per logical conversation/thread/DM/group chat. Stores OpenClaw `session_key`, provider, external IDs, group metadata, and full untrusted `raw_metadata` JSONB.
- **`channel_transcripts`** — One row per message. FK to `channel_sessions`, stores sender fields (`sender_id`, `sender_name`, `sender_username`, `sender_tag`, `sender_entity_id`), message content, role, and full `raw_metadata` JSONB.

### entity_facts Source Pointers
- Added `source_channel_transcript_id` and `source_channel_session_id` FK columns to `entity_facts`
- From any fact, you can now trace back to the exact message and reconstruct the full conversation

### Legacy Cleanup
- **Dropped `conversations` table** (superseded by `channel_sessions`)

### Script Changes
- **`memory-catchup.sh`**: Now ingests JSONL session transcripts + daily `memory/*.md` files into the new tables, then safely deletes source files. Rich metadata parsing (provider auto-detection, sender fields, group metadata). Extraction failures no longer block transcript ingestion.
- **`memory-extract/handler.ts`**: Real-time upsert of channel_sessions/transcripts during message processing, passes FK IDs to extraction pipeline.
- **`store-memories.sh`**: Populates source FK columns on entity_facts during insertion and reinforcement. SQL injection fix (ILIKE → exact LOWER equality).

### Migration
- `067_channel_sessions_transcripts.sql` — Creates tables, adds FK columns, drops `conversations`

### Testing
- 22 test cases (TC-001 through TC-022) covering happy paths, idempotency, deletion safety, edge cases, performance, legacy audit
- Phase 1 desk review passed (2 rounds)
- Phase 2 staging testing passed on nova-staging

### Documentation
- Updated ARCHITECTURE.md, memory/ARCHITECTURE.md, CHANGELOG.md, README.md, schema-reference.md, extraction pipeline docs, semantic-recall docs
- Fixed stale OpenAI→Ollama references in semantic-recall docs
- Removed dead `conversations` table from schema-reference.md

Closes #165, closes #138, closes #170