### PR TITLE
fix: remove dead source parameter from store_or_reinforce_fact

### DIFF
--- a/memory/scripts/extract_memories.py
+++ b/memory/scripts/extract_memories.py
@@ -353,7 +353,6 @@ def store_or_reinforce_fact(
     key: str,
     value: str,
     source_entity_id: Optional[int],
-    source: str,
     visibility: str,
     visibility_reason: Optional[str],
     conn,
@@ -699,7 +698,6 @@ def store_extracted(
             key=key,
             value=value,
             source_entity_id=source_entity_id,  # always the sender
-            source=sender_name or "auto-extracted",
             visibility=visibility,
             visibility_reason=visibility_reason,
             conn=conn,


### PR DESCRIPTION
Code review cleanup from Coder reviewing PRs #212/#213.

The `source: str` parameter in `store_or_reinforce_fact()` was dead code — the `source` column was dropped from entity_facts in PR #207 but the parameter was never removed.

Review doc: tests/CODE-REVIEW-PR212-213.md