### PR TITLE
fix: Audit and update stale nova-memory and path references across repo

### DIFF
--- a/cognition/agent-install.sh
+++ b/cognition/agent-install.sh
@@ -119,7 +119,7 @@ if [ ${#MISSING_FILES[@]} -gt 0 ]; then
         echo "  - $f" >&2
     done
     echo "  These are installed by nova-memory. Some features may not work." >&2
-    echo "  Install nova-memory: cd ~/.openclaw/workspace/nova-memory && bash agent-install.sh" >&2
+    echo "  Install nova-memory: cd ~/.openclaw/workspace/nova-mind && bash memory/agent-install.sh" >&2
 fi
 
 # Color codes for output

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -2273,7 +2273,7 @@ COMMENT ON COLUMN projects.repo_url IS 'GitHub repo URL. When set with locked=TR
 COMMENT ON COLUMN projects.locked IS 'When TRUE, project is repo-backed. Use GitHub (repo_url) for docs/updates, not this table. Prevents accidental writes to notes field.';
 
 
-COMMENT ON COLUMN projects.skills IS 'Array of skill names (from ~/clawd/skills/) relevant to this project';
+COMMENT ON COLUMN projects.skills IS 'Array of skill names (from ~/.openclaw/skills/) relevant to this project';
 
 --
 -- Name: idx_projects_status; Type: INDEX; Schema: -; Owner: -

--- a/memory/schema.sql
+++ b/memory/schema.sql
@@ -5056,7 +5056,7 @@ COMMENT ON COLUMN public.projects.locked IS 'When TRUE, project is repo-backed. 
 -- Name: COLUMN projects.skills; Type: COMMENT; Schema: public; Owner: nova
 --
 
-COMMENT ON COLUMN public.projects.skills IS 'Array of skill names (from ~/clawd/skills/) relevant to this project';
+COMMENT ON COLUMN public.projects.skills IS 'Array of skill names (from ~/.openclaw/skills/) relevant to this project';
 
 
 --

--- a/memory/schema/schema.sql
+++ b/memory/schema/schema.sql
@@ -2278,7 +2278,7 @@ COMMENT ON COLUMN projects.repo_url IS 'GitHub repo URL. When set with locked=TR
 COMMENT ON COLUMN projects.locked IS 'When TRUE, project is repo-backed. Use GitHub (repo_url) for docs/updates, not this table. Prevents accidental writes to notes field.';
 
 
-COMMENT ON COLUMN projects.skills IS 'Array of skill names (from ~/clawd/skills/) relevant to this project';
+COMMENT ON COLUMN projects.skills IS 'Array of skill names (from ~/.openclaw/skills/) relevant to this project';
 
 --
 -- Name: idx_projects_status; Type: INDEX; Schema: -; Owner: -

--- a/memory/scripts/test-delegation-memory.sh
+++ b/memory/scripts/test-delegation-memory.sh
@@ -54,7 +54,7 @@ psql -t -c "
 echo ""
 
 # Test 4: Semantic search (if proactive-recall.py is available)
-if [ -f "$HOME/.openclaw/workspace/nova-memory/scripts/proactive-recall.py" ]; then
+if [ -f "$HOME/.openclaw/workspace/nova-mind/memory/scripts/proactive-recall.py" ]; then
     echo "📊 Test 4: Semantic search for delegation"
     
     if [ -z "$OPENAI_API_KEY" ]; then
@@ -79,7 +79,7 @@ echo ""
 
 # Test 5: Memory extraction test
 echo "📊 Test 5: Memory extraction with delegation"
-if [ -f "$HOME/.openclaw/workspace/nova-memory/scripts/extract-memories.sh" ]; then
+if [ -f "$HOME/.openclaw/workspace/nova-mind/memory/scripts/extract-memories.sh" ]; then
     export SENDER_NAME="I)ruid"
     export SENDER_ID=""
     export IS_GROUP="false"
@@ -87,7 +87,7 @@ if [ -f "$HOME/.openclaw/workspace/nova-memory/scripts/extract-memories.sh" ]; t
     TEST_CONVO="[USER] Can you help me fix this bug?
 [CURRENT NOVA MESSAGE] Let me get Coder to help with that code issue."
     
-    EXTRACTED=$(echo "$TEST_CONVO" | "$HOME/.openclaw/workspace/nova-memory/scripts/extract-memories.sh" 2>/dev/null || echo "{}")
+    EXTRACTED=$(echo "$TEST_CONVO" | "$HOME/.openclaw/workspace/nova-mind/memory/scripts/extract-memories.sh" 2>/dev/null || echo "{}")
     
     if echo "$EXTRACTED" | jq -e '.facts[]? | select(.predicate == "delegates_to")' > /dev/null 2>&1; then
         echo "   ✅ Extraction recognizes delegation patterns"

--- a/relationships/shell-install.sh
+++ b/relationships/shell-install.sh
@@ -100,7 +100,7 @@ if [ ! -f "$PG_ENV" ]; then
     echo "   Expected: $PG_ENV" >&2
     echo "" >&2
     echo "pg-env.sh not found — is nova-memory installed?" >&2
-    echo "Run nova-memory/shell-install.sh first to install shared library files." >&2
+    echo "Run memory/shell-install.sh from nova-mind repo first to install shared library files." >&2
     exit 1
 fi
 


### PR DESCRIPTION
Comprehensive audit of all stale path references in the nova-mind repo.

### Fixed (6 files, 8 changes)
- `test-delegation-memory.sh`: 3x `nova-memory/scripts/` → `nova-mind/memory/scripts/`
- `cognition/agent-install.sh`: install instruction path
- `relationships/shell-install.sh`: error message path
- `database/schema.sql`, `memory/schema.sql`, `memory/schema/schema.sql`: `~/clawd/skills/` → `~/.openclaw/skills/` in SQL comments

### Intentionally left as-is
- GitHub issue URLs (immutable)
- `nova_memory` database name (that's the actual DB name)
- Documentation-only references in .md files
- Module self-branding in memory/ subdir