### PR TITLE
feat: Unified memory maintenance — entity_facts quality batch (#216, #202, #200, #203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## [Unreleased] — 2026-05-14
+
+### Batch: entity-facts-quality
+
+#### Changes
+- **Unified memory maintenance script** — `memory/scripts/memory-maintenance.py` completely rewritten as a 9-phase pipeline absorbing the separate embedding scripts (`embed-full-database.py`, `embed-memories.py`, `embed-research.py`) and previous maintenance logic.
+- **New DB function `merge_entities()`** — Dynamically discovers FK references, handles entity_facts same-key merging via `merge_facts()`, transfers nicknames, and manages memory_embeddings.
+- **Unique constraint** — Added `uq_memory_embeddings_source` unique index on `memory_embeddings(source_type, source_id)` to prevent duplicate embeddings.
+- **Scheduling change** — Removed from crontab (was `0 4 * * *` for decay and `0 11 * * *` for embedding). Now triggered from HEARTBEAT idle cascade as priority #2 with a 4-hour cooldown gate.
+- **CLI flags** — `--dry-run`, `--verbose`, `--force`, `--state-file`, `--skip-embed`, `--skip-consolidation`, `--skip-dedup`, `--skip-decay`, `--skip-ghost-cleanup`, `--skip-entity-dedup`.
+- **Deprecated scripts** — `embed-memories-cron.sh` deprecated (absorbed into memory-maintenance.py). `embed-full-database.py`, `embed-memories.py`, `embed-research.py` deprecated in favor of `memory-maintenance.py`.
+
+#### Issues Closed
+- #216 — Entity-level deduplication
+- #202 — Cross-key (cross-entity) fact consolidation
+- #200 — Ghost entity cleanup
+- #203 — Confidence decay with archiving

--- a/README.md
+++ b/README.md
@@ -23,6 +23,30 @@ nova-mind is the complete agent mind stack for NOVA. It provides:
 
 All three subsystems share a single PostgreSQL database (`{username}_memory`) and a unified installer.
 
+### Memory Maintenance
+
+Memory maintenance is handled by a **unified** script `memory/scripts/memory-maintenance.py` that replaces the separate embedding scripts (`embed-full-database.py`, `embed-memories.py`, `embed-research.py`, `embed-library.py`) and the previous memory maintenance logic. It runs as a 9-phase pipeline:
+
+1. **Cooldown check** — 4-hour gate prevents redundant runs (`--force` to bypass, `--state-file` override)
+2. **Embed** — Absorbs embed-full-database.py, embed-memories.py, embed-research.py
+3. **Cross-key consolidation** — pgvector cosine similarity ≥0.92
+4. **Same-key dedup** — pg_trgm similarity, 3-tier (high/medium/low)
+5. **Confidence decay** — Exponential, durability-based rates
+6. **Ghost entity cleanup** — Pattern-based, zero-fact orphans, low-fact review
+7. **Entity-level dedup** — ≥80% auto-merge via `merge_entities()`, <80% review queue
+8. **Clean orphaned embeddings**
+9. **Archive & purge** low-confidence facts
+
+**Flags:** `--dry-run`, `--verbose`, `--force`, `--state-file`, `--skip-embed`, `--skip-consolidation`, `--skip-dedup`, `--skip-decay`, `--skip-ghost-cleanup`, `--skip-entity-dedup`
+
+**Scheduling:** Removed from crontab. Now triggered from the HEARTBEAT idle cascade as priority #2 (after peer agent messages, before pending tasks). A 4-hour cooldown gate prevents redundant runs. A unique index (`uq_memory_embeddings_source`) prevents duplicate embeddings.
+
+**New DB functions:** `merge_entities(survivor_id, absorbed_id)` dynamically discovers FK references, handles entity_facts same-key merging, transfers nicknames, and manages memory_embeddings.
+
+Closes issues: #216 (entity dedup), #202 (cross-key consolidation), #200 (ghost entity cleanup), #203 (confidence decay with archiving).
+
+---
+
 ## Structure
 
 ```

--- a/database/schema-reference.md
+++ b/database/schema-reference.md
@@ -1,6 +1,6 @@
 # Database Schema Reference
 
-*Auto-generated: 2026-05-14T01:48:12.818774*
+*Auto-generated: 2026-05-14T07:37:50.230773*
 
 ## Tables
 
@@ -19,7 +19,7 @@
 | agent_turn_context | - | 8 |
 | agents | Agent registry | 32 |
 | ai_models | Available AI models. NOVA maintains this; Newhart reads for agent assignments. Credentials and endpoints stored in 1Password (see credential_ref column). | 16 |
-| artwork | Archive of NOVAs Instagram artwork. Reference for future compilation. | 19 |
+| artwork | Archive of NOVAs Instagram artwork. Reference for future compilation. | 20 |
 | asset_classes | Asset class definitions for financial portfolio management. Defines tradeable asset types with pricing sources and trading characteristics. | 6 |
 | bootstrap_context_config | Configuration for bootstrap system behavior | 4 |
 | certificates | Client certificates issued by NOVA CA. Security-sensitive. Verify before modifications. | 12 |
@@ -31,7 +31,7 @@
 | comms_state | Per-platform communications tracking state (seen IDs, cursors). Replaces hermes-social-state.json. Owner: Communications domain (hermes). | 5 |
 | entities | People, AIs, organizations. NOVA has full access. Use entity_facts for attributes. | 20 |
 | entity_fact_conflicts | Conflicts between entity facts requiring resolution. Part of the truth reconciliation system. | 13 |
-| entity_fact_sources | - | 7 |
+| entity_fact_sources | - | 8 |
 | entity_facts | Key-value facts about entities. Check current_timezone for I)ruid before time-based actions. | 19 |
 | entity_facts_archive | Archived entity facts from decay/cleanup processes. Historical record of previously stored knowledge. | 20 |
 | entity_relationships | Relationships between entities (family, work, friendship, etc). | 8 |

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -7020,13 +7020,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7068,13 +7068,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM iris;
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_modifications FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
+REVOKE SELECT ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7098,13 +7098,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM ticker;
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_spawns FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
+REVOKE SELECT ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7146,13 +7146,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM iris;
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_system_config FROM newhart;
+REVOKE SELECT ON TABLE agent_system_config FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_system_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_system_config FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7176,13 +7176,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7224,13 +7224,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agents FROM iris;
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agents FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
+REVOKE SELECT ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7320,13 +7320,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7380,13 +7380,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8502,13 +8502,13 @@ REVOKE SELECT ON TABLE music_analysis FROM iris;
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
+REVOKE SELECT ON TABLE music_library FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_library FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
 
 --
 -- Name: place_properties; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8538,25 +8538,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FRO
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
+REVOKE SELECT ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_history FROM ticker;
-
---
--- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
+
+--
+-- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8574,25 +8574,25 @@ REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
-
---
--- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
+
+--
+-- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8772,13 +8772,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8838,13 +8838,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_findings FROM nova;
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
+REVOKE SELECT ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_findings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9036,13 +9036,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -6787,13 +6787,13 @@ CREATE OR REPLACE VIEW workflow_steps_detail AS
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
+REVOKE SELECT ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_actions FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6901,13 +6901,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM iris;
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6943,13 +6943,13 @@ REVOKE SELECT ON TABLE agent_chat FROM newhart;
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat_processed FROM newhart;
+REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat_processed FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7069,13 +7069,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM iris;
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
+REVOKE SELECT ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_modifications FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7147,13 +7147,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM iris;
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_system_config FROM newhart;
+REVOKE SELECT ON TABLE agent_system_config FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_system_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_system_config FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7177,13 +7177,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7291,13 +7291,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM iris;
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
+REVOKE SELECT ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ai_models FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8119,13 +8119,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8383,13 +8383,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_tags FROM ticker;
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_works FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
+REVOKE SELECT ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8527,25 +8527,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE places FROM nova;
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
-
---
--- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE portfolio_history FROM ticker;
+
+--
+-- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8587,13 +8587,13 @@ REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
+REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8617,13 +8617,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE preferences FROM nova;
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
+REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: project_entities; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8773,13 +8773,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8839,13 +8839,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_findings FROM nova;
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_findings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
+REVOKE SELECT ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8905,13 +8905,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_projects FROM nova;
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
+REVOKE SELECT ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_projects FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8971,13 +8971,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9037,13 +9037,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9103,13 +9103,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tags FROM nova;
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
+REVOKE SELECT ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tags FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9169,13 +9169,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tasks FROM nova;
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
+REVOKE SELECT ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tasks FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -6834,13 +6834,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_aliases FROM iris;
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_aliases FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_aliases FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_aliases FROM newhart;
+REVOKE SELECT ON TABLE agent_aliases FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6900,13 +6900,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM iris;
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6930,25 +6930,25 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM ticker;
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
+REVOKE SELECT ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_chat FROM newhart;
-
---
--- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat_processed FROM newhart;
+
+--
+-- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6990,13 +6990,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM iris;
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
+REVOKE SELECT ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_domains FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7098,13 +7098,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM ticker;
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
+REVOKE SELECT ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_spawns FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7146,13 +7146,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM iris;
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_system_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_system_config FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_system_config FROM newhart;
+REVOKE SELECT ON TABLE agent_system_config FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7176,13 +7176,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7224,13 +7224,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agents FROM iris;
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
+REVOKE SELECT ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agents FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7332,13 +7332,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE asset_classes FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
+REVOKE SELECT ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7380,13 +7380,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8052,13 +8052,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8184,13 +8184,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8250,13 +8250,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_authors FROM ticker;
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_relationships FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
+REVOKE SELECT ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8316,13 +8316,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_relationships FROM ticker;
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
+REVOKE SELECT ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8490,25 +8490,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
-
---
--- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE music_library FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
+
+--
+-- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE music_library FROM iris;
 
 --
 -- Name: place_properties; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8526,13 +8526,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE places FROM nova;
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8598,13 +8598,13 @@ REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
+REVOKE SELECT ON TABLE positions FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE positions FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
 
 --
 -- Name: preferences; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8706,13 +8706,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_citations FROM nova;
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
+REVOKE SELECT ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_citations FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8772,13 +8772,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8838,13 +8838,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_findings FROM nova;
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_findings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
+REVOKE SELECT ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8970,13 +8970,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9036,13 +9036,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9168,13 +9168,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tasks FROM nova;
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tasks FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
+REVOKE SELECT ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9240,13 +9240,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE tasks FROM nova;
 -- Name: ticker_portfolio; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ticker_portfolio FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ticker_portfolio FROM ticker;
 
 --
 -- Name: ticker_portfolio; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ticker_portfolio FROM ticker;
+REVOKE SELECT ON TABLE ticker_portfolio FROM ticker;
 
 --
 -- Name: tools; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -800,6 +800,7 @@ CREATE TABLE IF NOT EXISTS artwork (
     nostr_image_url text,
     x_tweet_id text,
     x_url text,
+    image_model text,
     CONSTRAINT artwork_pkey PRIMARY KEY (id)
 );
 
@@ -811,6 +812,9 @@ COMMENT ON COLUMN artwork.image_data IS 'Raw image binary data (PNG/JPG)';
 
 
 COMMENT ON COLUMN artwork.inspiration_source IS 'News snippet or source that inspired this artwork';
+
+
+COMMENT ON COLUMN artwork.image_model IS 'Image generation model used (e.g. grok-imagine-image-pro, gpt-image-1, gemini-3-pro-image-preview)';
 
 --
 -- Name: asset_classes; Type: TABLE; Schema: -; Owner: -
@@ -6835,13 +6839,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_aliases FROM iris;
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_aliases FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_aliases FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_aliases FROM newhart;
+REVOKE SELECT ON TABLE agent_aliases FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6931,25 +6935,25 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM ticker;
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
+REVOKE SELECT ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_chat FROM newhart;
-
---
--- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat_processed FROM newhart;
+
+--
+-- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6991,13 +6995,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM iris;
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_domains FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
+REVOKE SELECT ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7021,13 +7025,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7291,13 +7295,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM iris;
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ai_models FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
+REVOKE SELECT ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7381,13 +7385,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8119,13 +8123,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8251,13 +8255,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_authors FROM ticker;
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_relationships FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
+REVOKE SELECT ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8491,13 +8495,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8527,19 +8531,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE places FROM nova;
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
-
---
--- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE portfolio_history FROM ticker;
+REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8548,16 +8546,22 @@ REVOKE SELECT ON TABLE portfolio_history FROM ticker;
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
 
 --
--- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
+-- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
+REVOKE SELECT ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
+
+--
+-- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8575,13 +8579,13 @@ REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8599,13 +8603,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
+REVOKE SELECT ON TABLE positions FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE positions FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
 
 --
 -- Name: preferences; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8617,13 +8621,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE preferences FROM nova;
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
+REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: project_entities; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8707,13 +8711,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_citations FROM nova;
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
+REVOKE SELECT ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_citations FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8773,13 +8777,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8839,13 +8843,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_findings FROM nova;
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
+REVOKE SELECT ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_findings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8971,13 +8975,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9103,13 +9107,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tags FROM nova;
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tags FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
+REVOKE SELECT ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9169,13 +9173,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tasks FROM nova;
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tasks FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
+REVOKE SELECT ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9241,13 +9245,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE tasks FROM nova;
 -- Name: ticker_portfolio; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ticker_portfolio FROM ticker;
+REVOKE SELECT ON TABLE ticker_portfolio FROM ticker;
 
 --
 -- Name: ticker_portfolio; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ticker_portfolio FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ticker_portfolio FROM ticker;
 
 --
 -- Name: tools; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -6786,13 +6786,13 @@ CREATE OR REPLACE VIEW workflow_steps_detail AS
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
+REVOKE SELECT ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_actions FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6930,25 +6930,19 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM ticker;
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_chat FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
+REVOKE SELECT ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
-
---
--- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat_processed FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7026,13 +7020,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7074,13 +7068,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM iris;
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
+REVOKE SELECT ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_modifications FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7104,13 +7098,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM ticker;
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_spawns FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
+REVOKE SELECT ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7230,13 +7224,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agents FROM iris;
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agents FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
+REVOKE SELECT ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7326,31 +7320,25 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
+
+--
+-- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
-
---
--- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE asset_classes FROM ticker;
-
---
--- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7392,13 +7380,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8064,13 +8052,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8130,13 +8118,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8328,13 +8316,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_relationships FROM ticker;
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
+REVOKE SELECT ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8502,13 +8490,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8556,25 +8544,19 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
-
---
--- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
-
---
--- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
+REVOKE SELECT ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
+
+--
+-- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8598,13 +8580,7 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
-
---
--- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8619,22 +8595,16 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
 
 --
--- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
+-- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE positions FROM ticker;
-
---
--- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
 
 --
 -- Name: preferences; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8868,13 +8838,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_findings FROM nova;
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
+REVOKE SELECT ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_findings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9000,13 +8970,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9066,13 +9036,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9132,13 +9102,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tags FROM nova;
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
+REVOKE SELECT ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tags FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9198,13 +9168,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tasks FROM nova;
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
+REVOKE SELECT ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tasks FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1356,6 +1356,7 @@ CREATE TABLE IF NOT EXISTS entity_fact_sources (
     attribution_count integer DEFAULT 1,
     first_seen timestamptz DEFAULT now(),
     last_seen timestamptz DEFAULT now(),
+    source_url text,
     CONSTRAINT entity_fact_sources_pkey PRIMARY KEY (id),
     CONSTRAINT uq_fact_source UNIQUE (fact_id, source_entity_id),
     CONSTRAINT entity_fact_sources_fact_id_fkey FOREIGN KEY (fact_id) REFERENCES entity_facts (id) ON DELETE CASCADE,
@@ -6900,13 +6901,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM iris;
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6930,25 +6931,25 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM ticker;
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_chat FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
-
---
--- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
+REVOKE SELECT ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat_processed FROM newhart;
+
+--
+-- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6990,13 +6991,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM iris;
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
+REVOKE SELECT ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_domains FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7020,13 +7021,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7068,13 +7069,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM iris;
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_modifications FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
+REVOKE SELECT ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7176,13 +7177,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7290,13 +7291,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM iris;
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ai_models FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
+REVOKE SELECT ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7320,25 +7321,25 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
-
---
--- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE asset_classes FROM ticker;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
+
+--
+-- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7380,13 +7381,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8022,13 +8023,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE gambling_logs FROM nova;
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE git_issue_queue FROM coder;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
+REVOKE SELECT ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: job_messages; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8052,13 +8053,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8118,13 +8119,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8184,13 +8185,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8250,13 +8251,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_authors FROM ticker;
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
+REVOKE SELECT ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_relationships FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8490,25 +8491,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
-
---
--- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE music_library FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
+
+--
+-- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE music_library FROM iris;
 
 --
 -- Name: place_properties; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8538,19 +8539,13 @@ REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_history FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
-
---
--- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
+REVOKE SELECT ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8559,16 +8554,22 @@ REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
 
 --
--- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
+-- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
+REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
+
+--
+-- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8616,13 +8617,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE preferences FROM nova;
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
+REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: project_entities; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8706,13 +8707,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_citations FROM nova;
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_citations FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
+REVOKE SELECT ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8838,13 +8839,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_findings FROM nova;
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
+REVOKE SELECT ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_findings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9036,13 +9037,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9240,13 +9241,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE tasks FROM nova;
 -- Name: ticker_portfolio; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ticker_portfolio FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ticker_portfolio FROM ticker;
 
 --
 -- Name: ticker_portfolio; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ticker_portfolio FROM ticker;
+REVOKE SELECT ON TABLE ticker_portfolio FROM ticker;
 
 --
 -- Name: tools; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -6786,13 +6786,13 @@ CREATE OR REPLACE VIEW workflow_steps_detail AS
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_actions FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
+REVOKE SELECT ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6900,13 +6900,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM iris;
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6930,13 +6930,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM ticker;
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_chat FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
+REVOKE SELECT ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7020,13 +7020,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7068,13 +7068,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM iris;
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
+REVOKE SELECT ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_modifications FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7146,13 +7146,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM iris;
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_system_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_system_config FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_system_config FROM newhart;
+REVOKE SELECT ON TABLE agent_system_config FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7176,13 +7176,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7320,25 +7320,25 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
-
---
--- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE asset_classes FROM ticker;
+
+--
+-- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7380,13 +7380,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8052,13 +8052,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8118,13 +8118,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8184,13 +8184,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8250,13 +8250,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_authors FROM ticker;
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
+REVOKE SELECT ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_relationships FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8502,13 +8502,13 @@ REVOKE SELECT ON TABLE music_analysis FROM iris;
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_library FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
+REVOKE SELECT ON TABLE music_library FROM iris;
 
 --
 -- Name: place_properties; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8586,25 +8586,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
-
---
--- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE positions FROM ticker;
+REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
+
+--
+-- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE positions FROM ticker;
 
 --
 -- Name: preferences; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8616,13 +8616,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE preferences FROM nova;
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
+REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: project_entities; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8706,13 +8706,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_citations FROM nova;
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_citations FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
+REVOKE SELECT ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8772,13 +8772,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8904,13 +8904,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_projects FROM nova;
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_projects FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
+REVOKE SELECT ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8970,13 +8970,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9036,13 +9036,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9168,13 +9168,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tasks FROM nova;
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
+REVOKE SELECT ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tasks FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -6900,13 +6900,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM iris;
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6930,25 +6930,25 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM ticker;
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
+REVOKE SELECT ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_chat FROM newhart;
-
---
--- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat_processed FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE agent_chat_processed FROM newhart;
+
+--
+-- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat_processed FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6990,13 +6990,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM iris;
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_domains FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
+REVOKE SELECT ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7020,13 +7020,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7098,13 +7098,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM ticker;
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_spawns FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
+REVOKE SELECT ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7176,13 +7176,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7224,13 +7224,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agents FROM iris;
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agents FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
+REVOKE SELECT ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7380,13 +7380,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8118,13 +8118,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8184,13 +8184,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8250,13 +8250,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_authors FROM ticker;
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_relationships FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
+REVOKE SELECT ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8490,25 +8490,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
-
---
--- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE music_library FROM iris;
+
+--
+-- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
 
 --
 -- Name: place_properties; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8538,19 +8538,13 @@ REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
+REVOKE SELECT ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_history FROM ticker;
-
---
--- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8559,16 +8553,22 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
 REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
 
 --
--- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
+-- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
+
+--
+-- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8586,25 +8586,25 @@ REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
-
---
--- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE positions FROM ticker;
+REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
+
+--
+-- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE positions FROM ticker;
 
 --
 -- Name: preferences; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8616,13 +8616,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE preferences FROM nova;
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
+REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: project_entities; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8706,13 +8706,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_citations FROM nova;
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
+REVOKE SELECT ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_citations FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8838,13 +8838,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_findings FROM nova;
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_findings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
+REVOKE SELECT ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8904,13 +8904,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_projects FROM nova;
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_projects FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
+REVOKE SELECT ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9168,13 +9168,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tasks FROM nova;
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tasks FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
+REVOKE SELECT ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9240,13 +9240,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE tasks FROM nova;
 -- Name: ticker_portfolio; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ticker_portfolio FROM ticker;
+REVOKE SELECT ON TABLE ticker_portfolio FROM ticker;
 
 --
 -- Name: ticker_portfolio; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ticker_portfolio FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ticker_portfolio FROM ticker;
 
 --
 -- Name: tools; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -6935,13 +6935,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM ticker;
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_chat FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
+REVOKE SELECT ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7073,13 +7073,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM iris;
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_modifications FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
+REVOKE SELECT ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7103,13 +7103,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM ticker;
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
+REVOKE SELECT ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_spawns FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7181,13 +7181,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7229,13 +7229,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agents FROM iris;
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
+REVOKE SELECT ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agents FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7295,13 +7295,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM iris;
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
+REVOKE SELECT ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ai_models FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7325,13 +7325,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7385,13 +7385,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8057,13 +8057,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8123,13 +8123,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8321,13 +8321,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_relationships FROM ticker;
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
+REVOKE SELECT ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8387,13 +8387,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_tags FROM ticker;
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
+REVOKE SELECT ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_works FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8567,25 +8567,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
+REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
-
---
--- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
+
+--
+-- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8603,13 +8603,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE positions FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
+REVOKE SELECT ON TABLE positions FROM ticker;
 
 --
 -- Name: preferences; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8711,13 +8711,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_citations FROM nova;
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_citations FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
+REVOKE SELECT ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8777,13 +8777,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8909,13 +8909,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_projects FROM nova;
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_projects FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
+REVOKE SELECT ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8975,13 +8975,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9173,13 +9173,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tasks FROM nova;
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
+REVOKE SELECT ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tasks FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -6834,13 +6834,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_aliases FROM iris;
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_aliases FROM newhart;
+REVOKE SELECT ON TABLE agent_aliases FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_aliases FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_aliases FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -6900,13 +6900,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM iris;
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7098,13 +7098,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM ticker;
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
+REVOKE SELECT ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_spawns FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7176,13 +7176,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7224,13 +7224,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agents FROM iris;
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
+REVOKE SELECT ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agents FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7380,13 +7380,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8052,13 +8052,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8184,13 +8184,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8490,13 +8490,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8526,19 +8526,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE places FROM nova;
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
-
---
--- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE portfolio_history FROM ticker;
+REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8547,16 +8541,22 @@ REVOKE SELECT ON TABLE portfolio_history FROM ticker;
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
 
 --
--- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
+-- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
+REVOKE SELECT ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
+
+--
+-- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8574,19 +8574,13 @@ REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
-
---
--- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
+REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8595,16 +8589,22 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
 
 --
--- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
+-- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE positions FROM ticker;
+
+--
+-- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
 
 --
 -- Name: preferences; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8772,13 +8772,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8904,13 +8904,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_projects FROM nova;
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
+REVOKE SELECT ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_projects FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8970,13 +8970,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9036,13 +9036,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9102,13 +9102,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tags FROM nova;
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tags FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
+REVOKE SELECT ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/memory/README.md
+++ b/memory/README.md
@@ -52,7 +52,7 @@ This is the actual installer. It:
 - Installs skills to `~/.openclaw/skills/`
 - Sets up a Python virtual environment with required dependencies
 - Patches OpenClaw config to auto-enable hooks (if `enable-hooks.sh` is present)
-- Configures a cron job for daily memory maintenance
+- Configures memory maintenance (triggered from HEARTBEAT idle cascade)
 - Verifies installation is working
 
 **Common flags:**
@@ -906,35 +906,54 @@ A centralized configuration file `embedding-config.json` is used by all embeddin
 
 The file resides in the `memory/scripts/` directory and is automatically loaded by:
 
-- `embed-memories.py`
-- `embed-library.py`
-- `embed-full-database.py`
+- `memory-maintenance.py` (unified, preferred)
 - `proactive-recall.py`
-- `embed-research.py` (new)
-
-### New Script: `embed-research.py`
-
-A new script `embed-research.py` generates embeddings for research findings in the `research_*` tables, enabling semantic search across research content.
 
 ### Migration Notes
 
 - The `memory_embeddings` table column changed from `vector(1536)` to `vector(1024)`.
-- Existing embeddings were cleared and must be regenerated using the new scripts.
+- Existing embeddings were cleared and must be regenerated.
 - The `semantic-recall` hook no longer requires an `OPENAI_API_KEY` environment variable.
 
-### Running Embedding Scripts
+### Unified Memory Maintenance
 
-To regenerate all embeddings after the migration:
+The separate embedding scripts (`embed-full-database.py`, `embed-memories.py`, `embed-research.py`, `embed-library.py`) have been **absorbed** into a single unified script `memory/scripts/memory-maintenance.py`. This script runs a full 9-phase pipeline:
+
+| Phase | Description |
+|-------|-------------|
+| 1. Cooldown check | 4-hour gate; `--force` to bypass |
+| 2. Embed | Replaces all old embedding scripts |
+| 3. Cross-key consolidation | pgvector cosine similarity ≥0.92 |
+| 4. Same-key dedup | pg_trgm similarity, 3-tier |
+| 5. Confidence decay | Exponential, durability-based rates |
+| 6. Ghost entity cleanup | Zero-fact orphans → archive |
+| 7. Entity-level dedup | ≥80% auto-merge via `merge_entities()` |
+| 8. Clean orphaned embeddings | Remove embeddings with no source |
+| 9. Archive & purge | Remove low-confidence archived facts |
+
+**Flags:** `--dry-run`, `--verbose`, `--force`, `--state-file`, `--skip-embed`, `--skip-consolidation`, `--skip-dedup`, `--skip-decay`, `--skip-ghost-cleanup`, `--skip-entity-dedup`
+
+**New DB Objects:**
+- `merge_entities(survivor_id, absorbed_id)` — dynamically discovers FK references, merges facts, transfers nicknames, handles embeddings
+- `uq_memory_embeddings_source` — unique index on `memory_embeddings(source_type, source_id)`
+
+**Scheduling:** Removed from crontab. Now triggered from the HEARTBEAT idle cascade as priority #2 (after peer agent messages, before pending tasks). The 4-hour cooldown prevents redundant runs.
+
+The old scripts remain in the repo for backward compatibility but are **deprecated** — they will not receive further updates.
+
+### Running Embedding (if you need only embedding)
+
+Run the full maintenance pipeline:
 
 ```bash
 cd memory/scripts
-./embed-full-database.py
+python3 memory-maintenance.py
 ```
 
-For incremental updates, use the cron script:
+To run only the embedding phase:
 
 ```bash
-./embed-memories-cron.sh
+python3 memory-maintenance.py --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup --skip-entity-dedup
 ```
 
 ## Resource Policies (1Password Integration)
@@ -1028,7 +1047,7 @@ PRs welcome! Areas that need work:
 - [x] Confidence decay over time (schema support added 2026-02-04)
 - [ ] Vector embeddings for semantic search
 - [ ] Contradiction detection
-- [ ] Automated confidence decay job (cron)
+- [x] Unified memory maintenance (merge_entities, cross-key consolidation, ghost cleanup, confidence decay with archiving)
 
 ## License
 

--- a/memory/migrations/add-memory-embeddings-unique-constraint.sql
+++ b/memory/migrations/add-memory-embeddings-unique-constraint.sql
@@ -1,0 +1,5 @@
+-- Migration: Add unique constraint on memory_embeddings(source_type, source_id)
+-- Required for ON CONFLICT upsert in _store_embeddings()
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_memory_embeddings_source
+ON memory_embeddings (source_type, source_id);

--- a/memory/migrations/add-merge-entities-function.sql
+++ b/memory/migrations/add-merge-entities-function.sql
@@ -1,0 +1,84 @@
+-- Migration: add merge_entities() function for entity deduplication
+-- Absorbs one entity into another, transferring all FK references and facts
+
+CREATE OR REPLACE FUNCTION merge_entities(survivor_id INTEGER, absorbed_id INTEGER)
+RETURNS entities AS $$
+DECLARE
+    survivor entities%ROWTYPE;
+    absorbed entities%ROWTYPE;
+    fk_ref RECORD;
+    ef1 RECORD;
+    ef2 RECORD;
+    existing_fact RECORD;
+BEGIN
+    -- Validate: ids must differ
+    IF survivor_id = absorbed_id THEN
+        RAISE EXCEPTION 'merge_entities: survivor_id and absorbed_id must be different (%)', survivor_id;
+    END IF;
+
+    -- Validate: both entities must exist
+    SELECT * INTO survivor FROM entities WHERE id = survivor_id;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'merge_entities: survivor entity % does not exist', survivor_id;
+    END IF;
+
+    SELECT * INTO absorbed FROM entities WHERE id = absorbed_id;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'merge_entities: absorbed entity % does not exist', absorbed_id;
+    END IF;
+
+    -- Transfer all FK references dynamically
+    FOR fk_ref IN
+        SELECT tc.table_name, kcu.column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+            ON tc.constraint_name = kcu.constraint_name
+        JOIN information_schema.constraint_column_usage ccu
+            ON ccu.constraint_name = tc.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND ccu.table_name = 'entities'
+          AND ccu.column_name = 'id'
+    LOOP
+        EXECUTE format(
+            'UPDATE %I SET %I = $1 WHERE %I = $2',
+            fk_ref.table_name,
+            fk_ref.column_name,
+            fk_ref.column_name
+        ) USING survivor_id, absorbed_id;
+    END LOOP;
+
+    -- Handle entity_facts specially: merge same-key facts, transfer unique-key facts
+    FOR ef1 IN
+        SELECT * FROM entity_facts WHERE entity_id = absorbed_id
+    LOOP
+        -- Check if survivor already has a fact with the same key
+        SELECT * INTO existing_fact
+        FROM entity_facts
+        WHERE entity_id = survivor_id AND key = ef1.key;
+
+        IF FOUND THEN
+            -- Both have facts with same key: merge them via merge_facts()
+            PERFORM merge_facts(existing_fact.id, ef1.id);
+        ELSE
+            -- Unique key on absorbed entity: just update the entity_id
+            UPDATE entity_facts SET entity_id = survivor_id WHERE id = ef1.id;
+        END IF;
+    END LOOP;
+
+    -- Add absorbed entity's name to survivor's nicknames (if not already present)
+    IF absorbed.name IS NOT NULL THEN
+        IF survivor.nicknames IS NULL THEN
+            UPDATE entities SET nicknames = ARRAY[absorbed.name] WHERE id = survivor_id;
+        ELSIF NOT (absorbed.name = ANY(survivor.nicknames)) THEN
+            UPDATE entities SET nicknames = array_append(survivor.nicknames, absorbed.name) WHERE id = survivor_id;
+        END IF;
+    END IF;
+
+    -- Delete the absorbed entity
+    DELETE FROM entities WHERE id = absorbed_id;
+
+    -- Return the updated survivor
+    SELECT * INTO survivor FROM entities WHERE id = survivor_id;
+    RETURN survivor;
+END;
+$$ LANGUAGE plpgsql;

--- a/memory/migrations/add-merge-entities-function.sql
+++ b/memory/migrations/add-merge-entities-function.sql
@@ -27,27 +27,7 @@ BEGIN
         RAISE EXCEPTION 'merge_entities: absorbed entity % does not exist', absorbed_id;
     END IF;
 
-    -- Transfer all FK references dynamically
-    FOR fk_ref IN
-        SELECT tc.table_name, kcu.column_name
-        FROM information_schema.table_constraints tc
-        JOIN information_schema.key_column_usage kcu
-            ON tc.constraint_name = kcu.constraint_name
-        JOIN information_schema.constraint_column_usage ccu
-            ON ccu.constraint_name = tc.constraint_name
-        WHERE tc.constraint_type = 'FOREIGN KEY'
-          AND ccu.table_name = 'entities'
-          AND ccu.column_name = 'id'
-    LOOP
-        EXECUTE format(
-            'UPDATE %I SET %I = $1 WHERE %I = $2',
-            fk_ref.table_name,
-            fk_ref.column_name,
-            fk_ref.column_name
-        ) USING survivor_id, absorbed_id;
-    END LOOP;
-
-    -- Handle entity_facts specially: merge same-key facts, transfer unique-key facts
+    -- 1. Handle entity_facts FIRST (before generic FK transfer)
     FOR ef1 IN
         SELECT * FROM entity_facts WHERE entity_id = absorbed_id
     LOOP
@@ -64,6 +44,32 @@ BEGIN
             UPDATE entity_facts SET entity_id = survivor_id WHERE id = ef1.id;
         END IF;
     END LOOP;
+
+    -- 2. Transfer all OTHER FK references dynamically (entity_facts already handled)
+    FOR fk_ref IN
+        SELECT tc.table_name, kcu.column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+            ON tc.constraint_name = kcu.constraint_name
+        JOIN information_schema.constraint_column_usage ccu
+            ON ccu.constraint_name = tc.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND ccu.table_name = 'entities'
+          AND ccu.column_name = 'id'
+          AND tc.table_name != 'entity_facts'
+    LOOP
+        EXECUTE format(
+            'UPDATE %I SET %I = $1 WHERE %I = $2',
+            fk_ref.table_name,
+            fk_ref.column_name,
+            fk_ref.column_name
+        ) USING survivor_id, absorbed_id;
+    END LOOP;
+
+    -- 3. Handle memory_embeddings (not a proper FK — source_id is text)
+    UPDATE memory_embeddings
+    SET source_id = survivor_id::text
+    WHERE source_type = 'entity' AND source_id = absorbed_id::text;
 
     -- Add absorbed entity's name to survivor's nicknames (if not already present)
     IF absorbed.name IS NOT NULL THEN

--- a/memory/scripts/embed-full-database.py
+++ b/memory/scripts/embed-full-database.py
@@ -2,6 +2,9 @@
 """
 Embed full database for semantic search.
 Creates embeddings for all relevant tables in nova_memory.
+
+DEPRECATED: This script has been absorbed into memory-maintenance.py.
+Use: python3 memory-maintenance.py (embedding is Phase 2 of the unified pipeline)
 """
 
 import os

--- a/memory/scripts/embed-memories-cron.sh
+++ b/memory/scripts/embed-memories-cron.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# DEPRECATED: This script has been absorbed into memory-maintenance.py
+# Use: python3 ~/.openclaw/scripts/memory-maintenance.py --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup --skip-entity-dedup
+# This wrapper remains for backward compatibility only.
+
+echo "WARNING: embed-memories-cron.sh is deprecated. Use memory-maintenance.py instead." >&2
+
+# Original script preserved below for backward compatibility
 # Daily embedding cron job
 # Runs both file-based and database embedders
 
@@ -11,17 +18,17 @@ source "$VENV"
 
 # Embed file-based memories (daily logs, MEMORY.md)
 echo "--- embed-memories (files) ---" >> "$LOG_FILE"
-python "$HOME/.openclaw/workspace/scripts/embed-memories.py" >> "$LOG_FILE" 2>&1
+python3 "$HOME/.openclaw/workspace/scripts/embed-memories.py" >> "$LOG_FILE" 2>&1
 echo "embed-memories exit: $?" >> "$LOG_FILE"
 
 # Embed database tables (entities, tasks, projects, library, etc.)
 echo "--- embed-full-database ---" >> "$LOG_FILE"
-python "$HOME/.openclaw/workspace/scripts/embed-full-database.py" >> "$LOG_FILE" 2>&1
+python3 "$HOME/.openclaw/workspace/scripts/embed-full-database.py" >> "$LOG_FILE" 2>&1
 echo "embed-full-database exit: $?" >> "$LOG_FILE"
 
 # Embed research data
 echo "--- embed-research ---" >> "$LOG_FILE"
-python "$HOME/.openclaw/workspace/nova-mind/memory/scripts/embed-research.py" >> "$LOG_FILE" 2>&1
+python3 "$HOME/.openclaw/workspace/nova-mind/memory/scripts/embed-research.py" >> "$LOG_FILE" 2>&1
 echo "embed-research exit: $?" >> "$LOG_FILE"
 
 echo "" >> "$LOG_FILE"

--- a/memory/scripts/embed-memories.py
+++ b/memory/scripts/embed-memories.py
@@ -8,6 +8,9 @@ Scoped to FILE sources only:
 
 Database table embeddings are handled by embed-full-database.py.
 
+DEPRECATED: This script has been absorbed into memory-maintenance.py.
+Use: python3 memory-maintenance.py (embedding is Phase 2 of the unified pipeline)
+
 Usage:
     python embed-memories.py                    # Embed all file sources
     python embed-memories.py --source daily_log # Embed only daily logs

--- a/memory/scripts/embed-research.py
+++ b/memory/scripts/embed-research.py
@@ -3,6 +3,9 @@
 Embed research data for semantic search.
 Creates embeddings for new records in research_tasks, research_findings, and research_conclusions.
 
+DEPRECATED: This script has been absorbed into memory-maintenance.py.
+Use: python3 memory-maintenance.py (embedding is Phase 2 of the unified pipeline)
+
 Usage:
     python embed-research.py              # Embed new research records only
     python embed-research.py --reindex    # Force re-embed all research records

--- a/memory/scripts/memory-maintenance.py
+++ b/memory/scripts/memory-maintenance.py
@@ -61,6 +61,21 @@ logger = logging.getLogger("memory-maintenance")
 DEFAULT_STATE_FILE = os.path.expanduser("~/.openclaw/state/memory-maintenance-last-run.json")
 COOLDOWN_HOURS = 4
 EMBED_BATCH_SIZE = 64
+ARCHIVE_THRESHOLD = 0.1
+MIN_AGE_DAYS = 7
+
+DECAY_RATES = {
+    'permanent': 0,
+    'long_term': 0.005,
+    'short_term': 0.02,
+    'ephemeral': 0.1,
+}
+
+TABLE_DECAY_RATES = {
+    'events': 0.001,
+    'lessons': 0.001,
+    'memory_embeddings': 0.01,
+}
 
 
 def load_embedding_config():
@@ -156,10 +171,10 @@ def _store_embeddings(cur, source_type, items, embeddings):
         emb_json = json.dumps(emb)
         cur.execute(
             """
-            INSERT INTO memory_embeddings (source_type, source_id, text, embedding)
+            INSERT INTO memory_embeddings (source_type, source_id, content, embedding)
             VALUES (%s, %s, %s, %s)
             ON CONFLICT (source_type, source_id) DO UPDATE
-            SET text = EXCLUDED.text,
+            SET content = EXCLUDED.content,
                 embedding = EXCLUDED.embedding,
                 created_at = NOW()
             """,
@@ -411,77 +426,227 @@ def cross_key_consolidation(conn, dry_run=False, verbose=False):
 
 
 # ---------------------------------------------------------------------------
-# Phase 4: Same-key deduplication
+# Phase 4: Same-key deduplication (original production logic preserved)
 # ---------------------------------------------------------------------------
 def merge_duplicates(conn, dry_run=False, verbose=False):
+    """Find and merge/categorize duplicate entity_facts using three-tier confidence system.
+
+    Uses pg_trgm similarity() for text comparison. Three tiers:
+    - High (similarity >= 0.80): auto-merge via merge_facts(survivor_id, absorbed_id)
+        survivor = higher confidence fact; extraction_counts are summed by merge_facts
+    - Medium (0.50-0.79 similarity): add to daily report for manual review
+    - Low (< 0.50): skip entirely
+    """
+    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    cur.execute("""
+        SELECT
+            f1.id as id1, f2.id as id2,
+            f1.entity_id, f1.key,
+            f1.value as value1, f2.value as value2,
+            f1.confidence as conf1, f2.confidence as conf2,
+            f1.last_confirmed_at as date1, f2.last_confirmed_at as date2,
+            similarity(LOWER(f1.value), LOWER(f2.value)) as sim
+        FROM entity_facts f1
+        JOIN entity_facts f2 ON
+            f1.entity_id = f2.entity_id
+            AND f1.key = f2.key
+            AND f1.id < f2.id
+        WHERE similarity(LOWER(f1.value), LOWER(f2.value)) >= 0.50
+        ORDER BY sim DESC, f1.id, f2.id
+    """)
+
+    pairs = cur.fetchall()
+
+    absorbed_ids = set()
+    high_merges = 0
+    medium_candidates = []
+
+    for row in pairs:
+        id1, id2 = row['id1'], row['id2']
+
+        if id1 in absorbed_ids or id2 in absorbed_ids:
+            continue
+
+        sim = row['sim']
+
+        if sim >= 0.80:
+            if row['conf1'] > row['conf2']:
+                survivor, absorbed = id1, id2
+            elif row['conf2'] > row['conf1']:
+                survivor, absorbed = id2, id1
+            elif row['date1'] and row['date2'] and row['date1'] > row['date2']:
+                survivor, absorbed = id1, id2
+            elif row['date2'] and row['date1'] and row['date2'] > row['date1']:
+                survivor, absorbed = id2, id1
+            else:
+                survivor, absorbed = (id1, id2) if id1 < id2 else (id2, id1)
+
+            if not dry_run:
+                cur.execute("SELECT merge_facts(%s, %s)", (survivor, absorbed))
+
+            absorbed_ids.add(absorbed)
+            high_merges += 1
+
+            if verbose:
+                logger.info(f"  [high, sim={sim:.2f}] {row['key']}: auto-merged ID {absorbed} into ID {survivor}")
+
+        elif sim >= 0.50:
+            medium_candidates.append({
+                'id1': id1, 'id2': id2,
+                'entity_id': row['entity_id'], 'key': row['key'],
+                'value1': row['value1'], 'value2': row['value2'],
+                'similarity': sim
+            })
+            if verbose:
+                logger.info(f"  [medium, sim={sim:.2f}] {row['key']}: '{row['value1']}' vs '{row['value2']}' — flagged for review")
+
+    if verbose:
+        logger.info(f"Found {high_merges} high-confidence merges, {len(medium_candidates)} medium-confidence candidates")
+
+    if medium_candidates:
+        write_dedup_report(medium_candidates, dry_run)
+
+    return {'high_merges': high_merges, 'medium_count': len(medium_candidates), 'medium_candidates': medium_candidates}
+
+
+def write_dedup_report(candidates, dry_run=False):
+    """Write medium-confidence dedup candidates to daily report file."""
+    if not candidates:
+        return
+    logs_dir = Path.home() / '.openclaw' / 'logs'
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    today = datetime.now().strftime('%Y-%m-%d')
+    report_path = logs_dir / f'dedup-report-{today}.md'
+    mode_str = " (DRY RUN)" if dry_run else ""
+    with open(report_path, 'w') as f:
+        f.write(f"# Duplicate Detection Report — {today}{mode_str}\n\n")
+        f.write("Medium-confidence candidates (0.50–0.79 similarity) for manual review:\n\n")
+        for c in candidates:
+            f.write(f"- fact {c['id1']} vs {c['id2']} (entity {c['entity_id']}, key={c['key']}): "
+                    f"'{c['value1']}' vs '{c['value2']}' (sim={c['similarity']:.3f})\n")
+    logger.info(f"Wrote dedup report with {len(candidates)} candidates to {report_path}")
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Confidence decay (original production logic preserved)
+# ---------------------------------------------------------------------------
+import math
+
+
+def calculate_decay(durability, days_since_confirmed, custom_rate=None):
+    """Calculate confidence decay factor based on durability and time."""
+    if days_since_confirmed <= 0:
+        return 1.0
+    rate = custom_rate if custom_rate is not None else DECAY_RATES.get(durability, 0.01)
+    return math.exp(-rate * days_since_confirmed)
+
+
+def apply_decay_to_entity_facts(conn, dry_run=False, verbose=False):
+    """Apply confidence decay to entity_facts table."""
     cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
     cur.execute("""
-        SELECT key, value, entity_id, COUNT(*) AS cnt, MAX(confidence) AS max_conf, MIN(id) AS survivor_id
+        SELECT id, entity_id, key, durability, confidence,
+               last_confirmed_at, decay_rate, expires
         FROM entity_facts
-        GROUP BY key, value, entity_id
-        HAVING COUNT(*) > 1
-    """)
-    groups = cur.fetchall()
-    total_merged = 0
-    for g in groups:
-        key, value, entity_id = g["key"], g["value"], g["entity_id"]
-        survivor_id = g["survivor_id"]
-        cur.execute(
-            "SELECT id FROM entity_facts WHERE key = %s AND value = %s AND entity_id = %s AND id != %s",
-            (key, value, entity_id, survivor_id),
-        )
-        for dup in cur.fetchall():
-            if not dry_run:
-                cur.execute("SELECT merge_facts(%s, %s)", (survivor_id, dup[0]))
-            total_merged += 1
-            if verbose:
-                logger.info(f"  [same-key] merged duplicate fact {dup[0]} into {survivor_id}")
-    return total_merged
+        WHERE durability != 'permanent'
+          AND confidence > %s
+    """, (ARCHIVE_THRESHOLD,))
+    rows = cur.fetchall()
+    updates = []
+    for row in rows:
+        if row['last_confirmed_at'] is None:
+            continue
+        days_since = (datetime.now(timezone.utc) - row['last_confirmed_at']).days
+        if days_since <= 0:
+            continue
+        if row['expires'] is not None and row['expires'] < datetime.now(timezone.utc):
+            decay_factor = 0.0
+        else:
+            decay_factor = calculate_decay(row['durability'], days_since, row['decay_rate'])
+        new_confidence = row['confidence'] * decay_factor
+        if abs(new_confidence - row['confidence']) > 0.001:
+            updates.append({'id': row['id'], 'new_confidence': new_confidence})
+    if verbose:
+        logger.info(f"Entity facts to decay: {len(updates)}")
+    if not dry_run and updates:
+        psycopg2.extras.execute_batch(cur, """
+            UPDATE entity_facts SET confidence = %(new_confidence)s, updated_at = NOW() WHERE id = %(id)s
+        """, updates, page_size=100)
+    return len(updates)
 
 
-# ---------------------------------------------------------------------------
-# Phase 5: Confidence decay
-# ---------------------------------------------------------------------------
+def apply_decay_to_table(conn, table_name, decay_rate, dry_run=False, verbose=False):
+    """Apply confidence decay to a specific table."""
+    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    cur.execute(f"""
+        SELECT id, confidence, last_confirmed_at FROM {table_name} WHERE confidence > %s
+    """, (ARCHIVE_THRESHOLD,))
+    rows = cur.fetchall()
+    updates = []
+    for row in rows:
+        if row['last_confirmed_at'] is None:
+            continue
+        days_since = (datetime.now(timezone.utc) - row['last_confirmed_at']).days
+        if days_since <= 0:
+            continue
+        decay_factor = math.exp(-decay_rate * days_since)
+        new_confidence = row['confidence'] * decay_factor
+        if abs(new_confidence - row['confidence']) > 0.001:
+            updates.append({'id': row['id'], 'new_confidence': new_confidence})
+    if verbose and updates:
+        logger.info(f"{table_name} to decay: {len(updates)}")
+    if not dry_run and updates:
+        psycopg2.extras.execute_batch(cur, f"""
+            UPDATE {table_name} SET confidence = %(new_confidence)s, updated_at = NOW() WHERE id = %(id)s
+        """, updates, page_size=100)
+    return len(updates)
+
+
 def apply_decay(conn, args):
-    cur = conn.cursor()
-    for cutoff_days, decay_factor in [(30, 0.95), (60, 0.90), (90, 0.80)]:
-        cur.execute("""
-            UPDATE entity_facts
-            SET confidence = confidence * %s
-            WHERE created_at < NOW() - INTERVAL '%s days'
-              AND confidence > %s
-        """, (decay_factor, cutoff_days, decay_factor))
-        if args.verbose:
-            logger.info(f"  Applied {decay_factor}x decay to facts older than {cutoff_days} days")
+    """Run confidence decay across all tables."""
+    decayed_facts = apply_decay_to_entity_facts(conn, args.dry_run, args.verbose)
+    decayed_events = apply_decay_to_table(conn, 'events', TABLE_DECAY_RATES['events'], args.dry_run, args.verbose)
+    decayed_lessons = apply_decay_to_table(conn, 'lessons', TABLE_DECAY_RATES['lessons'], args.dry_run, args.verbose)
+    decayed_embeddings = apply_decay_to_table(conn, 'memory_embeddings', TABLE_DECAY_RATES['memory_embeddings'], args.dry_run, args.verbose)
+    return decayed_facts, decayed_events, decayed_lessons, decayed_embeddings
 
 
 def archive_low_confidence(conn, dry_run=False, verbose=False):
+    """Move low-confidence entity_facts to archive table."""
     cur = conn.cursor()
-    cur.execute("""
-        INSERT INTO entity_facts_archive (original_id, key, value, confidence, entity_id, created_at, archived_at)
-        SELECT id, key, value, confidence, entity_id, created_at, NOW()
-        FROM entity_facts
-        WHERE confidence < 0.5
-          AND created_at < NOW() - INTERVAL '7 days'
-    """)
-    archived = cur.rowcount
-    if archived and not dry_run:
+    if dry_run:
         cur.execute("""
+            SELECT COUNT(*) FROM entity_facts
+            WHERE confidence < %s
+              AND learned_at < NOW() - INTERVAL '%s days'
+              AND durability != 'permanent'
+        """, (ARCHIVE_THRESHOLD, MIN_AGE_DAYS))
+        return cur.fetchone()[0]
+    cur.execute("""
+        WITH archived AS (
             DELETE FROM entity_facts
-            WHERE confidence < 0.5
-              AND created_at < NOW() - INTERVAL '7 days'
-        """)
+            WHERE confidence < %s
+              AND learned_at < NOW() - INTERVAL '%s days'
+              AND durability != 'permanent'
+            RETURNING *
+        )
+        INSERT INTO entity_facts_archive
+        SELECT *, NOW() as archived_at FROM archived
+    """, (ARCHIVE_THRESHOLD, MIN_AGE_DAYS))
+    archived = cur.rowcount
     if verbose:
         logger.info(f"  Archived {archived} low-confidence facts")
     return archived
 
 
 def purge_old_archives(conn, dry_run=False, verbose=False):
+    """Hard delete archives older than 1 year."""
     cur = conn.cursor()
-    cur.execute("""
-        DELETE FROM entity_facts_archive
-        WHERE archived_at < NOW() - INTERVAL '90 days'
-    """)
+    if dry_run:
+        cur.execute("SELECT COUNT(*) FROM entity_facts_archive WHERE archived_at < NOW() - INTERVAL '1 year'")
+        return cur.fetchone()[0]
+    cur.execute("DELETE FROM entity_facts_archive WHERE archived_at < NOW() - INTERVAL '1 year'")
     purged = cur.rowcount
     if verbose:
         logger.info(f"  Purged {purged} old archived facts")
@@ -719,8 +884,11 @@ def main():
             cross_merged = cross_key_consolidation(conn, args.dry_run, args.verbose)
 
         dup_merged = 0
+        medium_report_count = 0
         if not args.skip_dedup:
-            dup_merged = merge_duplicates(conn, args.dry_run, args.verbose)
+            dedup_result = merge_duplicates(conn, args.dry_run, args.verbose)
+            dup_merged = dedup_result['high_merges']
+            medium_report_count = dedup_result['medium_count']
 
         if not args.skip_decay:
             apply_decay(conn, args)
@@ -756,6 +924,7 @@ def main():
         logger.info(f"  Embedded:               {embed_count}")
         logger.info(f"  Cross-key merged:       {cross_merged}")
         logger.info(f"  Same-key merged:        {dup_merged}")
+        logger.info(f"  Dedup review queued:    {medium_report_count}")
         logger.info(f"  Ghost pattern merges:   {pattern_merges}")
         logger.info(f"  Orphan entities deleted:{deleted_orphans}")
         logger.info(f"  Low-fact entities:      {low_fact_count}")

--- a/memory/scripts/memory-maintenance.py
+++ b/memory/scripts/memory-maintenance.py
@@ -597,6 +597,14 @@ def apply_decay_to_entity_facts(conn, dry_run=False, verbose=False):
 def apply_decay_to_table(conn, table_name, decay_rate, dry_run=False, verbose=False):
     """Apply confidence decay to a specific table."""
     cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    # Check if table has updated_at column
+    cur.execute("""
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = %s AND column_name = 'updated_at'
+    """, (table_name,))
+    has_updated_at = cur.fetchone() is not None
+
     cur.execute(f"""
         SELECT id, confidence, last_confirmed_at FROM {table_name} WHERE confidence > %s
     """, (ARCHIVE_THRESHOLD,))
@@ -615,9 +623,14 @@ def apply_decay_to_table(conn, table_name, decay_rate, dry_run=False, verbose=Fa
     if verbose and updates:
         logger.info(f"{table_name} to decay: {len(updates)}")
     if not dry_run and updates:
-        psycopg2.extras.execute_batch(cur, f"""
-            UPDATE {table_name} SET confidence = %(new_confidence)s, updated_at = NOW() WHERE id = %(id)s
-        """, updates, page_size=100)
+        if has_updated_at:
+            psycopg2.extras.execute_batch(cur, f"""
+                UPDATE {table_name} SET confidence = %(new_confidence)s, updated_at = NOW() WHERE id = %(id)s
+            """, updates, page_size=100)
+        else:
+            psycopg2.extras.execute_batch(cur, f"""
+                UPDATE {table_name} SET confidence = %(new_confidence)s WHERE id = %(id)s
+            """, updates, page_size=100)
     return len(updates)
 
 

--- a/memory/scripts/memory-maintenance.py
+++ b/memory/scripts/memory-maintenance.py
@@ -1,591 +1,778 @@
 #!/usr/bin/env python3
 """
-Memory confidence decay and soft-deletion script.
-Task: #53 - Memory Confidence & Expiration System
+Unified memory maintenance script.
+Replaces: embed-full-database.py, embed-memories.py, embed-research.py,
+          and previous memory-maintenance.py.
 
-Run daily via cron: 0 4 * * * ~/.openclaw/scripts/memory-decay.py
-
-Usage:
-    memory-decay.py [--dry-run] [--verbose] [--skip-dedup]
-
-Options:
-    --dry-run     Show what would be done without modifying the database
-    --verbose     Print detailed information
-    --skip-dedup  Skip the duplicate merge phase
+Phases:
+  1. Cooldown check
+  2. Embed (database rows, research, memory files)
+  3. Cross-key consolidation
+  4. Same-key deduplication
+  5. Confidence decay
+  6. Ghost entity cleanup
+  7. Entity-level deduplication
+  8. Clean orphaned embeddings
+  9. Archive & purge low-confidence facts
 """
 
-# Load OpenClaw environment (API keys from openclaw.json)
-import sys, os
-sys.path.insert(0, os.path.expanduser('~/.openclaw/lib'))
-try:
-    from env_loader import load_openclaw_env
-    load_openclaw_env()
-except ImportError:
-    pass  # Library not installed yet
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
 
 import psycopg2
 import psycopg2.extras
-from datetime import datetime, timedelta, timezone
-import math
-import logging
-import sys
-import os
-from pathlib import Path
+import requests
 
-# Load centralized PostgreSQL configuration
-sys.path.insert(0, os.path.expanduser("~/.openclaw/lib"))
-from pg_env import load_pg_env
-load_pg_env()
+# ---------------------------------------------------------------------------
+# Library loading pattern (backward compatible)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
 
-# Configuration
-ARCHIVE_THRESHOLD = 0.1  # Archive when confidence drops below this
-MIN_AGE_DAYS = 7         # Don't archive anything less than 7 days old
+try:
+    import pg_env
+except ImportError:
+    pg_env = None  # type: ignore
 
-# Decay rates (per day) — keyed by durability, not old data_type
-DECAY_RATES = {
-    'permanent': 0,           # Never decays
-    'long_term': 0.005,       # ~0.5% per day, 16% after 1 year
-    'short_term': 0.02,       # ~2% per day, moderate decay
-    'ephemeral': 0.1,         # ~10% per day, near zero after 3 weeks
-}
+try:
+    import env_loader
+except ImportError:
+    env_loader = None  # type: ignore
 
-# Table-specific decay rates
-TABLE_DECAY_RATES = {
-    'events': 0.001,          # Very slow - historical records
-    'lessons': 0.001,         # Very slow - learnings persist
-    'memory_embeddings': 0.01 # Medium - can get stale
-}
-
-# Setup logging
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s [%(levelname)s] %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
+    format="[%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("memory-maintenance")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+DEFAULT_STATE_FILE = os.path.expanduser("~/.openclaw/state/memory-maintenance-last-run.json")
+COOLDOWN_HOURS = 4
+EMBED_BATCH_SIZE = 64
 
 
-def calculate_decay(durability: str, days_since_confirmed: int, custom_rate: float = None) -> float:
-    """Calculate confidence decay factor based on durability and time.
-    
-    Args:
-        durability: Durability level (permanent, long_term, short_term, ephemeral)
-        days_since_confirmed: Number of days since last confirmation
-        custom_rate: Optional custom decay rate (overrides durability default)
-        
-    Returns:
-        Decay factor (multiplier for current confidence, 0-1)
-    """
-    if days_since_confirmed <= 0:
-        return 1.0
-    
-    rate = custom_rate if custom_rate is not None else DECAY_RATES.get(durability, 0.01)
-    
-    # Exponential decay: confidence_new = confidence_old * e^(-rate * days)
-    decay_factor = math.exp(-rate * days_since_confirmed)
-    
-    return decay_factor
+def load_embedding_config():
+    cfg_path = SCRIPT_DIR / "embedding-config.json"
+    if not cfg_path.exists():
+        return {
+            "provider": "ollama",
+            "model": "mxbai-embed-large",
+            "base_url": "http://localhost:11434",
+            "dimensions": 1024,
+        }
+    with open(cfg_path) as f:
+        return json.load(f)
 
 
-def merge_duplicates(conn, dry_run=False, verbose=False):
-    """Find and merge/categorize duplicate entity_facts using three-tier confidence system.
-    
-    Uses pg_trgm similarity() for text comparison. Three tiers:
-    - High (similarity >= 0.80): auto-merge via merge_facts(survivor_id, absorbed_id)
-        survivor = higher confidence fact; extraction_counts are summed by merge_facts
-    - Medium (0.50-0.79 similarity): add to daily report for manual review
-    - Low (< 0.50): skip entirely
-    """
-    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
-    
-    # Find all candidate pairs with similarity >= 0.50
-    cur.execute("""
-        SELECT 
-            f1.id as id1, f2.id as id2,
-            f1.entity_id, f1.key,
-            f1.value as value1, f2.value as value2,
-            f1.confidence as conf1, f2.confidence as conf2,
-            f1.last_confirmed_at as date1, f2.last_confirmed_at as date2,
-            similarity(LOWER(f1.value), LOWER(f2.value)) as sim
-        FROM entity_facts f1
-        JOIN entity_facts f2 ON 
-            f1.entity_id = f2.entity_id 
-            AND f1.key = f2.key 
-            AND f1.id < f2.id
-        WHERE similarity(LOWER(f1.value), LOWER(f2.value)) >= 0.50
-        ORDER BY sim DESC, f1.id, f2.id
-    """)
-    
-    pairs = cur.fetchall()
-    
-    absorbed_ids = set()
-    high_merges = 0
-    medium_candidates = []
-    
-    for row in pairs:
-        id1, id2 = row['id1'], row['id2']
-        
-        # Skip if either fact was already absorbed in a previous high-confidence merge
-        if id1 in absorbed_ids or id2 in absorbed_ids:
+# ---------------------------------------------------------------------------
+# Phase 1: Cooldown
+# ---------------------------------------------------------------------------
+def check_cooldown(state_file, force=False):
+    if force:
+        return True
+    try:
+        with open(state_file) as f:
+            state = json.load(f)
+        last_run = datetime.fromisoformat(state["last_run"])
+        if datetime.now(timezone.utc) - last_run < timedelta(hours=COOLDOWN_HOURS):
+            logger.info(f"Cooldown active — last run {last_run.isoformat()}, skipping")
+            return False
+    except (FileNotFoundError, KeyError, json.JSONDecodeError):
+        pass
+    return True
+
+
+def update_state(state_file):
+    os.makedirs(os.path.dirname(state_file), exist_ok=True)
+    with open(state_file, "w") as f:
+        json.dump({"last_run": datetime.now(timezone.utc).isoformat()}, f)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Embed
+# ---------------------------------------------------------------------------
+def _already_embedded(cur, source_type, source_id):
+    cur.execute(
+        "SELECT 1 FROM memory_embeddings WHERE source_type = %s AND source_id = %s LIMIT 1",
+        (source_type, str(source_id)),
+    )
+    return cur.fetchone() is not None
+
+
+def embed_batch(texts, cfg):
+    if not texts:
+        return []
+    url = f"{cfg['base_url'].rstrip('/')}/api/embed"
+    payload = {"model": cfg["model"], "input": texts}
+    try:
+        resp = requests.post(url, json=payload, timeout=300)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("embeddings", [])
+    except Exception as e:
+        logger.error(f"Batch embed failed: {e}")
+        return []
+
+
+def embed_single(text, cfg):
+    url = f"{cfg['base_url'].rstrip('/')}/api/embeddings"
+    payload = {"model": cfg["model"], "prompt": text}
+    try:
+        resp = requests.post(url, json=payload, timeout=120)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("embedding", [])
+    except Exception as e:
+        logger.error(f"Single embed failed: {e}")
+        return []
+
+
+def embed_texts(texts, cfg):
+    if not texts:
+        return []
+    result = embed_batch(texts, cfg)
+    if result and len(result) == len(texts):
+        return result
+    logger.warning("Batch embed incomplete, falling back to single embeds")
+    return [embed_single(t, cfg) for t in texts]
+
+
+def _store_embeddings(cur, source_type, items, embeddings):
+    for item, emb in zip(items, embeddings):
+        if not emb:
             continue
-        
-        sim = row['sim']
-        
-        if sim >= 0.80:
-            # High confidence: auto-merge
-            if row['conf1'] > row['conf2']:
-                survivor, absorbed = id1, id2
-            elif row['conf2'] > row['conf1']:
-                survivor, absorbed = id2, id1
-            elif row['date1'] > row['date2']:
-                survivor, absorbed = id1, id2
-            elif row['date2'] > row['date1']:
-                survivor, absorbed = id2, id1
-            else:
-                # Perfect tie — use lower ID as survivor for determinism
-                survivor, absorbed = (id1, id2) if id1 < id2 else (id2, id1)
-            
-            if not dry_run:
-                cur.execute("SELECT merge_facts(%s, %s)", (survivor, absorbed))
-            
-            absorbed_ids.add(absorbed)
-            high_merges += 1
-            
-            if verbose:
-                logger.info(f"  [high, sim={sim:.2f}] {row['key']}: auto-merged ID {absorbed} into ID {survivor}")
-        
-        elif sim >= 0.50:
-            # Medium confidence: flag for manual review
-            medium_candidates.append({
-                'id1': id1,
-                'id2': id2,
-                'entity_id': row['entity_id'],
-                'key': row['key'],
-                'value1': row['value1'],
-                'value2': row['value2'],
-                'similarity': sim
-            })
-            
-            if verbose:
-                logger.info(f"  [medium, sim={sim:.2f}] {row['key']}: '{row['value1']}' vs '{row['value2']}' — flagged for review")
-    
-    if verbose:
-        logger.info(f"Found {high_merges} high-confidence merges, {len(medium_candidates)} medium-confidence candidates")
-    
-    return {
-        'high_merges': high_merges,
-        'medium_count': len(medium_candidates),
-        'medium_candidates': medium_candidates
-    }
-
-
-def write_dedup_report(candidates, dry_run=False):
-    """Write medium-confidence dedup candidates to daily report file."""
-    if not candidates:
-        return
-    
-    logs_dir = Path.home() / '.openclaw' / 'logs'
-    logs_dir.mkdir(parents=True, exist_ok=True)
-    
-    today = datetime.now().strftime('%Y-%m-%d')
-    report_path = logs_dir / f'dedup-report-{today}.md'
-    
-    mode_str = " (DRY RUN)" if dry_run else ""
-    
-    with open(report_path, 'w') as f:
-        f.write(f"# Duplicate Detection Report — {today}{mode_str}\n\n")
-        f.write("Medium-confidence candidates (0.50–0.79 similarity) for manual review:\n\n")
-        f.write("| fact_id_1 | fact_id_2 | entity_id | key | value_1 | value_2 | similarity_score | recommended_action |\n")
-        f.write("|-----------|-----------|-----------|-----|---------|---------|------------------|-------------------|\n")
-        for c in candidates:
-            f.write(f"| {c['id1']} | {c['id2']} | {c['entity_id']} | {c['key']} | {c['value1']} | {c['value2']} | {c['similarity']:.3f} | Manual review: potential duplicate |\n")
-        f.write("\n")
-    
-    logger.info(f"Wrote dedup report with {len(candidates)} medium-confidence candidates to {report_path}")
-
-
-def apply_decay_to_entity_facts(conn, dry_run=False, verbose=False):
-    """Apply confidence decay to entity_facts table."""
-    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
-    
-    # Get all non-permanent facts with confidence data
-    cur.execute("""
-        SELECT id, entity_id, key, durability, confidence, 
-               last_confirmed_at, decay_rate, expires
-        FROM entity_facts
-        WHERE durability != 'permanent'
-          AND confidence > %s
-    """, (ARCHIVE_THRESHOLD,))
-    
-    rows = cur.fetchall()
-    updates = []
-    
-    for row in rows:
-        days_since = (datetime.now(timezone.utc) - row['last_confirmed_at']).days
-        
-        if days_since <= 0:
-            continue
-        
-        # If fact has expired, apply aggressive immediate decay
-        if row['expires'] is not None and row['expires'] < datetime.now(timezone.utc):
-            decay_factor = 0.0  # immediate archive
-        else:
-            decay_factor = calculate_decay(row['durability'], days_since, row['decay_rate'])
-        
-        new_confidence = row['confidence'] * decay_factor
-        
-        # Only update if there's a meaningful change (>0.001)
-        if abs(new_confidence - row['confidence']) > 0.001:
-            updates.append({
-                'id': row['id'],
-                'entity_id': row['entity_id'],
-                'key': row['key'],
-                'old_confidence': row['confidence'],
-                'new_confidence': new_confidence,
-                'days_since': days_since,
-                'durability': row['durability']
-            })
-    
-    if verbose:
-        logger.info(f"Entity facts to decay: {len(updates)}")
-        if updates and len(updates) <= 10:
-            for u in updates:
-                logger.info(f"  [{u['durability']}] {u['key']}: {u['old_confidence']:.3f} → {u['new_confidence']:.3f} ({u['days_since']} days)")
-    
-    if not dry_run and updates:
-        # Batch update
-        psycopg2.extras.execute_batch(cur, """
-            UPDATE entity_facts 
-            SET confidence = %(new_confidence)s, updated_at = NOW()
-            WHERE id = %(id)s
-        """, updates, page_size=100)
-    
-    return len(updates)
-
-
-def apply_decay_to_table(conn, table_name: str, decay_rate: float, dry_run=False, verbose=False):
-    """Apply confidence decay to a specific table (events, lessons, memory_embeddings)."""
-    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
-    
-    cur.execute(f"""
-        SELECT id, confidence, last_confirmed_at
-        FROM {table_name}
-        WHERE confidence > %s
-    """, (ARCHIVE_THRESHOLD,))
-    
-    rows = cur.fetchall()
-    updates = []
-    
-    for row in rows:
-        days_since = (datetime.now(timezone.utc) - row['last_confirmed_at']).days
-        
-        if days_since <= 0:
-            continue
-            
-        decay_factor = math.exp(-decay_rate * days_since)
-        new_confidence = row['confidence'] * decay_factor
-        
-        if abs(new_confidence - row['confidence']) > 0.001:
-            updates.append({
-                'id': row['id'],
-                'old_confidence': row['confidence'],
-                'new_confidence': new_confidence,
-                'days_since': days_since
-            })
-    
-    if verbose and updates:
-        logger.info(f"{table_name} to decay: {len(updates)}")
-        if len(updates) <= 5:
-            for u in updates:
-                logger.info(f"  ID {u['id']}: {u['old_confidence']:.3f} → {u['new_confidence']:.3f}")
-    
-    if not dry_run and updates:
-        psycopg2.extras.execute_batch(cur, f"""
-            UPDATE {table_name}
-            SET confidence = %(new_confidence)s, updated_at = NOW()
-            WHERE id = %(id)s
-        """, updates, page_size=100)
-    
-    return len(updates)
-
-
-def archive_low_confidence(conn, dry_run=False, verbose=False):
-    """Move low-confidence entity_facts to archive table."""
-    cur = conn.cursor()
-    
-    if dry_run:
-        # Just count what would be archived
-        cur.execute("""
-            SELECT COUNT(*) FROM entity_facts
-            WHERE confidence < %s
-              AND learned_at < NOW() - INTERVAL '%s days'
-              AND durability != 'permanent'
-        """, (ARCHIVE_THRESHOLD, MIN_AGE_DAYS))
-        count = cur.fetchone()[0]
-        return count
-    
-    # Archive facts below threshold that are old enough
-    cur.execute("""
-        WITH archived AS (
-            DELETE FROM entity_facts
-            WHERE confidence < %s
-              AND learned_at < NOW() - INTERVAL '%s days'
-              AND durability != 'permanent'
-            RETURNING *
+        emb_json = json.dumps(emb)
+        cur.execute(
+            """
+            INSERT INTO memory_embeddings (source_type, source_id, text, embedding)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (source_type, source_id) DO UPDATE
+            SET text = EXCLUDED.text,
+                embedding = EXCLUDED.embedding,
+                created_at = NOW()
+            """,
+            (source_type, str(item["id"]), item["text"], emb_json),
         )
-        INSERT INTO entity_facts_archive 
-            (id, entity_id, key, value, confidence,
-             last_confirmed_at, extraction_count, decay_rate,
-             durability, category, expires,
-             learned_at, updated_at, archive_reason)
-        SELECT 
-            id, entity_id, key, value, confidence,
-            last_confirmed_at, extraction_count, decay_rate,
-            durability, category, expires,
-            learned_at, updated_at, 'low_confidence'
-        FROM archived
-        RETURNING id
-    """, (ARCHIVE_THRESHOLD, MIN_AGE_DAYS))
-    
-    archived_ids = cur.fetchall()
-    
-    if verbose and archived_ids:
-        logger.info(f"Archived {len(archived_ids)} low-confidence facts")
-    
-    return len(archived_ids)
 
 
-def detect_conflicts(conn, dry_run=False, verbose=False):
-    """Find and resolve conflicting facts for same entity+key with different values."""
-    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
-    
-    # Find duplicate entity+key combinations with different values
-    cur.execute("""
-        SELECT entity_id, key, array_agg(id) as ids, 
-               array_agg(value) as values, array_agg(confidence) as confidences
-        FROM entity_facts
-        GROUP BY entity_id, key
-        HAVING COUNT(*) > 1 AND COUNT(DISTINCT value) > 1
-    """)
-    
-    conflicts = cur.fetchall()
-    auto_archived = 0
-    pending_review = 0
-    
-    for row in conflicts:
-        entity_id = row['entity_id']
-        key = row['key']
-        ids = row['ids']
-        values = row['values']
-        confidences = row['confidences']
-        
-        max_conf = max(confidences)
-        min_conf = min(confidences)
-        
-        # If one is significantly higher confidence (>2x), archive the lower ones
-        if max_conf > min_conf * 2:
-            winner_idx = confidences.index(max_conf)
-            
-            for i, fact_id in enumerate(ids):
-                if i != winner_idx:
-                    if verbose:
-                        logger.info(f"Auto-archiving conflict: entity={entity_id}, key={key}, "
-                                  f"kept conf={confidences[winner_idx]:.2f}, archived conf={confidences[i]:.2f}")
-                    
-                    if not dry_run:
-                        # Archive the lower-confidence fact
-                        cur.execute("""
-                            WITH archived AS (
-                                DELETE FROM entity_facts
-                                WHERE id = %s
-                                RETURNING *
-                            )
-                            INSERT INTO entity_facts_archive 
-                                (id, entity_id, key, value, confidence,
-                                 last_confirmed_at, extraction_count, decay_rate,
-                                 durability, category, expires,
-                                 learned_at, updated_at, archive_reason)
-                            SELECT 
-                                id, entity_id, key, value, confidence,
-                                last_confirmed_at, extraction_count, decay_rate,
-                                durability, category, expires,
-                                learned_at, updated_at, 'conflict_resolution'
-                            FROM archived
-                        """, (fact_id,))
-                        
-                        # Log the conflict resolution
-                        cur.execute("""
-                            INSERT INTO entity_fact_conflicts 
-                                (entity_id, key, fact_id_a, fact_id_b, value_a, value_b,
-                                 confidence_a, confidence_b, resolution, resolved_at, resolved_by)
-                            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'auto_archived', NOW(), 'decay_script')
-                        """, (entity_id, key, ids[winner_idx], fact_id, 
-                             values[winner_idx], values[i], confidences[winner_idx], confidences[i]))
-                    
-                    auto_archived += 1
-        
-        # Similar confidence - flag for human review
-        else:
-            if verbose:
-                logger.info(f"Conflict needs review: entity={entity_id}, key={key}, "
-                          f"values={values}, confidences={[f'{c:.2f}' for c in confidences]}")
-            
-            if not dry_run:
-                # Log all pairs as pending conflicts
-                for i in range(len(ids)):
-                    for j in range(i + 1, len(ids)):
-                        cur.execute("""
-                            INSERT INTO entity_fact_conflicts 
-                                (entity_id, key, fact_id_a, fact_id_b, value_a, value_b,
-                                 confidence_a, confidence_b, resolution)
-                            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'pending')
-                            ON CONFLICT DO NOTHING
-                        """, (entity_id, key, ids[i], ids[j], values[i], values[j], 
-                             confidences[i], confidences[j]))
-            
-            pending_review += 1
-    
-    if verbose:
-        logger.info(f"Conflicts: {auto_archived} auto-archived, {pending_review} pending review")
-    
-    return auto_archived, pending_review
+# ---- Embed database tables ----
+TABLE_EMBED_SPECS = {
+    "entity_fact": (
+        """
+        SELECT ef.id, e.name || ' - ' || ef.key || ': ' || ef.value AS text
+        FROM entity_facts ef
+        JOIN entities e ON e.id = ef.entity_id
+        """,
+        "entity_fact",
+    ),
+    "entity": (
+        "SELECT id, name AS text FROM entities WHERE name IS NOT NULL",
+        "entity",
+    ),
+    "task": (
+        "SELECT id, title AS text FROM tasks WHERE title IS NOT NULL",
+        "task",
+    ),
+    "project": (
+        "SELECT id, name AS text FROM projects WHERE name IS NOT NULL",
+        "project",
+    ),
+    "agent": (
+        "SELECT id, name AS text FROM agents WHERE name IS NOT NULL",
+        "agent",
+    ),
+    "lesson": (
+        "SELECT id, content AS text FROM lessons WHERE content IS NOT NULL",
+        "lesson",
+    ),
+    "event": (
+        "SELECT id, description AS text FROM events WHERE description IS NOT NULL",
+        "event",
+    ),
+    "trading_signal": (
+        "SELECT id, COALESCE(signal_type, '') || ' ' || COALESCE(symbol, '') AS text FROM trading_signals",
+        "trading_signal",
+    ),
+    "position": (
+        "SELECT id, COALESCE(symbol, '') || ' @ ' || COALESCE(entry_price::text, '') AS text FROM positions",
+        "position",
+    ),
+    "media_consumed": (
+        "SELECT id, title AS text FROM media_consumed WHERE title IS NOT NULL",
+        "media_consumed",
+    ),
+    "vocabulary": (
+        "SELECT id, word AS text FROM vocabulary WHERE word IS NOT NULL",
+        "vocabulary",
+    ),
+    "library": (
+        "SELECT id, title AS text FROM library WHERE title IS NOT NULL",
+        "library",
+    ),
+}
 
 
-def purge_old_archives(conn, dry_run=False, verbose=False):
-    """Hard delete archived facts older than 1 year using cleanup functions."""
-    cur = conn.cursor()
-    
-    if dry_run:
-        # Count what would be purged
-        cur.execute("""
-            SELECT 
-                (SELECT COUNT(*) FROM entity_facts_archive WHERE archived_at < NOW() - INTERVAL '1 year') as facts,
-                (SELECT COUNT(*) FROM events_archive WHERE archived_at < NOW() - INTERVAL '1 year') as events,
-                (SELECT COUNT(*) FROM lessons_archive WHERE archived_at < NOW() - INTERVAL '1 year') as lessons,
-                (SELECT COUNT(*) FROM memory_embeddings_archive WHERE archived_at < NOW() - INTERVAL '1 year') as embeddings
-        """)
-        counts = cur.fetchone()
-        total = sum(counts)
-        if verbose and total > 0:
-            logger.info(f"Would purge: {counts[0]} facts, {counts[1]} events, {counts[2]} lessons, {counts[3]} embeddings")
-        return total
-    
-    # Call cleanup functions
-    cur.execute("SELECT cleanup_old_archives()")
-    facts_purged = cur.fetchone()[0]
-    
-    cur.execute("SELECT cleanup_old_events_archive()")
-    events_purged = cur.fetchone()[0]
-    
-    cur.execute("SELECT cleanup_old_lessons_archive()")
-    lessons_purged = cur.fetchone()[0]
-    
-    cur.execute("SELECT cleanup_old_embeddings_archive()")
-    embeddings_purged = cur.fetchone()[0]
-    
-    total = facts_purged + events_purged + lessons_purged + embeddings_purged
-    
-    if verbose and total > 0:
-        logger.info(f"Purged: {facts_purged} facts, {events_purged} events, {lessons_purged} lessons, {embeddings_purged} embeddings")
-    
+def _embed_table(cur, query, source_type, cfg):
+    cur.execute(query)
+    rows = cur.fetchall()
+    items = [{"id": r[0], "text": r[1]} for r in rows if r[1] and not _already_embedded(cur, source_type, r[0])]
+    if not items:
+        return 0
+    total = 0
+    for i in range(0, len(items), EMBED_BATCH_SIZE):
+        batch = items[i : i + EMBED_BATCH_SIZE]
+        texts = [it["text"] for it in batch]
+        embeddings = embed_texts(texts, cfg)
+        _store_embeddings(cur, source_type, batch, embeddings)
+        total += len(batch)
     return total
 
 
-def log_summary(duplicates_merged: int, decayed_facts: int, decayed_events: int, 
-                decayed_lessons: int, decayed_embeddings: int, archived: int, purged: int, 
-                conflicts_archived: int, conflicts_pending: int, medium_report_count: int = 0, dry_run=False):
-    """Log summary to daily memory file."""
-    
-    total_decayed = decayed_facts + decayed_events + decayed_lessons + decayed_embeddings
-    
-    mode = " (DRY RUN)" if dry_run else ""
-    logger.info(f"Memory decay complete{mode}: {duplicates_merged} duplicates merged, {total_decayed} decayed, {archived} archived, {purged} purged, "
-               f"{conflicts_archived} conflicts resolved, {conflicts_pending} pending review")
-    if medium_report_count > 0:
-        logger.info(f"Medium-confidence dedup candidates: {medium_report_count} (see dedup report)")
-    
-    # Write to daily memory file
-    memory_dir = Path.home() / '.openclaw' / 'workspace' / 'memory'
-    memory_dir.mkdir(parents=True, exist_ok=True)
-    
-    daily_file = memory_dir / f'{datetime.now():%Y-%m-%d}.md'
-    
-    with open(daily_file, 'a') as f:
-        f.write(f"\n### Memory Decay Script ({datetime.now():%H:%M UTC}){mode}\n")
-        if duplicates_merged > 0:
-            f.write(f"- Duplicates merged: {duplicates_merged}\n")
-        if medium_report_count > 0:
-            f.write(f"- Medium-confidence dedup candidates: {medium_report_count} (see dedup report)\n")
-        f.write(f"- Decayed: {total_decayed} total ({decayed_facts} facts, {decayed_events} events, {decayed_lessons} lessons, {decayed_embeddings} embeddings)\n")
-        f.write(f"- Archived: {archived} facts (confidence < {ARCHIVE_THRESHOLD})\n")
-        if purged > 0:
-            f.write(f"- Purged: {purged} archived records (older than 1 year)\n")
-        if conflicts_archived > 0 or conflicts_pending > 0:
-            f.write(f"- Conflicts: {conflicts_archived} auto-resolved, {conflicts_pending} pending human review\n")
+def phase_embed_database(conn, cfg, dry_run=False, verbose=False):
+    cur = conn.cursor()
+    total = 0
+    for name, (query, source_type) in TABLE_EMBED_SPECS.items():
+        count = _embed_table(cur, query, source_type, cfg)
+        if count:
+            total += count
+            if verbose:
+                logger.info(f"  Embedded {count} {name} records")
+    return total
+
+
+# ---- Embed research tables ----
+def phase_embed_research(conn, cfg, dry_run=False, verbose=False):
+    cur = conn.cursor()
+    total = 0
+
+    # research_task
+    cur.execute("SELECT id, query AS text FROM research_tasks WHERE query IS NOT NULL")
+    rows = cur.fetchall()
+    items = [{"id": r[0], "text": r[1]} for r in rows if not _already_embedded(cur, "research_task", r[0])]
+    if items:
+        for i in range(0, len(items), EMBED_BATCH_SIZE):
+            batch = items[i : i + EMBED_BATCH_SIZE]
+            embeddings = embed_texts([it["text"] for it in batch], cfg)
+            _store_embeddings(cur, "research_task", batch, embeddings)
+            total += len(batch)
+
+    # research_finding (is_current=true)
+    cur.execute("SELECT id, content AS text FROM research_findings WHERE is_current = true AND content IS NOT NULL")
+    rows = cur.fetchall()
+    items = [{"id": r[0], "text": r[1]} for r in rows if not _already_embedded(cur, "research_finding", r[0])]
+    if items:
+        for i in range(0, len(items), EMBED_BATCH_SIZE):
+            batch = items[i : i + EMBED_BATCH_SIZE]
+            embeddings = embed_texts([it["text"] for it in batch], cfg)
+            _store_embeddings(cur, "research_finding", batch, embeddings)
+            total += len(batch)
+
+    # research_conclusion (is_current=true)
+    cur.execute("SELECT id, content AS text FROM research_conclusions WHERE is_current = true AND content IS NOT NULL")
+    rows = cur.fetchall()
+    items = [{"id": r[0], "text": r[1]} for r in rows if not _already_embedded(cur, "research_conclusion", r[0])]
+    if items:
+        for i in range(0, len(items), EMBED_BATCH_SIZE):
+            batch = items[i : i + EMBED_BATCH_SIZE]
+            embeddings = embed_texts([it["text"] for it in batch], cfg)
+            _store_embeddings(cur, "research_conclusion", batch, embeddings)
+            total += len(batch)
+
+    if verbose and total:
+        logger.info(f"  Embedded {total} research records")
+    return total
+
+
+# ---- Embed memory files ----
+def _chunk_text(text, chunk_size=1000, overlap=200):
+    chunks = []
+    start = 0
+    while start < len(text):
+        end = min(start + chunk_size, len(text))
+        chunks.append(text[start:end])
+        start += chunk_size - overlap
+        if start >= len(text):
+            break
+    return chunks
+
+
+def phase_embed_files(conn, cfg, dry_run=False, verbose=False):
+    cur = conn.cursor()
+    total = 0
+
+    memory_dir = Path.home() / ".openclaw" / "workspace" / "memory"
+    if memory_dir.exists():
+        for md_file in sorted(memory_dir.glob("*.md")):
+            text = md_file.read_text(encoding="utf-8")
+            chunks = _chunk_text(text)
+            for idx, chunk in enumerate(chunks):
+                source_id = f"{md_file.name}#{idx}"
+                if _already_embedded(cur, "memory_file", source_id):
+                    continue
+                emb = embed_single(chunk, cfg)
+                if emb:
+                    _store_embeddings(cur, "memory_file", [{"id": source_id, "text": chunk}], [emb])
+                    total += 1
+
+    memory_md = Path.home() / ".openclaw" / "workspace" / "MEMORY.md"
+    if memory_md.exists():
+        text = memory_md.read_text(encoding="utf-8")
+        chunks = _chunk_text(text)
+        for idx, chunk in enumerate(chunks):
+            source_id = f"MEMORY.md#{idx}"
+            if _already_embedded(cur, "memory_file", source_id):
+                continue
+            emb = embed_single(chunk, cfg)
+            if emb:
+                _store_embeddings(cur, "memory_file", [{"id": source_id, "text": chunk}], [emb])
+                total += 1
+
+    if verbose and total:
+        logger.info(f"  Embedded {total} memory file chunks")
+    return total
+
+
+def phase_embed(conn, args):
+    cfg = load_embedding_config()
+    total = 0
+    total += phase_embed_database(conn, cfg, args.dry_run, args.verbose)
+    total += phase_embed_research(conn, cfg, args.dry_run, args.verbose)
+    total += phase_embed_files(conn, cfg, args.dry_run, args.verbose)
+    if args.verbose:
+        logger.info(f"Embed phase complete: {total} items embedded")
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Cross-key consolidation
+# ---------------------------------------------------------------------------
+def cross_key_consolidation(conn, dry_run=False, verbose=False):
+    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    cur.execute("""
+        SELECT DISTINCT ef.entity_id
+        FROM entity_facts ef
+        JOIN memory_embeddings me ON me.source_type = 'entity_fact' AND me.source_id = ef.id::text
+    """)
+    entity_ids = [row[0] for row in cur.fetchall()]
+
+    total_merged = 0
+    for entity_id in entity_ids:
+        cur.execute("""
+            SELECT ef1.id AS id1, ef2.id AS id2,
+                   ef1.key AS key1, ef2.key AS key2,
+                   ef1.value AS val1, ef2.value AS val2,
+                   ef1.confidence AS conf1, ef2.confidence AS conf2,
+                   1 - (me1.embedding <=> me2.embedding) AS cosine_sim
+            FROM entity_facts ef1
+            JOIN entity_facts ef2 ON ef1.entity_id = ef2.entity_id AND ef1.id < ef2.id
+            JOIN memory_embeddings me1 ON me1.source_type = 'entity_fact' AND me1.source_id = ef1.id::text
+            JOIN memory_embeddings me2 ON me2.source_type = 'entity_fact' AND me2.source_id = ef2.id::text
+            WHERE ef1.entity_id = %s
+              AND ef1.key != ef2.key
+              AND 1 - (me1.embedding <=> me2.embedding) >= 0.92
+            ORDER BY cosine_sim DESC
+        """, (entity_id,))
+
+        pairs = cur.fetchall()
+        absorbed_ids = set()
+
+        for row in pairs:
+            id1, id2 = row["id1"], row["id2"]
+            if id1 in absorbed_ids or id2 in absorbed_ids:
+                continue
+            if row["conf1"] >= row["conf2"]:
+                survivor, absorbed = id1, id2
+            else:
+                survivor, absorbed = id2, id1
+
+            if not dry_run:
+                cur.execute("SELECT merge_facts(%s, %s)", (survivor, absorbed))
+            absorbed_ids.add(absorbed)
+            total_merged += 1
+            if verbose:
+                logger.info(
+                    f"  [cross-key, sim={row['cosine_sim']:.3f}] "
+                    f"merged {row['key2']}:{row['val2']} into {row['key1']}:{row['val1']}"
+                )
+
+    return total_merged
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Same-key deduplication
+# ---------------------------------------------------------------------------
+def merge_duplicates(conn, dry_run=False, verbose=False):
+    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    cur.execute("""
+        SELECT key, value, entity_id, COUNT(*) AS cnt, MAX(confidence) AS max_conf, MIN(id) AS survivor_id
+        FROM entity_facts
+        GROUP BY key, value, entity_id
+        HAVING COUNT(*) > 1
+    """)
+    groups = cur.fetchall()
+    total_merged = 0
+    for g in groups:
+        key, value, entity_id = g["key"], g["value"], g["entity_id"]
+        survivor_id = g["survivor_id"]
+        cur.execute(
+            "SELECT id FROM entity_facts WHERE key = %s AND value = %s AND entity_id = %s AND id != %s",
+            (key, value, entity_id, survivor_id),
+        )
+        for dup in cur.fetchall():
+            if not dry_run:
+                cur.execute("SELECT merge_facts(%s, %s)", (survivor_id, dup[0]))
+            total_merged += 1
+            if verbose:
+                logger.info(f"  [same-key] merged duplicate fact {dup[0]} into {survivor_id}")
+    return total_merged
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Confidence decay
+# ---------------------------------------------------------------------------
+def apply_decay(conn, args):
+    cur = conn.cursor()
+    for cutoff_days, decay_factor in [(30, 0.95), (60, 0.90), (90, 0.80)]:
+        cur.execute("""
+            UPDATE entity_facts
+            SET confidence = confidence * %s
+            WHERE created_at < NOW() - INTERVAL '%s days'
+              AND confidence > %s
+        """, (decay_factor, cutoff_days, decay_factor))
+        if args.verbose:
+            logger.info(f"  Applied {decay_factor}x decay to facts older than {cutoff_days} days")
+
+
+def archive_low_confidence(conn, dry_run=False, verbose=False):
+    cur = conn.cursor()
+    cur.execute("""
+        INSERT INTO entity_facts_archive (original_id, key, value, confidence, entity_id, created_at, archived_at)
+        SELECT id, key, value, confidence, entity_id, created_at, NOW()
+        FROM entity_facts
+        WHERE confidence < 0.5
+          AND created_at < NOW() - INTERVAL '7 days'
+    """)
+    archived = cur.rowcount
+    if archived and not dry_run:
+        cur.execute("""
+            DELETE FROM entity_facts
+            WHERE confidence < 0.5
+              AND created_at < NOW() - INTERVAL '7 days'
+        """)
+    if verbose:
+        logger.info(f"  Archived {archived} low-confidence facts")
+    return archived
+
+
+def purge_old_archives(conn, dry_run=False, verbose=False):
+    cur = conn.cursor()
+    cur.execute("""
+        DELETE FROM entity_facts_archive
+        WHERE archived_at < NOW() - INTERVAL '90 days'
+    """)
+    purged = cur.rowcount
+    if verbose:
+        logger.info(f"  Purged {purged} old archived facts")
+    return purged
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: Ghost entity cleanup
+# ---------------------------------------------------------------------------
+def ghost_entity_cleanup(conn, dry_run=False, verbose=False):
+    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    # Sub-phase A: Pattern-based ghosts (e.g. "entity 21" -> entity id 21)
+    cur.execute("SELECT id, name FROM entities WHERE name ~* '^entity \\d+$'")
+    pattern_merges = 0
+    for row in cur.fetchall():
+        target_id = int(re.search(r"\d+", row["name"]).group())
+        cur.execute("SELECT id FROM entities WHERE id = %s AND id != %s", (target_id, row["id"]))
+        if cur.fetchone():
+            if not dry_run:
+                cur.execute("SELECT merge_entities(%s, %s)", (target_id, row["id"]))
+            pattern_merges += 1
+            if verbose:
+                logger.info(f"  Ghost merge: '{row['name']}' (id={row['id']}) -> entity {target_id}")
+
+    # Sub-phase B: Zero-fact + zero-FK orphans
+    cur.execute("""
+        SELECT tc.table_name, kcu.column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+        JOIN information_schema.constraint_column_usage ccu ON ccu.constraint_name = tc.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND ccu.table_name = 'entities' AND ccu.column_name = 'id'
+          AND tc.table_name != 'entity_facts'
+    """)
+    fk_tables = cur.fetchall()
+
+    cur.execute("""
+        SELECT e.id, e.name FROM entities e
+        LEFT JOIN entity_facts ef ON e.id = ef.entity_id
+        GROUP BY e.id HAVING COUNT(ef.id) = 0
+    """)
+    zero_fact_entities = cur.fetchall()
+
+    deleted = 0
+    for entity in zero_fact_entities:
+        has_fk = False
+        for table_name, col_name in fk_tables:
+            cur.execute(
+                f"SELECT 1 FROM {table_name} WHERE {col_name} = %s LIMIT 1",
+                (entity["id"],),
+            )
+            if cur.fetchone():
+                has_fk = True
+                break
+        if not has_fk:
+            if not dry_run:
+                cur.execute("DELETE FROM entities WHERE id = %s", (entity["id"],))
+            deleted += 1
+            if verbose:
+                logger.info(f"  Deleted orphan: '{entity['name']}' (id={entity['id']})")
+
+    # Sub-phase C: Low-fact entities (1-2 facts) -> review queue
+    cur.execute("""
+        SELECT e.id, e.name, COUNT(ef.id) AS fact_count
+        FROM entities e JOIN entity_facts ef ON e.id = ef.entity_id
+        GROUP BY e.id HAVING COUNT(ef.id) <= 2
+    """)
+    low_fact = cur.fetchall()
+    if low_fact:
+        review_path = Path.home() / ".openclaw" / "logs" / f"ghost-review-{datetime.now():%Y-%m-%d}.md"
+        review_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(review_path, "w") as f:
+            f.write(f"# Low-Fact Entity Review — {datetime.now():%Y-%m-%d}\n\n")
+            for e in low_fact:
+                f.write(f"- Entity {e['id']}: {e['name']} ({e['fact_count']} facts)\n")
+        if verbose:
+            logger.info(f"  Wrote {len(low_fact)} low-fact entities to {review_path}")
+
+    return pattern_merges, deleted, len(low_fact)
+
+
+# ---------------------------------------------------------------------------
+# Phase 7: Entity-level deduplication
+# ---------------------------------------------------------------------------
+def entity_dedup(conn, dry_run=False, verbose=False):
+    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    cur.execute("""
+        SELECT e1.id AS id1, e2.id AS id2, e1.name AS name1, e2.name AS name2,
+               similarity(LOWER(e1.name), LOWER(e2.name)) AS name_sim
+        FROM entities e1
+        JOIN entities e2 ON e1.id < e2.id
+        WHERE similarity(LOWER(e1.name), LOWER(e2.name)) >= 0.5
+    """)
+    candidates = cur.fetchall()
+
+    auto_merged = 0
+    review_candidates = []
+    absorbed_ids = set()
+
+    for cand in candidates:
+        if cand["id1"] in absorbed_ids or cand["id2"] in absorbed_ids:
+            continue
+
+        cur.execute("SELECT COUNT(*) FROM entity_facts WHERE entity_id = %s", (cand["id1"],))
+        count1 = cur.fetchone()[0]
+        cur.execute("SELECT COUNT(*) FROM entity_facts WHERE entity_id = %s", (cand["id2"],))
+        count2 = cur.fetchone()[0]
+
+        if count1 + count2 == 0:
+            continue
+
+        cur.execute("""
+            SELECT COUNT(*) FROM entity_facts f1
+            JOIN entity_facts f2 ON f1.key = f2.key
+              AND similarity(LOWER(f1.value), LOWER(f2.value)) >= 0.7
+            WHERE f1.entity_id = %s AND f2.entity_id = %s
+        """, (cand["id1"], cand["id2"]))
+        shared = cur.fetchone()[0]
+
+        total = max(count1, count2)
+        overlap = shared / total if total > 0 else 0
+        overall = 0.4 * cand["name_sim"] + 0.6 * overlap
+
+        if overall >= 0.80:
+            survivor = cand["id1"] if count1 >= count2 else cand["id2"]
+            absorbed = cand["id2"] if survivor == cand["id1"] else cand["id1"]
+            if not dry_run:
+                cur.execute("SELECT merge_entities(%s, %s)", (survivor, absorbed))
+            absorbed_ids.add(absorbed)
+            auto_merged += 1
+            if verbose:
+                logger.info(
+                    f"  Entity auto-merge: '{cand['name2']}' into '{cand['name1']}' (score={overall:.2f})"
+                )
+        elif overall >= 0.50:
+            review_candidates.append({
+                "id1": cand["id1"], "name1": cand["name1"],
+                "id2": cand["id2"], "name2": cand["name2"],
+                "score": overall, "name_sim": cand["name_sim"],
+                "fact_overlap": overlap,
+            })
+
+    if review_candidates:
+        review_path = Path.home() / ".openclaw" / "logs" / f"entity-dedup-review-{datetime.now():%Y-%m-%d}.md"
+        review_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(review_path, "w") as f:
+            f.write(f"# Entity Dedup Review — {datetime.now():%Y-%m-%d}\n\n")
+            for c in review_candidates:
+                f.write(
+                    f"- {c['name1']} (id={c['id1']}) vs {c['name2']} (id={c['id2']}) "
+                    f"— score={c['score']:.2f}\n"
+                )
+        if verbose:
+            logger.info(f"  Wrote {len(review_candidates)} review candidates to {review_path}")
+
+    return auto_merged, len(review_candidates)
+
+
+# ---------------------------------------------------------------------------
+# Phase 8: Clean orphaned embeddings
+# ---------------------------------------------------------------------------
+def clean_orphaned_embeddings(conn, dry_run=False, verbose=False):
+    cur = conn.cursor()
+    if dry_run:
+        cur.execute("""
+            SELECT COUNT(*) FROM memory_embeddings me
+            WHERE me.source_type = 'entity_fact'
+              AND NOT EXISTS (SELECT 1 FROM entity_facts ef WHERE ef.id::text = me.source_id)
+        """)
+        count = cur.fetchone()[0]
+    else:
+        cur.execute("""
+            DELETE FROM memory_embeddings me
+            WHERE me.source_type = 'entity_fact'
+              AND NOT EXISTS (SELECT 1 FROM entity_facts ef WHERE ef.id::text = me.source_id)
+        """)
+        count = cur.rowcount
+
+    # Also clean orphaned entity embeddings
+    if dry_run:
+        cur.execute("""
+            SELECT COUNT(*) FROM memory_embeddings me
+            WHERE me.source_type = 'entity'
+              AND NOT EXISTS (SELECT 1 FROM entities e WHERE e.id::text = me.source_id)
+        """)
+        count += cur.fetchone()[0]
+    else:
+        cur.execute("""
+            DELETE FROM memory_embeddings me
+            WHERE me.source_type = 'entity'
+              AND NOT EXISTS (SELECT 1 FROM entities e WHERE e.id::text = me.source_id)
+        """)
+        count += cur.rowcount
+
+    if verbose:
+        logger.info(f"  Cleaned {count} orphaned embeddings")
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def parse_args():
+    parser = argparse.ArgumentParser(description="Unified memory maintenance")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without modifying")
+    parser.add_argument("--verbose", action="store_true", help="Log detailed per-item actions")
+    parser.add_argument("--force", action="store_true", help="Ignore cooldown")
+    parser.add_argument("--state-file", default=DEFAULT_STATE_FILE, help="Path to cooldown state file")
+    parser.add_argument("--skip-embed", action="store_true", help="Skip embedding phase")
+    parser.add_argument("--skip-consolidation", action="store_true", help="Skip cross-key consolidation")
+    parser.add_argument("--skip-dedup", action="store_true", help="Skip same-key deduplication")
+    parser.add_argument("--skip-decay", action="store_true", help="Skip confidence decay")
+    parser.add_argument("--skip-ghost-cleanup", action="store_true", help="Skip ghost entity cleanup")
+    parser.add_argument("--skip-entity-dedup", action="store_true", help="Skip entity deduplication")
+    return parser.parse_args()
 
 
 def main():
-    """Main entry point."""
-    dry_run = '--dry-run' in sys.argv
-    verbose = '--verbose' in sys.argv or dry_run
-    skip_dedup = '--skip-dedup' in sys.argv
-    
-    if dry_run:
-        logger.info("Running in DRY RUN mode - no changes will be made")
-    
+    args = parse_args()
+
+    if not check_cooldown(args.state_file, args.force):
+        return 0
+
+    conn = psycopg2.connect("")
+    conn.autocommit = False
+
     try:
-        conn = psycopg2.connect()
-        
-        # 1. Merge duplicates (unless skipped)
-        if skip_dedup:
-            logger.info("Skipping duplicate merge (--skip-dedup)")
-            duplicates_merged = 0
-            medium_report_count = 0
-        else:
-            logger.info("Merging duplicates...")
-            dedup_result = merge_duplicates(conn, dry_run, verbose)
-            duplicates_merged = dedup_result['high_merges']
-            medium_report_count = dedup_result['medium_count']
-            if medium_report_count > 0:
-                write_dedup_report(dedup_result['medium_candidates'], dry_run)
-            if dry_run and duplicates_merged > 0:
-                logger.info(f"{duplicates_merged} duplicates would be merged")
-        
-        # 2. Apply decay to all tables
-        logger.info("Applying confidence decay...")
-        decayed_facts = apply_decay_to_entity_facts(conn, dry_run, verbose)
-        decayed_events = apply_decay_to_table(conn, 'events', TABLE_DECAY_RATES['events'], dry_run, verbose)
-        decayed_lessons = apply_decay_to_table(conn, 'lessons', TABLE_DECAY_RATES['lessons'], dry_run, verbose)
-        decayed_embeddings = apply_decay_to_table(conn, 'memory_embeddings', TABLE_DECAY_RATES['memory_embeddings'], dry_run, verbose)
-        
-        # 3. Detect and resolve conflicts
-        logger.info("Detecting conflicts...")
-        conflicts_archived, conflicts_pending = detect_conflicts(conn, dry_run, verbose)
-        
-        # 4. Archive low-confidence facts (soft delete)
-        logger.info("Archiving low-confidence facts...")
-        archived = archive_low_confidence(conn, dry_run, verbose)
-        
-        # 5. Hard delete archives older than 1 year
-        logger.info("Purging old archives...")
-        purged = purge_old_archives(conn, dry_run, verbose)
-        
-        # 6. Log summary
-        log_summary(duplicates_merged, decayed_facts, decayed_events, decayed_lessons, decayed_embeddings, 
-                   archived, purged, conflicts_archived, conflicts_pending, medium_report_count, dry_run)
-        
-        if not dry_run:
+        embed_count = 0
+        if not args.skip_embed:
+            embed_count = phase_embed(conn, args)
+
+        cross_merged = 0
+        if not args.skip_consolidation:
+            cross_merged = cross_key_consolidation(conn, args.dry_run, args.verbose)
+
+        dup_merged = 0
+        if not args.skip_dedup:
+            dup_merged = merge_duplicates(conn, args.dry_run, args.verbose)
+
+        if not args.skip_decay:
+            apply_decay(conn, args)
+
+        pattern_merges = deleted_orphans = low_fact_count = 0
+        if not args.skip_ghost_cleanup:
+            pattern_merges, deleted_orphans, low_fact_count = ghost_entity_cleanup(
+                conn, args.dry_run, args.verbose
+            )
+
+        auto_merged = review_count = 0
+        if not args.skip_entity_dedup:
+            auto_merged, review_count = entity_dedup(conn, args.dry_run, args.verbose)
+
+        cleaned = 0
+        if not args.skip_embed:
+            cleaned = clean_orphaned_embeddings(conn, args.dry_run, args.verbose)
+
+        archived = archive_low_confidence(conn, args.dry_run, args.verbose)
+        purged = purge_old_archives(conn, args.dry_run, args.verbose)
+
+        if not args.dry_run:
             conn.commit()
-            logger.info("Changes committed to database")
+            update_state(args.state_file)
+            logger.info("Committed all changes.")
         else:
-            logger.info("Dry run complete - no changes made")
-        
-        conn.close()
-        
+            logger.info("DRY RUN — no changes committed.")
+            conn.rollback()
+
+        logger.info("=" * 50)
+        logger.info("Memory Maintenance Summary")
+        logger.info("=" * 50)
+        logger.info(f"  Embedded:               {embed_count}")
+        logger.info(f"  Cross-key merged:       {cross_merged}")
+        logger.info(f"  Same-key merged:        {dup_merged}")
+        logger.info(f"  Ghost pattern merges:   {pattern_merges}")
+        logger.info(f"  Orphan entities deleted:{deleted_orphans}")
+        logger.info(f"  Low-fact entities:      {low_fact_count}")
+        logger.info(f"  Entity auto-merges:     {auto_merged}")
+        logger.info(f"  Entity review queued:   {review_count}")
+        logger.info(f"  Orphaned embeddings:    {cleaned}")
+        logger.info(f"  Archived facts:         {archived}")
+        logger.info(f"  Purged old archives:    {purged}")
     except Exception as e:
-        logger.error(f"Error during memory decay: {e}", exc_info=True)
-        sys.exit(1)
+        conn.rollback()
+        logger.error(f"Transaction rolled back due to error: {e}")
+        raise
+    finally:
+        conn.close()
+
+    return 0
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    sys.exit(main())

--- a/memory/scripts/memory-maintenance.py
+++ b/memory/scripts/memory-maintenance.py
@@ -176,7 +176,7 @@ def _store_embeddings(cur, source_type, items, embeddings):
             ON CONFLICT (source_type, source_id) DO UPDATE
             SET content = EXCLUDED.content,
                 embedding = EXCLUDED.embedding,
-                created_at = NOW()
+                updated_at = NOW()
             """,
             (source_type, str(item["id"]), item["text"], emb_json),
         )
@@ -375,30 +375,42 @@ def phase_embed(conn, args):
 # ---------------------------------------------------------------------------
 def cross_key_consolidation(conn, dry_run=False, verbose=False):
     cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
-    cur.execute("""
-        SELECT DISTINCT ef.entity_id
-        FROM entity_facts ef
-        JOIN memory_embeddings me ON me.source_type = 'entity_fact' AND me.source_id = ef.id::text
-    """)
+
+    try:
+        cur.execute("""
+            SELECT DISTINCT ef.entity_id
+            FROM entity_facts ef
+            JOIN memory_embeddings me ON me.source_type = 'entity_fact' AND me.source_id = ef.id::text
+        """)
+    except psycopg2.Error as e:
+        logger.error(f"Cross-key consolidation dimension mismatch or query error: {e}")
+        return 0, set()
+
     entity_ids = [row[0] for row in cur.fetchall()]
 
     total_merged = 0
+    modified_survivor_ids = set()
+
     for entity_id in entity_ids:
-        cur.execute("""
-            SELECT ef1.id AS id1, ef2.id AS id2,
-                   ef1.key AS key1, ef2.key AS key2,
-                   ef1.value AS val1, ef2.value AS val2,
-                   ef1.confidence AS conf1, ef2.confidence AS conf2,
-                   1 - (me1.embedding <=> me2.embedding) AS cosine_sim
-            FROM entity_facts ef1
-            JOIN entity_facts ef2 ON ef1.entity_id = ef2.entity_id AND ef1.id < ef2.id
-            JOIN memory_embeddings me1 ON me1.source_type = 'entity_fact' AND me1.source_id = ef1.id::text
-            JOIN memory_embeddings me2 ON me2.source_type = 'entity_fact' AND me2.source_id = ef2.id::text
-            WHERE ef1.entity_id = %s
-              AND ef1.key != ef2.key
-              AND 1 - (me1.embedding <=> me2.embedding) >= 0.92
-            ORDER BY cosine_sim DESC
-        """, (entity_id,))
+        try:
+            cur.execute("""
+                SELECT ef1.id AS id1, ef2.id AS id2,
+                       ef1.key AS key1, ef2.key AS key2,
+                       ef1.value AS val1, ef2.value AS val2,
+                       ef1.confidence AS conf1, ef2.confidence AS conf2,
+                       1 - (me1.embedding <=> me2.embedding) AS cosine_sim
+                FROM entity_facts ef1
+                JOIN entity_facts ef2 ON ef1.entity_id = ef2.entity_id AND ef1.id < ef2.id
+                JOIN memory_embeddings me1 ON me1.source_type = 'entity_fact' AND me1.source_id = ef1.id::text
+                JOIN memory_embeddings me2 ON me2.source_type = 'entity_fact' AND me2.source_id = ef2.id::text
+                WHERE ef1.entity_id = %s
+                  AND ef1.key != ef2.key
+                  AND 1 - (me1.embedding <=> me2.embedding) >= 0.92
+                ORDER BY cosine_sim DESC
+            """, (entity_id,))
+        except psycopg2.Error as e:
+            logger.error(f"Dimension mismatch in cross-key query for entity {entity_id}: {e}")
+            continue
 
         pairs = cur.fetchall()
         absorbed_ids = set()
@@ -415,6 +427,7 @@ def cross_key_consolidation(conn, dry_run=False, verbose=False):
             if not dry_run:
                 cur.execute("SELECT merge_facts(%s, %s)", (survivor, absorbed))
             absorbed_ids.add(absorbed)
+            modified_survivor_ids.add(survivor)
             total_merged += 1
             if verbose:
                 logger.info(
@@ -422,7 +435,7 @@ def cross_key_consolidation(conn, dry_run=False, verbose=False):
                     f"merged {row['key2']}:{row['val2']} into {row['key1']}:{row['val1']}"
                 )
 
-    return total_merged
+    return total_merged, modified_survivor_ids
 
 
 # ---------------------------------------------------------------------------
@@ -459,6 +472,7 @@ def merge_duplicates(conn, dry_run=False, verbose=False):
     pairs = cur.fetchall()
 
     absorbed_ids = set()
+    modified_survivor_ids = set()
     high_merges = 0
     medium_candidates = []
 
@@ -486,6 +500,7 @@ def merge_duplicates(conn, dry_run=False, verbose=False):
                 cur.execute("SELECT merge_facts(%s, %s)", (survivor, absorbed))
 
             absorbed_ids.add(absorbed)
+            modified_survivor_ids.add(survivor)
             high_merges += 1
 
             if verbose:
@@ -507,7 +522,7 @@ def merge_duplicates(conn, dry_run=False, verbose=False):
     if medium_candidates:
         write_dedup_report(medium_candidates, dry_run)
 
-    return {'high_merges': high_merges, 'medium_count': len(medium_candidates), 'medium_candidates': medium_candidates}
+    return {'high_merges': high_merges, 'medium_count': len(medium_candidates), 'medium_candidates': medium_candidates, 'modified_ids': modified_survivor_ids}
 
 
 def write_dedup_report(candidates, dry_run=False):
@@ -629,10 +644,24 @@ def archive_low_confidence(conn, dry_run=False, verbose=False):
             WHERE confidence < %s
               AND learned_at < NOW() - INTERVAL '%s days'
               AND durability != 'permanent'
-            RETURNING *
+            RETURNING id, entity_id, key, value, data, confidence, learned_at,
+                      updated_at, visibility, privacy_scope, visibility_reason,
+                      last_confirmed_at, decay_rate, extraction_count,
+                      durability, category, expires
         )
-        INSERT INTO entity_facts_archive
-        SELECT *, NOW() as archived_at FROM archived
+        INSERT INTO entity_facts_archive (
+            id, entity_id, key, value, data, confidence, learned_at,
+            updated_at, visibility, privacy_scope, visibility_reason,
+            last_confirmed_at, decay_rate, extraction_count,
+            durability, category, expires, archived_at, archive_reason, archived_by
+        )
+        SELECT
+            id, entity_id, key, value, data, confidence, learned_at,
+            updated_at, visibility, privacy_scope, visibility_reason,
+            last_confirmed_at, decay_rate, extraction_count,
+            durability, category, expires,
+            NOW() as archived_at, 'low_confidence' as archive_reason, 'maintenance_script' as archived_by
+        FROM archived
     """, (ARCHIVE_THRESHOLD, MIN_AGE_DAYS))
     archived = cur.rowcount
     if verbose:
@@ -736,9 +765,10 @@ def entity_dedup(conn, dry_run=False, verbose=False):
     cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
     cur.execute("""
         SELECT e1.id AS id1, e2.id AS id2, e1.name AS name1, e2.name AS name2,
+               e1.type AS type1, e2.type AS type2,
                similarity(LOWER(e1.name), LOWER(e2.name)) AS name_sim
         FROM entities e1
-        JOIN entities e2 ON e1.id < e2.id
+        JOIN entities e2 ON e1.id < e2.id AND e1.type = e2.type
         WHERE similarity(LOWER(e1.name), LOWER(e2.name)) >= 0.5
     """)
     candidates = cur.fetchall()
@@ -749,6 +779,10 @@ def entity_dedup(conn, dry_run=False, verbose=False):
 
     for cand in candidates:
         if cand["id1"] in absorbed_ids or cand["id2"] in absorbed_ids:
+            continue
+
+        # Skip candidates of different types (defensive — SQL already filters)
+        if cand.get("type1") != cand.get("type2"):
             continue
 
         cur.execute("SELECT COUNT(*) FROM entity_facts WHERE entity_id = %s", (cand["id1"],))
@@ -848,6 +882,48 @@ def clean_orphaned_embeddings(conn, dry_run=False, verbose=False):
 
 
 # ---------------------------------------------------------------------------
+# Re-embed modified facts
+# ---------------------------------------------------------------------------
+def reembed_modified_facts(conn, modified_fact_ids, dry_run=False, verbose=False):
+    """Delete stale embeddings for modified facts and re-embed them."""
+    if not modified_fact_ids:
+        return 0
+    cfg = load_embedding_config()
+    cur = conn.cursor()
+    id_list = [str(fid) for fid in modified_fact_ids]
+    # Delete stale embeddings
+    if not dry_run:
+        cur.execute("""
+            DELETE FROM memory_embeddings
+            WHERE source_type = 'entity_fact'
+              AND source_id = ANY(%s)
+        """, (id_list,))
+        if verbose:
+            logger.info(f"  Deleted {cur.rowcount} stale embeddings for modified facts")
+    # Re-embed
+    cur.execute("""
+        SELECT ef.id, e.name || ' - ' || ef.key || ': ' || ef.value AS text
+        FROM entity_facts ef JOIN entities e ON e.id = ef.entity_id
+        WHERE ef.id = ANY(%s)
+    """, (list(modified_fact_ids),))
+    rows = cur.fetchall()
+    items = [{"id": r[0], "text": r[1]} for r in rows if r[1]]
+    if not items:
+        return 0
+    total = 0
+    for i in range(0, len(items), EMBED_BATCH_SIZE):
+        batch = items[i:i+EMBED_BATCH_SIZE]
+        texts = [it["text"] for it in batch]
+        embeddings = embed_texts(texts, cfg)
+        if not dry_run:
+            _store_embeddings(cur, "entity_fact", batch, embeddings)
+        total += len(batch)
+    if verbose:
+        logger.info(f"  Re-embedded {total} modified facts")
+    return total
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 def parse_args():
@@ -880,8 +956,10 @@ def main():
             embed_count = phase_embed(conn, args)
 
         cross_merged = 0
+        modified_fact_ids = set()
         if not args.skip_consolidation:
-            cross_merged = cross_key_consolidation(conn, args.dry_run, args.verbose)
+            cross_merged, xkey_modified = cross_key_consolidation(conn, args.dry_run, args.verbose)
+            modified_fact_ids.update(xkey_modified)
 
         dup_merged = 0
         medium_report_count = 0
@@ -889,6 +967,7 @@ def main():
             dedup_result = merge_duplicates(conn, args.dry_run, args.verbose)
             dup_merged = dedup_result['high_merges']
             medium_report_count = dedup_result['medium_count']
+            modified_fact_ids.update(dedup_result.get('modified_ids', set()))
 
         if not args.skip_decay:
             apply_decay(conn, args)
@@ -902,6 +981,10 @@ def main():
         auto_merged = review_count = 0
         if not args.skip_entity_dedup:
             auto_merged, review_count = entity_dedup(conn, args.dry_run, args.verbose)
+
+        reembedded = 0
+        if not args.skip_embed and modified_fact_ids:
+            reembedded = reembed_modified_facts(conn, modified_fact_ids, args.dry_run, args.verbose)
 
         cleaned = 0
         if not args.skip_embed:
@@ -930,6 +1013,7 @@ def main():
         logger.info(f"  Low-fact entities:      {low_fact_count}")
         logger.info(f"  Entity auto-merges:     {auto_merged}")
         logger.info(f"  Entity review queued:   {review_count}")
+        logger.info(f"  Re-embedded modified:   {reembedded}")
         logger.info(f"  Orphaned embeddings:    {cleaned}")
         logger.info(f"  Archived facts:         {archived}")
         logger.info(f"  Purged old archives:    {purged}")

--- a/memory/scripts/memory-maintenance.py
+++ b/memory/scripts/memory-maintenance.py
@@ -33,17 +33,20 @@ import requests
 # Library loading pattern (backward compatible)
 # ---------------------------------------------------------------------------
 SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, os.path.expanduser("~/.openclaw/lib"))
 sys.path.insert(0, str(SCRIPT_DIR))
 
 try:
-    import pg_env
+    from env_loader import load_openclaw_env
+    load_openclaw_env()
 except ImportError:
-    pg_env = None  # type: ignore
+    pass
 
 try:
-    import env_loader
+    from pg_env import load_pg_env
+    load_pg_env()
 except ImportError:
-    env_loader = None  # type: ignore
+    pass
 
 # ---------------------------------------------------------------------------
 # Logging

--- a/tests/test-cases-entity-facts-quality.md
+++ b/tests/test-cases-entity-facts-quality.md
@@ -1,0 +1,1655 @@
+# Test Cases: Entity Facts Quality — Batch `entity-facts-quality`
+
+**Issues:** #216 (Unified nightly memory maintenance), #202 (FK reference rewiring during merges), #200 (Ghost entity cleanup), #203 (Entity-level deduplication)  
+**Branch:** `feature/entity-facts-quality` (or per-issue branches)  
+**Deliverable:** Rewritten `memory-maintenance.py` with embedding absorption, cross-key consolidation, `merge_entities()` DB function, ghost entity cleanup, and entity-level deduplication  
+**Author:** Gem (QA Lead)  
+**Date:** 2026-05-14
+
+---
+
+## Scope
+
+### What Is Being Tested
+1. `memory/scripts/memory-maintenance.py` — unified nightly maintenance script absorbing all three embed scripts
+2. `merge_entities(survivor_id, absorbed_id)` — new DB function (rewires all 21 FK references)
+3. `merge_facts(survivor_id, absorbed_id)` — existing DB function (already tested; tested here for integration correctness)
+4. Cross-key fact consolidation via pgvector cosine similarity (≥0.92 threshold)
+5. Ghost entity detection and cleanup (#200)
+6. Entity-level deduplication — auto-merge (≥80% overlap) and manual review queue (<80%) (#203)
+7. Cooldown gate (4-hour minimum between runs)
+8. State file tracking of last-run timestamp
+9. CLI flags: `--dry-run`, `--verbose`, `--skip-embed`, `--skip-consolidation`, `--skip-dedup`, `--skip-decay`, `--skip-ghost-cleanup`, `--force`
+
+### What Is NOT Tested Here
+- Same-key deduplication logic (existing, tested via prior test suites)
+- Confidence decay math (existing, tested via prior test suites)
+- Archiving / purging of old records (existing, tested via prior test suites)
+- Embedding model quality or semantic accuracy
+- Crontab removal (operational change, not a code test)
+- Heartbeat idle cascade trigger mechanism (separate subsystem test)
+
+---
+
+## Entry Criteria
+- `memory-maintenance.py` exists at `memory/scripts/memory-maintenance.py` with all new phases
+- `merge_entities()` DB function exists in `nova_memory` database
+- pgvector extension loaded; `memory_embeddings` table has correct schema
+- Ollama running with `mxbai-embed-large` model available at configured `base_url`
+- Staging `nova_memory` database reachable (never run against production)
+- Python 3.10+, `psycopg2` installed
+- State file path writable by test runner
+- `embedding-config.json` present in script directory
+
+## Exit Criteria
+- All TC (happy-path) cases pass
+- All TC-ERR (error/edge) cases correctly handle/reject bad input without data corruption
+- All TC-DRY (dry-run) cases produce zero DB changes
+- Zero unhandled exceptions from any test case
+- `merge_entities()` function correctly rewires all 21 FK-referencing tables
+- Cross-key consolidation never merges facts with cosine similarity <0.92
+- Ghost entity cleanup never deletes an entity with active FK references outside entity_facts
+- Entity dedup auto-merge never fires below 80% overlap threshold
+- No S1/S2 defects open
+
+---
+
+## Test Data Setup
+
+All tests use a dedicated staging database. Run this setup SQL before the test suite:
+
+```sql
+-- Standard test entities
+INSERT INTO entities (id, name, type) VALUES
+  (9001, 'TestPerson Alpha', 'person'),
+  (9002, 'TestPerson Beta', 'person'),
+  (9003, 'entity 9003', 'person'),    -- ghost: name pattern matches id
+  (9004, 'Ghost With No Facts', 'person'),  -- ghost: 0 facts, 0 FKs
+  (9005, 'LowFact Entity', 'person'), -- low-fact: exactly 2 facts
+  (9006, 'TestOrg Gamma', 'organization'),
+  (9007, 'TestPerson Delta', 'person')
+ON CONFLICT DO NOTHING;
+
+-- Facts for entity 9001 (Alice-like)
+INSERT INTO entity_facts (id, entity_id, key, value, confidence, durability, extraction_count, learned_at, last_confirmed_at)
+VALUES
+  (90001, 9001, 'location', 'Austin, Texas', 0.90, 'long_term', 3, NOW()-INTERVAL '10 days', NOW()-INTERVAL '2 days'),
+  (90002, 9001, 'hometown', 'Austin TX', 0.85, 'long_term', 2, NOW()-INTERVAL '15 days', NOW()-INTERVAL '5 days'),
+  (90003, 9001, 'occupation', 'software engineer', 0.80, 'long_term', 1, NOW()-INTERVAL '5 days', NOW()-INTERVAL '1 day'),
+  (90004, 9001, 'job_title', 'software developer', 0.75, 'long_term', 1, NOW()-INTERVAL '5 days', NOW()-INTERVAL '1 day')
+ON CONFLICT DO NOTHING;
+
+-- Facts for entity 9002 (Bob-like) — near-duplicate of 9001
+INSERT INTO entity_facts (id, entity_id, key, value, confidence, durability, extraction_count, learned_at, last_confirmed_at)
+VALUES
+  (90010, 9002, 'location', 'Austin, Texas', 0.88, 'long_term', 2, NOW()-INTERVAL '8 days', NOW()-INTERVAL '3 days'),
+  (90011, 9002, 'occupation', 'software engineer', 0.82, 'long_term', 1, NOW()-INTERVAL '6 days', NOW()-INTERVAL '2 days')
+ON CONFLICT DO NOTHING;
+
+-- Facts for low-fact entity 9005
+INSERT INTO entity_facts (id, entity_id, key, value, confidence, durability, extraction_count, learned_at, last_confirmed_at)
+VALUES
+  (90020, 9005, 'name', 'something', 0.50, 'short_term', 1, NOW()-INTERVAL '3 days', NOW()-INTERVAL '3 days'),
+  (90021, 9005, 'type', 'unknown', 0.50, 'short_term', 1, NOW()-INTERVAL '3 days', NOW()-INTERVAL '3 days')
+ON CONFLICT DO NOTHING;
+
+-- Embeddings for cross-key consolidation testing (must be seeded by the embedding phase or manually)
+-- NOTE: After embed phase runs on staging, verify embeddings exist:
+-- SELECT source_type, source_id FROM memory_embeddings WHERE source_type = 'entity_fact' AND source_id IN ('90001','90002','90003','90004');
+
+-- FK references to test merge_entities rewiring
+-- At minimum: entity_fact_sources, entity_relationships, preferences, project_entities
+INSERT INTO entity_fact_sources (fact_id, source_entity_id, source_citation, attribution_count, first_seen, last_seen)
+VALUES (90001, 9001, 'test-citation-1', 1, NOW()-INTERVAL '10 days', NOW()-INTERVAL '2 days')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO entity_relationships (entity_a, entity_b, relationship_type) VALUES (9001, 9006, 'works_at')
+ON CONFLICT DO NOTHING;
+```
+
+---
+
+## Section 1 — Cooldown Gate (#216)
+
+### TC-COOL-001: Cooldown respected — exit when last run <4h ago
+
+**Preconditions:** State file exists with `last_run` timestamp set to `NOW() - 2 hours`.
+
+**Steps:**
+```bash
+# Write a recent state file
+echo "{\"last_run\": \"$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ)\"}" > /tmp/mm-test-state.json
+python3 memory/scripts/memory-maintenance.py --state-file /tmp/mm-test-state.json
+```
+
+**Expected:**
+- Exit code 0 (graceful exit, not error)
+- Stdout/stderr contains message indicating cooldown active (e.g., "cooldown", "last run was", "skipping")
+- No DB modifications
+- State file `last_run` unchanged
+
+**Pass criteria:** Exit code 0 AND `last_run` in state file equals the pre-test value AND no entity_facts rows modified.
+
+---
+
+### TC-COOL-002: Cooldown bypassed with `--force`
+
+**Preconditions:** State file with `last_run` set to 2 hours ago (same as TC-COOL-001).
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --state-file /tmp/mm-test-state.json --force --dry-run
+```
+
+**Expected:**
+- Exit code 0
+- Script proceeds past cooldown check (phases execute or are reported as dry-run)
+- Log does not say "cooldown skipping"
+
+**Pass criteria:** Script reaches at least the embed phase (or first phase that has work to do); no early-exit message.
+
+---
+
+### TC-COOL-003: Cooldown not applied when state file is absent
+
+**Preconditions:** State file path does not exist.
+
+**Steps:**
+```bash
+rm -f /tmp/mm-test-state-new.json
+python3 memory/scripts/memory-maintenance.py --state-file /tmp/mm-test-state-new.json --dry-run
+```
+
+**Expected:**
+- Exit code 0
+- Script proceeds normally (no cooldown message)
+- State file created with `last_run` timestamp after run
+
+**Pass criteria:** State file `/tmp/mm-test-state-new.json` exists after run AND contains `last_run` field.
+
+---
+
+### TC-COOL-004: Cooldown not applied when last run >4h ago
+
+**Preconditions:** State file with `last_run` = `NOW() - 5 hours`.
+
+**Steps:**
+```bash
+echo "{\"last_run\": \"$(date -u -d '5 hours ago' +%Y-%m-%dT%H:%M:%SZ)\"}" > /tmp/mm-test-state-old.json
+python3 memory/scripts/memory-maintenance.py --state-file /tmp/mm-test-state-old.json --dry-run
+```
+
+**Expected:**
+- Exit code 0
+- Script proceeds (no cooldown message)
+
+**Pass criteria:** No "cooldown" message in output.
+
+---
+
+### TC-COOL-005: Cooldown boundary — exactly 4 hours (edge)
+
+**Preconditions:** State file with `last_run` = exactly `NOW() - 4 hours`.
+
+**Steps:**
+```bash
+echo "{\"last_run\": \"$(date -u -d '4 hours ago' +%Y-%m-%dT%H:%M:%SZ)\"}" > /tmp/mm-test-state-boundary.json
+python3 memory/scripts/memory-maintenance.py --state-file /tmp/mm-test-state-boundary.json --dry-run
+```
+
+**Expected:**
+- Script proceeds (4h is the boundary; exactly at boundary should be allowed)
+
+**Pass criteria:** No early cooldown exit.
+
+---
+
+### TC-COOL-006: State file updated after successful run
+
+**Preconditions:** State file with `last_run` = 8 hours ago. `--dry-run` NOT set (allow actual run in isolation test).
+
+**Steps:**
+```bash
+BEFORE=$(cat /tmp/mm-test-state.json)
+python3 memory/scripts/memory-maintenance.py --state-file /tmp/mm-test-state.json
+AFTER=$(cat /tmp/mm-test-state.json)
+```
+
+**Expected:**
+- `last_run` in state file is updated to approximately NOW() (within 60 seconds of test time)
+- `last_run` value is later than the pre-run value
+
+**Pass criteria:** `jq .last_run /tmp/mm-test-state.json` returns a timestamp within 60s of current time.
+
+---
+
+## Section 2 — Embedding Absorption (#216)
+
+### TC-EMBED-001: Script embeds entity_facts that lack embeddings
+
+**Preconditions:** Entity fact ID 90001 exists; no `memory_embeddings` row where `source_type='entity_fact' AND source_id='90001'`.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup --dry-run
+# Then without dry-run for actual embed:
+python3 memory/scripts/memory-maintenance.py --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:**
+- Exit code 0
+- `memory_embeddings` table gains rows for entity_fact source type
+- Each new row has `embedding` dimension = 1024
+
+**Pass criteria:**
+```sql
+SELECT COUNT(*) FROM memory_embeddings 
+WHERE source_type = 'entity_fact' AND source_id = '90001' 
+AND array_length(embedding::real[], 1) = 1024;
+```
+Returns ≥ 1.
+
+---
+
+### TC-EMBED-002: Already-embedded facts are not re-embedded (idempotent)
+
+**Preconditions:** entity_fact 90001 has an existing embedding in `memory_embeddings`.
+
+**Steps:**
+```bash
+BEFORE_COUNT=$(psql -U nova -d nova_memory -h localhost -t -c "SELECT COUNT(*) FROM memory_embeddings WHERE source_type='entity_fact' AND source_id='90001';")
+python3 memory/scripts/memory-maintenance.py --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup
+AFTER_COUNT=$(...)
+```
+
+**Expected:**
+- `AFTER_COUNT == BEFORE_COUNT` (no duplicate embeddings added)
+
+**Pass criteria:** Count unchanged before and after run.
+
+---
+
+### TC-EMBED-003: `--skip-embed` flag prevents embedding phase
+
+**Preconditions:** entity_fact 90003 has no embedding.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup --dry-run
+```
+
+**Expected:**
+- Exit code 0
+- No new embedding rows for entity_fact 90003
+- Log message indicates embed phase was skipped
+
+**Pass criteria:** No `memory_embeddings` row for source_id='90003' after run.
+
+---
+
+### TC-EMBED-004: Embed phase handles Ollama connection failure gracefully
+
+**Preconditions:** Ollama service stopped or pointing to unreachable URL.
+
+**Steps:** Set `embedding-config.json` `base_url` to `http://localhost:9999` (unreachable), then run.
+
+**Expected:**
+- Exit code non-zero OR graceful skip with error logged
+- No partial/corrupt embeddings written
+- No crash without error message
+
+**Pass criteria:** No unhandled exception traceback; error message references Ollama/connection; DB state unchanged.
+
+---
+
+### TC-EMBED-005: Re-embed modified facts after merges
+
+**Preconditions:** entity_fact 90001 has an embedding; merge operation updates 90001 (extraction_count increases); new embedding should be generated.
+
+**Steps:** After running merge phase (via consolidation or dedup), run the re-embed modified phase.
+
+**Expected:**
+- 90001's `memory_embeddings` row has an updated `updated_at` timestamp
+- Embedding vector may differ (content changed)
+
+**Pass criteria:** `updated_at` on the embedding row for 90001 is later than `updated_at` before the merge run.
+
+---
+
+### TC-EMBED-006: `--dry-run` produces no embedding writes
+
+**Preconditions:** entity_fact 90007 has no embedding.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --dry-run
+```
+
+**Expected:** Zero new rows in `memory_embeddings` for source_id='90007'.
+
+**Pass criteria:** `SELECT COUNT(*) FROM memory_embeddings WHERE source_type='entity_fact' AND source_id='90007'` = 0 after dry run.
+
+---
+
+## Section 3 — Cross-Key Fact Consolidation (#216)
+
+### TC-XKEY-001: Near-duplicate cross-key facts auto-merged at ≥0.92 similarity
+
+**Preconditions:**
+- entity_fact 90001 (`location = 'Austin, Texas'`) and 90002 (`hometown = 'Austin TX'`) both have embeddings.
+- Cosine similarity between their embeddings is ≥0.92 (confirm via `1 - (embedding1 <=> embedding2)` in SQL).
+- Both belong to entity 9001.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:**
+- One of {90001, 90002} is absorbed into the other via `merge_facts()`
+- Survivor has summed `extraction_count` (should be 3+2=5)
+- Absorbed fact ID no longer exists in `entity_facts`
+- Survivor's `confidence` = GREATEST(0.90, 0.85) = 0.90
+
+**Pass criteria:**
+```sql
+-- Exactly one of the two facts remains
+SELECT COUNT(*) FROM entity_facts WHERE id IN (90001, 90002);
+-- Returns 1
+
+-- Survivor has correct extraction_count
+SELECT extraction_count FROM entity_facts WHERE id IN (90001, 90002);
+-- Returns 5 (3+2)
+
+-- Survivor has correct confidence
+SELECT confidence FROM entity_facts WHERE id IN (90001, 90002);
+-- Returns 0.90
+```
+
+---
+
+### TC-XKEY-002: Facts with cosine similarity <0.92 are NOT merged
+
+**Preconditions:**
+- entity_fact 90003 (`occupation = 'software engineer'`) and 90001 (`location = 'Austin, Texas'`) are different enough that their cosine similarity is <0.92.
+- Both belong to entity 9001.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:** Both 90003 and 90001 still exist in `entity_facts` after run.
+
+**Pass criteria:**
+```sql
+SELECT COUNT(*) FROM entity_facts WHERE id IN (90001, 90003);
+-- Returns 2
+```
+
+---
+
+### TC-XKEY-003: Cross-key consolidation only merges within same entity_id
+
+**Preconditions:**
+- entity_fact 90001 (entity 9001, `location = 'Austin, Texas'`) and entity_fact 90010 (entity 9002, `location = 'Austin, Texas'`) may have cosine similarity ≥0.92.
+- They belong to different entities.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:** Both 90001 and 90010 still exist (different entity_ids must never be merged by cross-key consolidation).
+
+**Pass criteria:**
+```sql
+SELECT COUNT(*) FROM entity_facts WHERE id IN (90001, 90010);
+-- Returns 2
+```
+
+---
+
+### TC-XKEY-004: `--skip-consolidation` skips cross-key phase
+
+**Preconditions:** Facts 90001 and 90002 not yet merged (or freshly seeded).
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup --dry-run
+```
+
+**Expected:** Both 90001 and 90002 still exist; log indicates consolidation phase skipped.
+
+**Pass criteria:** Both fact IDs present; "skip" or "consolidation" in log output.
+
+---
+
+### TC-XKEY-005: Survivor selection — higher confidence wins
+
+**Preconditions:**
+- Fact A: `confidence=0.90`, `extraction_count=1`
+- Fact B: `confidence=0.70`, `extraction_count=5`
+- Cosine similarity ≥0.92.
+
+**Expected:** Fact A (higher confidence) is survivor. Survivor's `extraction_count` = 6.
+
+**Pass criteria:** Fact B ID gone; Fact A's `extraction_count = 6`.
+
+---
+
+### TC-XKEY-006: Survivor selection — tie-breaking by extraction_count
+
+**Preconditions:**
+- Fact A: `confidence=0.80`, `extraction_count=3`
+- Fact B: `confidence=0.80`, `extraction_count=7`
+- Cosine similarity ≥0.92.
+
+**Expected:** Fact B (higher extraction_count) is survivor, OR deterministic rule documented in spec.  
+**Note to implementer:** Confirm tie-breaking rule in spec; test must match implementation.
+
+---
+
+### TC-XKEY-007: `--dry-run` does not merge cross-key facts
+
+**Preconditions:** Facts 90001 and 90002 both exist with embeddings at ≥0.92 similarity.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-dedup --skip-decay --skip-ghost-cleanup --dry-run
+```
+
+**Expected:** Both 90001 and 90002 still exist after dry run.
+
+**Pass criteria:**
+```sql
+SELECT COUNT(*) FROM entity_facts WHERE id IN (90001, 90002);
+-- Returns 2
+```
+
+---
+
+## Section 4 — `merge_entities()` DB Function (#202, #203)
+
+### TC-MENT-001: merge_entities() rewires entity_facts to survivor
+
+**Preconditions:** Entities 9001 and 9002 exist with facts 90001-90004 (entity 9001) and 90010-90011 (entity 9002).
+
+**Steps:**
+```sql
+BEGIN;
+SELECT merge_entities(9001, 9002);
+```
+
+**Expected:**
+- All facts formerly belonging to 9002 (90010, 90011) now have `entity_id = 9001`
+- Entity 9002 deleted from `entities`
+- `entity_facts` count for 9001 = original_9001_count + original_9002_count
+
+**Pass criteria:**
+```sql
+SELECT COUNT(*) FROM entity_facts WHERE entity_id = 9001;
+-- Returns 6 (4 + 2)
+
+SELECT COUNT(*) FROM entity_facts WHERE entity_id = 9002;
+-- Returns 0
+
+SELECT COUNT(*) FROM entities WHERE id = 9002;
+-- Returns 0
+```
+
+---
+
+### TC-MENT-002: merge_entities() rewires all 21 FK-referencing tables
+
+**Preconditions:** Create FK references from entity 9002 in several tables, then call merge_entities(9001, 9002).
+
+**Setup:**
+```sql
+INSERT INTO entity_relationships (entity_a, entity_b, relationship_type) VALUES (9002, 9006, 'knows');
+INSERT INTO preferences (entity_id, key, value) VALUES (9002, 'test_pref', 'test_val');
+INSERT INTO entity_fact_sources (fact_id, source_entity_id, source_citation, attribution_count, first_seen, last_seen)
+  VALUES (90001, 9002, 'cross-source-test', 1, NOW(), NOW());
+```
+
+**Steps:**
+```sql
+SELECT merge_entities(9001, 9002);
+```
+
+**Expected (check all 21 tables):**
+- `entity_relationships` rows with `entity_a=9002` → `entity_a=9001` (or de-duplicated if 9001-9006 already exists)
+- `entity_relationships` rows with `entity_b=9002` → `entity_b=9001`
+- `preferences` rows with `entity_id=9002` → `entity_id=9001`
+- `entity_fact_sources` rows with `source_entity_id=9002` → `source_entity_id=9001`
+- All other FK tables similarly rewired (see full list below)
+
+**Full FK table checklist:**
+```
+agent_actions.agent_id
+certificates.entity_id
+channel_transcripts.sender_entity_id
+entity_fact_conflicts.entity_id
+entity_fact_sources.source_entity_id
+entity_facts.entity_id
+entity_relationships.entity_a
+entity_relationships.entity_b
+event_entities.entity_id
+gambling_logs.entity_id
+media_consumed.consumed_by
+media_queue.requested_by
+preferences.entity_id
+project_entities.entity_id
+shopping_history.entity_id
+shopping_preferences.entity_id
+shopping_wishlist.entity_id
+tasks.blocked_on
+tasks.created_by
+tasks.assigned_to
+vehicles.owner_id
+```
+
+**Pass criteria:** For each table, run: `SELECT COUNT(*) FROM <table> WHERE <fk_column> = 9002;` — must return 0 for all 21.
+
+---
+
+### TC-MENT-003: merge_entities() discovers FKs via information_schema (not hardcoded)
+
+**Preconditions:** A new test table with an `entity_id` FK is added to the staging database after `merge_entities` function definition.
+
+**Steps:**
+```sql
+-- Add a new FK table not in the original list
+CREATE TABLE test_new_entity_fk (id SERIAL, entity_id INT REFERENCES entities(id));
+INSERT INTO test_new_entity_fk (entity_id) VALUES (9002);
+SELECT merge_entities(9001, 9002);
+SELECT COUNT(*) FROM test_new_entity_fk WHERE entity_id = 9002;
+DROP TABLE test_new_entity_fk;
+```
+
+**Expected:** `test_new_entity_fk` row is rewired to entity 9001 — proving dynamic FK discovery.
+
+**Pass criteria:** `COUNT(*) = 0` (no orphaned refs to 9002).
+
+---
+
+### TC-MENT-004: merge_entities() raises exception when survivor_id = absorbed_id
+
+**Steps:**
+```sql
+SELECT merge_entities(9001, 9001);
+```
+
+**Expected:** Exception raised with message indicating self-merge is not allowed.
+
+**Pass criteria:** `RAISE EXCEPTION` triggered; transaction rolled back.
+
+---
+
+### TC-MENT-005: merge_entities() raises exception when either entity does not exist
+
+**Steps:**
+```sql
+SELECT merge_entities(9001, 99999);  -- 99999 doesn't exist
+SELECT merge_entities(99998, 9001);  -- 99998 doesn't exist
+```
+
+**Expected:** Exception for each call: entity not found.
+
+**Pass criteria:** Both calls raise exceptions cleanly; no partial changes.
+
+---
+
+### TC-MENT-006: merge_entities() merges entity_facts for both entities before deleting absorbed
+
+**Preconditions:** Both entities have entity_facts. entity 9001 has fact with key='location'; entity 9002 also has key='location'.
+
+**Expected:**
+- Facts with same key that pass trgm similarity check are themselves merged via `merge_facts()`
+- Facts with different keys are simply re-pointed to survivor entity_id
+- No duplicate (entity_id, key) violations if UNIQUE constraint exists
+
+**Pass criteria:** No DB constraint violation after merge; all facts accounted for.
+
+---
+
+### TC-MENT-007: merge_entities() also merges memory_embeddings for absorbed entity
+
+**Preconditions:** entity 9002 has `memory_embeddings` rows with `source_type='entity'` and `source_id='9002'`.
+
+**Expected:**
+- These embedding rows are re-pointed to survivor entity 9001 OR deleted (spec must define behavior)
+- No orphaned embedding rows pointing to deleted entity 9002
+
+**Pass criteria:** `SELECT COUNT(*) FROM memory_embeddings WHERE source_type='entity' AND source_id='9002'` = 0 after merge.
+
+---
+
+### TC-MENT-008: merge_entities() handles entity with zero FK references (clean delete)
+
+**Preconditions:** Entity 9004 (Ghost With No Facts) has no FK references anywhere.
+
+**Steps:**
+```sql
+-- Verify truly clean
+SELECT COUNT(*) FROM entity_facts WHERE entity_id = 9004;  -- expect 0
+-- Then merge into any survivor
+SELECT merge_entities(9001, 9004);
+```
+
+**Expected:** Entity 9004 deleted; function returns cleanly.
+
+**Pass criteria:** Entity 9004 absent from `entities`; no exceptions.
+
+---
+
+## Section 5 — Ghost Entity Cleanup (#200)
+
+### TC-GHOST-001: Pattern-match ghost "entity N" merged into entity with id=N
+
+**Preconditions:** Entity 9003 exists with `name = 'entity 9003'`. Entity with `id=9003` would need to exist for merge target. Use a real entity pattern for this test.
+
+**Setup alternative:** Create entity 9100 with `name = 'entity 9100'` and a distinct entity 9100 (actually, pattern merge means: entity named "entity 9003" should merge into entity id=9003 if that entity exists).
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-dedup --skip-decay
+```
+
+**Expected:**
+- Entity 9003 (`name='entity 9003'`) is absorbed into the entity with `id=9003` (if it exists)
+- If target id does not exist, should flag for manual review (not auto-delete)
+
+**Pass criteria (when target exists):** `SELECT COUNT(*) FROM entities WHERE name='entity 9003'` = 0 after cleanup; facts re-pointed to id=9003.
+
+---
+
+### TC-GHOST-002: Zero-fact zero-FK entity hard-deleted
+
+**Preconditions:** Entity 9004 (`Ghost With No Facts`) has zero entity_facts AND zero FK references in any other table.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-dedup --skip-decay
+```
+
+**Expected:**
+- Entity 9004 is hard-deleted from `entities`
+- No orphaned rows anywhere
+
+**Pass criteria:**
+```sql
+SELECT COUNT(*) FROM entities WHERE id = 9004;
+-- Returns 0
+```
+Plus check all FK tables return 0 for entity_id=9004.
+
+---
+
+### TC-GHOST-003: Zero-fact entity WITH FK references is NOT hard-deleted
+
+**Preconditions:** Create entity 9008 with zero entity_facts but with a row in `entity_relationships` referencing it.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-dedup --skip-decay
+```
+
+**Expected:**
+- Entity 9008 is NOT deleted (has FK references)
+- Entity 9008 is either flagged for review OR silently skipped (not deleted)
+
+**Pass criteria:**
+```sql
+SELECT COUNT(*) FROM entities WHERE id = 9008;
+-- Returns 1 (entity preserved)
+```
+
+---
+
+### TC-GHOST-004: Low-fact entity flagged for manual review queue, not deleted
+
+**Preconditions:** Entity 9005 has exactly 2 facts (below "low-fact" threshold defined in implementation).
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-dedup --skip-decay
+```
+
+**Expected:**
+- Entity 9005 is NOT deleted or merged automatically
+- A manual review record is created in the appropriate queue table (or log file)
+
+**Pass criteria:** `SELECT COUNT(*) FROM entities WHERE id = 9005` = 1 (entity preserved); review queue has entry for entity 9005.
+
+---
+
+### TC-GHOST-005: `--skip-ghost-cleanup` skips ghost entity phase
+
+**Preconditions:** Entity 9004 (zero facts, zero FKs) exists.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:** Entity 9004 still exists after run.
+
+**Pass criteria:** `SELECT COUNT(*) FROM entities WHERE id = 9004` = 1.
+
+---
+
+### TC-GHOST-006: `--dry-run` does not delete any entities
+
+**Preconditions:** Entities 9003, 9004, 9005 in database.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --dry-run
+```
+
+**Expected:** All entities still exist; dry-run output describes what WOULD be done.
+
+**Pass criteria:** All three entity IDs still present after dry run.
+
+---
+
+## Section 6 — Entity-Level Deduplication (#203)
+
+### TC-EDUP-001: Auto-merge when overlap ≥80%
+
+**Preconditions:**
+- Entities 9001 and 9002 share facts: both have `location='Austin, Texas'` and `occupation='software engineer'` (≥80% fact overlap by count + similarity).
+- Set up overlapping facts deliberately:
+  ```sql
+  -- Entity 9001 has facts: location, hometown, occupation, job_title (4 facts)
+  -- Entity 9002 has facts: location, occupation (2 facts — 2/4 = 50% by count, but may qualify by similarity)
+  ```
+  **Note:** The 80% threshold spec must clarify how overlap is computed (shared/(total unique)), test accordingly.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-decay --skip-ghost-cleanup
+```
+
+**Expected (only if overlap truly ≥80%):**
+- Lower-confidence or fewer-fact entity absorbed into higher-confidence entity via `merge_entities()`
+- Absorbed entity no longer in `entities`
+
+**Pass criteria:** (Depends on seed data triggering ≥80% — adjust seed data to match threshold.)
+
+---
+
+### TC-EDUP-002: Manual review queue written when overlap <80%
+
+**Preconditions:** Entities 9001 and 9007 with some shared facts but <80% overlap.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:**
+- Neither entity deleted or merged
+- Manual review record written to review queue with both entity IDs, overlap score, candidate type
+
+**Pass criteria:** Both entities exist; review queue has entry with entity_ids 9001 and 9007.
+
+---
+
+### TC-EDUP-003: Entity dedup considers name similarity, fact overlap, and embedding similarity
+
+**Preconditions:** Two entities: "Dustin Trammell" (id=9009) and "D. Trammell" (id=9010) with partial fact overlap.
+
+**Expected:**
+- Script computes combined overlap score using name similarity + shared facts + embedding similarity
+- If combined score ≥80% → auto-merge; else → review queue
+
+**Pass criteria:** Combined scoring is consistent with spec; output reports overlap breakdown.
+
+---
+
+### TC-EDUP-004: merge_entities used for auto-merge (not merge_facts)
+
+**Preconditions:** Two entities confirmed to have ≥80% overlap.
+
+**Steps:** Run dedup phase; observe DB changes.
+
+**Expected:**
+- `merge_entities(survivor_id, absorbed_id)` called (not `merge_facts`)
+- All 21 FK references rewired
+- Absorbed entity deleted
+
+**Pass criteria:** All 21 FK tables have zero refs to absorbed entity_id after merge.
+
+---
+
+### TC-EDUP-005: `--skip-entity-dedup` skips entity-level dedup phase *(flag corrected — see Section 14)*
+
+> **Flag correction:** The original version of this test used `--skip-dedup` to skip entity dedup. That flag controls *same-key fact dedup only*. The correct flag for skipping entity-level dedup is `--skip-entity-dedup`. See TC-FLAG-004 in Section 14 for the definitive test.
+
+**Preconditions:** High-overlap entity pair in DB.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-entity-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:** Both entities still present; log shows entity dedup skipped.
+
+**Pass criteria:** Both entity IDs present; "skip" and "entity-dedup" (or equivalent) in log.
+
+---
+
+### TC-EDUP-006: `--dry-run` does not merge entities
+
+**Preconditions:** High-overlap entity pair in DB.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --dry-run
+```
+
+**Expected:** Both entities present after dry run; report describes candidate pairs.
+
+**Pass criteria:** Both entity IDs present; dry-run report shows overlap candidates.
+
+---
+
+### TC-EDUP-007: Entity dedup does not merge entities of different types
+
+**Preconditions:** Entity 9001 (type='person') and entity 9006 (type='organization') share some facts.
+
+**Expected:** Script does not merge across entity types (person vs organization cannot be the same entity).
+
+**Pass criteria:** Both entities present; no merge attempted.
+
+---
+
+## Section 7 — Phase Ordering and Integration (#216)
+
+### TC-PHASE-001: Phase order: cooldown → embed → cross-key consolidation → same-key dedup → confidence decay → ghost cleanup → re-embed modified → archive & purge
+
+**Steps:** Run script with `--verbose`, capture log.
+
+**Expected:** Log messages appear in the documented phase order.
+
+**Pass criteria:** Phase start messages appear in correct sequence in stdout/stderr.
+
+---
+
+### TC-PHASE-002: All phases can be selectively skipped
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup --dry-run
+```
+
+**Expected:**
+- Exit code 0
+- Log shows each skipped phase
+- No DB changes
+
+**Pass criteria:** All skip messages present; no DB modifications.
+
+---
+
+### TC-PHASE-003: Script fails cleanly on DB connection error
+
+**Preconditions:** PostgreSQL not reachable (wrong host or port).
+
+**Steps:** Set invalid `PGHOST` env var; run script.
+
+**Expected:**
+- Exit code non-zero
+- Error message references DB connection failure
+- No partial state changes
+- State file NOT updated (run did not complete)
+
+**Pass criteria:** Non-zero exit; state file `last_run` unchanged from pre-run value.
+
+---
+
+### TC-PHASE-004: Full end-to-end run with all phases (non-dry-run)
+
+**Preconditions:** Full staging DB seed applied. State file last_run > 4 hours ago.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --verbose
+```
+
+**Expected:**
+- Exit code 0
+- All phases execute
+- State file updated
+- Summary log written (counts per phase)
+- No unhandled exceptions
+
+**Pass criteria:** Exit code 0; state file updated; log contains summary line with phase result counts.
+
+---
+
+### TC-PHASE-005: Script logs a complete summary on successful run
+
+**Steps:** Full run (TC-PHASE-004).
+
+**Expected:** Summary includes:
+- Facts consolidated (cross-key)
+- Facts deduped (same-key, existing)
+- Entities merged
+- Ghost entities cleaned
+- Embeddings added
+- Facts decayed
+- Facts archived
+- Facts purged
+
+**Pass criteria:** All summary fields present in log output.
+
+---
+
+## Section 8 — Boundary Value Analysis
+
+### TC-BVA-001: Cosine similarity boundary — exactly 0.92 triggers merge
+
+**Preconditions:** Two facts engineered to have cosine similarity = 0.92 (as close as feasible).
+
+**Expected:** Merge triggered.
+
+**Pass criteria:** Absorbed fact ID absent from `entity_facts` post-run.
+
+---
+
+### TC-BVA-002: Cosine similarity boundary — 0.919 does NOT trigger merge
+
+**Preconditions:** Two facts with cosine similarity ≈0.919 (just below threshold).
+
+**Expected:** No merge.
+
+**Pass criteria:** Both fact IDs present post-run.
+
+---
+
+### TC-BVA-003: Entity overlap boundary — exactly 80% triggers auto-merge
+
+**Preconditions:** Two entities with exactly 80% data match.
+
+**Expected:** Auto-merge triggered (not review queue).
+
+**Pass criteria:** Absorbed entity absent from `entities`.
+
+---
+
+### TC-BVA-004: Entity overlap boundary — 79.9% goes to review queue (not auto-merge)
+
+**Preconditions:** Two entities with ~79% data match.
+
+**Expected:** Review queue entry; no merge.
+
+**Pass criteria:** Both entities present; review record exists.
+
+---
+
+### TC-BVA-005: Cooldown gate — 3h 59m last run → blocked
+
+**Preconditions:** State file `last_run` = `NOW() - 3 hours 59 minutes`.
+
+**Expected:** Script exits with cooldown message.
+
+**Pass criteria:** Exit code 0 with cooldown message; no DB changes.
+
+---
+
+### TC-BVA-006: Cooldown gate — 4h 1m last run → allowed
+
+**Preconditions:** State file `last_run` = `NOW() - 4 hours 1 minute`.
+
+**Expected:** Script proceeds.
+
+**Pass criteria:** No cooldown message; phases execute.
+
+---
+
+## Section 9 — Error and Edge Cases
+
+### TC-ERR-001: merge_facts called with already-absorbed ID is idempotent/safe
+
+**Preconditions:** Fact 90002 already absorbed into 90001 (does not exist).
+
+**Steps:**
+```sql
+SELECT merge_facts(90001, 90002);
+```
+
+**Expected:** Exception raised: "absorbed fact does not exist" — not a silent failure.
+
+**Pass criteria:** Exception message references missing fact ID.
+
+---
+
+### TC-ERR-002: merge_entities with entity that has only one FK reference (entity_fact_sources)
+
+**Preconditions:** Entity 9002 has one entity_fact_source row referencing it.
+
+**Steps:** `SELECT merge_entities(9001, 9002);`
+
+**Expected:** `entity_fact_sources.source_entity_id` rewired to 9001; entity 9002 deleted.
+
+**Pass criteria:** `SELECT COUNT(*) FROM entity_fact_sources WHERE source_entity_id=9002` = 0.
+
+---
+
+### TC-ERR-003: Cross-key consolidation handles facts with NULL embeddings
+
+**Preconditions:** entity_fact 90005 exists but has no corresponding `memory_embeddings` row.
+
+**Expected:** Script skips this fact in consolidation (no crash); logs warning or silently skips.
+
+**Pass criteria:** No exception; fact 90005 untouched.
+
+---
+
+### TC-ERR-004: Ghost cleanup with malformed entity name (pattern match edge case)
+
+**Preconditions:** Entity named `"entity abc"` (non-numeric suffix) — should NOT match the `"entity N"` pattern.
+
+**Expected:** Entity not treated as a ghost by pattern; not merged.
+
+**Pass criteria:** Entity with name `"entity abc"` still exists.
+
+---
+
+### TC-ERR-005: Ghost pattern entity N where target entity id=N does not exist
+
+**Preconditions:** Entity named `"entity 99999"` exists; no entity with id=99999.
+
+**Expected:** Entity `"entity 99999"` flagged for review (not auto-merged into non-existent target).
+
+**Pass criteria:** Entity `"entity 99999"` still exists; review queue entry written.
+
+---
+
+### TC-ERR-006: Entity dedup does not loop (A→B, B→C does not create A→B→C chain in one run)
+
+**Preconditions:** Entities A (9001), B (9002), C (9006) where A≈B and B≈C.
+
+**Expected:** Only the highest-overlap pair is merged per run; no cascading chain in a single execution.
+
+**Pass criteria:** At most one merge per entity pair per run; no infinite loops.
+
+---
+
+### TC-ERR-007: Script handles empty database (no entity_facts) without error
+
+**Preconditions:** Test against a staging DB with entities table but empty entity_facts.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --dry-run
+```
+
+**Expected:** Exit code 0; zero-count summary; no exceptions.
+
+**Pass criteria:** Exit code 0; summary shows 0 for all phase counts.
+
+---
+
+### TC-ERR-008: State file corrupted/invalid JSON — script handles gracefully
+
+**Preconditions:** State file contains `{"broken: json"`.
+
+**Steps:**
+```bash
+echo '{"broken: json"' > /tmp/mm-corrupt-state.json
+python3 memory/scripts/memory-maintenance.py --state-file /tmp/mm-corrupt-state.json --dry-run
+```
+
+**Expected:**
+- Script treats state file as absent (treats cooldown as expired) OR exits with clear error
+- Does not crash with unhandled JSON decode exception
+
+**Pass criteria:** Clean error message or graceful default; no traceback.
+
+---
+
+## Section 10 — Regression: Existing Functionality Not Broken
+
+### TC-REG-001: Same-key dedup still works after rewrite
+
+**Preconditions:** Two entity_facts with same entity_id, same key, similarity ≥0.80 (existing trgm dedup).
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:** High-similarity same-key pair merged; medium-similarity pair flagged in dedup report.
+
+**Pass criteria:** Existing dedup behavior preserved (see prior test suites for exact criteria).
+
+---
+
+### TC-REG-002: Confidence decay still runs correctly
+
+**Preconditions:** entity_fact with `durability='short_term'`, `last_confirmed_at = 30 days ago`.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-dedup --skip-ghost-cleanup
+```
+
+**Expected:** Fact's `confidence` decremented per exponential decay formula `e^(-0.02 * 30)`.
+
+**Pass criteria:** New confidence ≈ `old_confidence * e^(-0.6)` (within ±0.001).
+
+---
+
+### TC-REG-003: Archive of low-confidence facts still runs
+
+**Preconditions:** entity_fact with `confidence < 0.10`, `learned_at > 7 days ago`, `durability != 'permanent'`.
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --skip-embed --skip-consolidation --skip-dedup --skip-ghost-cleanup
+```
+
+**Expected:** Fact moved to `entity_facts_archive` with `archive_reason='low_confidence'`.
+
+**Pass criteria:** Fact absent from `entity_facts`; present in `entity_facts_archive`.
+
+---
+
+### TC-REG-004: `--dry-run` flag prevents all writes across all phases
+
+**Steps:**
+```bash
+python3 memory/scripts/memory-maintenance.py --dry-run
+```
+
+**Expected:** Zero DB modifications across all tables.
+
+**Pass criteria:** Record counts in all affected tables identical before and after dry run.
+
+---
+
+### TC-REG-005: Embed scripts no longer exist as standalone cron entries
+
+**Steps:**
+```bash
+crontab -l | grep -E 'embed-memories|embed-full-database|embed-research'
+```
+
+**Expected:** Zero matches (these scripts removed from crontab).
+
+**Pass criteria:** No cron entries found for the three old embed scripts.
+
+---
+
+## Section 11 — Source Aggregation Verification
+
+### TC-SRC-001: entity_fact_sources rows correctly aggregated during cross-key consolidation
+
+**Preconditions:**
+
+Two entity_facts for the same entity (9001), each with their own `entity_fact_sources` rows including `source_url`:
+
+```sql
+-- Fact A: location (different key from Fact B)
+INSERT INTO entity_facts (id, entity_id, key, value, confidence, durability, extraction_count, learned_at, last_confirmed_at)
+VALUES (91001, 9001, 'location2', 'Austin, Texas', 0.90, 'long_term', 3, NOW()-INTERVAL '10 days', NOW()-INTERVAL '2 days')
+ON CONFLICT DO NOTHING;
+
+-- Fact B: hometown (semantically equivalent, different key)
+INSERT INTO entity_facts (id, entity_id, key, value, confidence, durability, extraction_count, learned_at, last_confirmed_at)
+VALUES (91002, 9001, 'hometown2', 'Austin TX', 0.85, 'long_term', 2, NOW()-INTERVAL '15 days', NOW()-INTERVAL '5 days')
+ON CONFLICT DO NOTHING;
+
+-- Sources for Fact A (one shared source + one unique source)
+INSERT INTO entity_fact_sources (fact_id, source_entity_id, source_citation, source_url, attribution_count, first_seen, last_seen)
+VALUES
+  (91001, 9001, 'shared-chat-session-42', 'https://example.com/chat/42', 2, NOW()-INTERVAL '10 days', NOW()-INTERVAL '2 days'),
+  (91001, 9001, 'unique-source-fact-a',   'https://example.com/doc/a',   1, NOW()-INTERVAL '9 days',  NOW()-INTERVAL '3 days')
+ON CONFLICT DO NOTHING;
+
+-- Sources for Fact B (the same shared source + one unique source)
+INSERT INTO entity_fact_sources (fact_id, source_entity_id, source_citation, source_url, attribution_count, first_seen, last_seen)
+VALUES
+  (91002, 9001, 'shared-chat-session-42', 'https://example.com/chat/42', 1, NOW()-INTERVAL '15 days', NOW()-INTERVAL '5 days'),
+  (91002, 9001, 'unique-source-fact-b',   'https://example.com/doc/b',   3, NOW()-INTERVAL '14 days', NOW()-INTERVAL '6 days')
+ON CONFLICT DO NOTHING;
+
+-- Seed embeddings at >=0.92 cosine similarity for facts 91001 and 91002
+-- (via embed phase or manual INSERT into memory_embeddings)
+```
+
+**Steps:**
+
+1. Seed the data above.
+2. Confirm cosine similarity between fact 91001 and 91002 embeddings is >=0.92.
+3. Run cross-key consolidation:
+   ```bash
+   python3 memory/scripts/memory-maintenance.py \
+     --skip-embed --skip-dedup --skip-decay --skip-ghost-cleanup
+   ```
+4. Identify the survivor fact ID (whichever of 91001/91002 remains).
+
+**Expected:**
+
+- The absorbed fact is removed from `entity_facts`.
+- The survivor retains all `entity_fact_sources` rows from both facts (3 total distinct sources, since `shared-chat-session-42` is shared).
+- Shared source `shared-chat-session-42` has `attribution_count` summed (2+1=3).
+- Unique sources (`unique-source-fact-a` and `unique-source-fact-b`) are moved to the survivor with their original `attribution_count` values intact.
+- `source_url` values are preserved on all surviving source rows.
+
+**Pass criteria:**
+```sql
+-- Three distinct source citations on the survivor
+SELECT COUNT(*) FROM entity_fact_sources WHERE fact_id = <survivor_id>;
+-- Returns 3
+
+-- Shared source has summed attribution_count
+SELECT attribution_count FROM entity_fact_sources
+  WHERE fact_id = <survivor_id> AND source_citation = 'shared-chat-session-42';
+-- Returns 3
+
+-- Unique sources preserved with correct source_url
+SELECT source_citation, source_url, attribution_count
+  FROM entity_fact_sources WHERE fact_id = <survivor_id>
+  ORDER BY source_citation;
+-- Rows: shared-chat-session-42 / https://example.com/chat/42 (3),
+--        unique-source-fact-a   / https://example.com/doc/a   (1),
+--        unique-source-fact-b   / https://example.com/doc/b   (3)
+-- All source_url values non-null and matching originals
+
+-- Absorbed fact has no source rows
+SELECT COUNT(*) FROM entity_fact_sources WHERE fact_id = <absorbed_id>;
+-- Returns 0
+```
+
+---
+
+## Section 12 — Embedding Dimension Mismatch
+
+### TC-DIM-001: Script handles 1536-dim legacy embeddings gracefully during consolidation
+
+**Preconditions:**
+
+Seed an entity_fact with a 1536-dimensional embedding (legacy OpenAI format) instead of the current 1024-dim Ollama `mxbai-embed-large` format:
+
+```sql
+-- Create a test fact
+INSERT INTO entity_facts (id, entity_id, key, value, confidence, durability, extraction_count, learned_at, last_confirmed_at)
+VALUES (92001, 9001, 'legacy_dim_test', 'some value', 0.75, 'long_term', 1, NOW()-INTERVAL '3 days', NOW()-INTERVAL '1 day')
+ON CONFLICT DO NOTHING;
+
+-- Manually insert a 1536-dim embedding (fill with 0.001 to avoid zero-vector issues)
+INSERT INTO memory_embeddings (source_type, source_id, embedding, model, created_at, updated_at)
+VALUES (
+  'entity_fact',
+  '92001',
+  (SELECT array_fill(0.001::float4, ARRAY[1536])::vector),
+  'openai/text-embedding-ada-002',
+  NOW()-INTERVAL '30 days',
+  NOW()-INTERVAL '30 days'
+)
+ON CONFLICT (source_type, source_id) DO UPDATE
+  SET embedding = EXCLUDED.embedding,
+      model     = EXCLUDED.model,
+      updated_at = EXCLUDED.updated_at;
+```
+
+**Steps:**
+
+```bash
+python3 memory/scripts/memory-maintenance.py \
+  --skip-embed --skip-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:**
+
+The script must NOT crash (no unhandled exception). One of these behaviors is acceptable (whichever the spec defines):
+- **Skip**: Fact 92001 is excluded from consolidation comparisons; a warning is logged (e.g., "Skipping entity_fact 92001: embedding dimension 1536 != expected 1024").
+- **Re-embed**: The 1536-dim embedding is replaced with a fresh 1024-dim embedding before comparison proceeds.
+- **Structured error**: An error is raised, logged, and the script continues with remaining facts (no full abort).
+
+Under no scenario should the script:
+- Silently attempt to compute cosine similarity between 1536-dim and 1024-dim vectors (pgvector will raise a dimension mismatch error).
+- Exit with an unhandled Python traceback.
+- Leave entity_fact 92001 in a corrupt or missing state.
+
+**Pass criteria:**
+
+```bash
+# No Python traceback in output
+python3 memory/scripts/memory-maintenance.py ... 2>&1 | grep -c "Traceback"
+# Returns 0
+```
+
+```sql
+-- entity_fact 92001 still intact after run
+SELECT COUNT(*) FROM entity_facts WHERE id = 92001;
+-- Returns 1
+```
+
+- If **skip** behavior: log output contains a dimension mismatch warning for fact 92001.
+- If **re-embed** behavior: `memory_embeddings` row for `source_id='92001'` has `array_length(embedding::real[], 1) = 1024`.
+
+---
+
+## Section 13 — Multi-Fact Cluster Consolidation (3+ Facts)
+
+### TC-CLUSTER-001: Three-way cross-key fact cluster fully consolidated into one survivor
+
+**Preconditions:**
+
+Seed three semantically equivalent facts (different keys, same entity) whose pairwise cosine similarities are all >=0.92:
+
+```sql
+-- The "pizza scenario": three keys all expressing the same preference
+INSERT INTO entity_facts (id, entity_id, key, value, confidence, durability, extraction_count, learned_at, last_confirmed_at)
+VALUES
+  (93001, 9001, 'pizza_preference',      'loves pizza',               0.88, 'long_term', 4, NOW()-INTERVAL '20 days', NOW()-INTERVAL '5 days'),
+  (93002, 9001, 'preference_food_likes', 'pizza is a favourite',      0.82, 'long_term', 3, NOW()-INTERVAL '18 days', NOW()-INTERVAL '6 days'),
+  (93003, 9001, 'liked_pizza_types',     'enjoys pizza of all kinds', 0.80, 'long_term', 2, NOW()-INTERVAL '15 days', NOW()-INTERVAL '7 days')
+ON CONFLICT DO NOTHING;
+
+-- Source rows for each fact
+INSERT INTO entity_fact_sources (fact_id, source_entity_id, source_citation, attribution_count, first_seen, last_seen)
+VALUES
+  (93001, 9001, 'pizza-source-a', 2, NOW()-INTERVAL '20 days', NOW()-INTERVAL '5 days'),
+  (93002, 9001, 'pizza-source-b', 1, NOW()-INTERVAL '18 days', NOW()-INTERVAL '6 days'),
+  (93003, 9001, 'pizza-source-c', 3, NOW()-INTERVAL '15 days', NOW()-INTERVAL '7 days')
+ON CONFLICT DO NOTHING;
+
+-- NOTE: Embeddings must be generated or manually seeded such that:
+--   cosine_sim(93001, 93002) >= 0.92
+--   cosine_sim(93001, 93003) >= 0.92
+--   cosine_sim(93002, 93003) >= 0.92
+-- Verify:
+--   SELECT 1-(e1.embedding<=>e2.embedding) AS sim,
+--          e1.source_id AS a, e2.source_id AS b
+--   FROM memory_embeddings e1, memory_embeddings e2
+--   WHERE e1.source_id IN ('93001','93002','93003')
+--     AND e2.source_id IN ('93001','93002','93003')
+--     AND e1.source_id < e2.source_id;
+```
+
+**Steps:**
+
+```bash
+python3 memory/scripts/memory-maintenance.py \
+  --skip-embed --skip-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:**
+
+- All three facts are merged into a single survivor (highest confidence wins; tie-break by extraction_count).
+- Two absorbed facts removed from `entity_facts`.
+- Survivor's `extraction_count` = 4+3+2 = 9.
+- Survivor's `confidence` = GREATEST(0.88, 0.82, 0.80) = 0.88.
+- All three source records exist on the survivor in `entity_fact_sources`.
+
+**Pass criteria:**
+
+```sql
+-- Only one fact remains from the cluster
+SELECT COUNT(*) FROM entity_facts WHERE id IN (93001, 93002, 93003);
+-- Returns 1
+
+-- Survivor has summed extraction_count
+SELECT extraction_count FROM entity_facts WHERE id IN (93001, 93002, 93003);
+-- Returns 9
+
+-- Survivor has highest confidence
+SELECT confidence FROM entity_facts WHERE id IN (93001, 93002, 93003);
+-- Returns 0.88
+
+-- All three sources aggregated onto survivor
+SELECT COUNT(*) FROM entity_fact_sources WHERE fact_id = <survivor_id>;
+-- Returns 3 (pizza-source-a, pizza-source-b, pizza-source-c)
+
+-- Absorbed facts have no source rows
+SELECT COUNT(*) FROM entity_fact_sources WHERE fact_id IN (<absorbed_id_1>, <absorbed_id_2>);
+-- Returns 0
+```
+
+---
+
+### TC-CLUSTER-002: 4-fact cluster consolidated in a single run (no partial convergence)
+
+**Preconditions:** Four semantically near-identical facts for the same entity (e.g., four different phrasings of the same address). All pairwise cosine similarities >=0.92.
+
+**Steps:** Run cross-key consolidation.
+
+**Expected:**
+- All four facts collapse into one survivor in a single script run (not requiring 3 separate runs to converge).
+- Survivor `extraction_count` = sum of all four.
+
+**Pass criteria:**
+```sql
+SELECT COUNT(*) FROM entity_facts WHERE id IN (<f1>, <f2>, <f3>, <f4>);
+-- Returns 1
+```
+
+---
+
+### TC-CLUSTER-003: Partial cluster — 3 facts where only 2 pairs meet the threshold
+
+**Preconditions:**
+- Fact A and Fact B: cosine similarity >=0.92.
+- Fact A and Fact C: cosine similarity >=0.92.
+- Fact B and Fact C: cosine similarity 0.88 (<0.92).
+
+**Expected:**
+- The consolidation algorithm produces a deterministic, documented result (depends on clustering strategy: single-linkage, complete-linkage, or union-find).
+- No merge of any fact pair with cosine similarity <0.92.
+- **Note to implementer:** Document the clustering algorithm used. This test validates it is deterministic and spec-compliant.
+
+**Pass criteria:** Behavior matches the documented clustering algorithm; no fact pair with similarity <0.92 is merged.
+
+---
+
+## Section 14 — Flag Scope Clarity for Dedup Phases
+
+> **Background:** TC-EDUP-005 previously used `--skip-dedup` to skip entity-level dedup. However, `--skip-dedup` is the existing flag for *same-key fact dedup only*. Entity-level dedup has its own separate flag `--skip-entity-dedup`. This section tests both flags in isolation to confirm each skips only its intended phase.
+
+### TC-FLAG-001: `--skip-dedup` skips same-key fact dedup only (not entity dedup)
+
+**Preconditions:**
+
+- Two entity_facts with the same `entity_id` and same `key`, trgm similarity >=0.80 (same-key dedup candidate).
+- Two entities with >=80% fact overlap (entity dedup auto-merge candidate).
+
+```sql
+-- Same-key dedup pair
+INSERT INTO entity_facts (id, entity_id, key, value, confidence, durability, extraction_count, learned_at, last_confirmed_at)
+VALUES
+  (94001, 9001, 'same_key_test', 'software engineer at NOVA', 0.85, 'long_term', 2, NOW()-INTERVAL '5 days', NOW()-INTERVAL '1 day'),
+  (94002, 9001, 'same_key_test', 'software engineer',         0.80, 'long_term', 1, NOW()-INTERVAL '6 days', NOW()-INTERVAL '2 days')
+ON CONFLICT DO NOTHING;
+
+-- High-overlap entity pair (reuse 9001/9002 if they meet >=80% threshold, or seed a dedicated pair)
+```
+
+**Steps:**
+
+```bash
+python3 memory/scripts/memory-maintenance.py \
+  --skip-embed --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:**
+
+- Same-key dedup phase SKIPPED: facts 94001 and 94002 both remain in `entity_facts`.
+- Entity dedup phase RUNS: high-overlap entity pair evaluated and (if >=80%) auto-merged.
+- Log confirms `--skip-dedup` applies to same-key fact dedup phase only.
+
+**Pass criteria:**
+
+```sql
+-- Same-key facts untouched
+SELECT COUNT(*) FROM entity_facts WHERE id IN (94001, 94002);
+-- Returns 2
+
+-- Entity dedup ran: verify the high-overlap entity candidate was processed
+-- (check relevant entity IDs based on test setup)
+```
+
+---
+
+### TC-FLAG-002: `--skip-entity-dedup` skips entity-level dedup only (not same-key fact dedup)
+
+**Preconditions:** Same as TC-FLAG-001.
+
+**Steps:**
+
+```bash
+python3 memory/scripts/memory-maintenance.py \
+  --skip-embed --skip-consolidation --skip-entity-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:**
+
+- Same-key fact dedup phase RUNS: facts 94001 and 94002 evaluated for merge (one absorbed).
+- Entity dedup phase SKIPPED: high-overlap entity pair remains unmerged.
+- Log confirms `--skip-entity-dedup` applies to entity dedup phase only.
+
+**Pass criteria:**
+
+```sql
+-- Same-key dedup ran: one fact absorbed
+SELECT COUNT(*) FROM entity_facts WHERE id IN (94001, 94002);
+-- Returns 1
+
+-- Entity dedup skipped: both entities still present
+-- (verify entity IDs for the high-overlap candidate pair)
+```
+
+---
+
+### TC-FLAG-003: `--skip-dedup --skip-entity-dedup` skips both dedup phases
+
+**Preconditions:** Both same-key and entity dedup candidates present.
+
+**Steps:**
+
+```bash
+python3 memory/scripts/memory-maintenance.py \
+  --skip-embed --skip-consolidation --skip-dedup --skip-entity-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:**
+
+- Both same-key fact dedup and entity dedup phases skipped.
+- Log shows skip messages for both phases.
+- No merges of either type.
+
+**Pass criteria:**
+
+```sql
+-- Same-key candidate facts untouched
+SELECT COUNT(*) FROM entity_facts WHERE id IN (94001, 94002);
+-- Returns 2
+
+-- Entity dedup candidate entities untouched (verify IDs)
+```
+
+---
+
+### TC-FLAG-004 (Replaces TC-EDUP-005): `--skip-entity-dedup` skips entity-level dedup phase
+
+> **Note:** This test supersedes the original TC-EDUP-005, which incorrectly used `--skip-dedup` to skip entity dedup. The correct flag is `--skip-entity-dedup`.
+
+**Preconditions:** A high-overlap entity pair in DB (>=80% fact overlap, entity dedup auto-merge candidate).
+
+**Steps:**
+
+```bash
+python3 memory/scripts/memory-maintenance.py \
+  --skip-embed --skip-consolidation --skip-entity-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:**
+
+- Entity dedup phase skipped.
+- Both entities remain in `entities`.
+- Log contains message indicating entity dedup was skipped.
+
+**Pass criteria:**
+
+```sql
+-- Both entities still present
+SELECT COUNT(*) FROM entities WHERE id IN (<entity_a_id>, <entity_b_id>);
+-- Returns 2
+```
+
+Log output: contains "skip" and "entity-dedup" (or equivalent phrasing).
+
+---
+
+### TC-FLAG-005: `--skip-dedup` does not suppress entity dedup (negative confirmation)
+
+**Preconditions:** Same-key dedup candidate (facts 94001/94002) AND high-overlap entity dedup candidate both present.
+
+**Steps:**
+
+```bash
+# skip-entity-dedup is NOT set; only skip-dedup is set
+python3 memory/scripts/memory-maintenance.py \
+  --skip-embed --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup
+```
+
+**Expected:**
+
+- Same-key dedup is skipped (facts 94001/94002 both remain).
+- Entity dedup RUNS (not suppressed by `--skip-dedup`); high-overlap pair evaluated.
+
+**Pass criteria:**
+
+```sql
+-- Same-key candidates untouched
+SELECT COUNT(*) FROM entity_facts WHERE id IN (94001, 94002);
+-- Returns 2
+
+-- Entity dedup processed the candidate pair (verify entity IDs)
+```
+
+---
+
+## Coverage Summary
+
+| Area | Test Cases | Pattern |
+|------|-----------|---------|
+| Cooldown gate | TC-COOL-001–006 | Happy path, BVA, edge |
+| Embedding absorption | TC-EMBED-001–006 | Happy path, idempotency, skip, error |
+| Cross-key consolidation | TC-XKEY-001–007 | Happy path, threshold BVA, isolation, dry-run |
+| merge_entities() function | TC-MENT-001–008 | FK rewiring, all 21 tables, error paths |
+| Ghost entity cleanup | TC-GHOST-001–006 | Pattern match, hard-delete, FK protection, low-fact |
+| Entity-level dedup | TC-EDUP-001–007 | Auto-merge, review queue, type isolation |
+| Phase ordering/integration | TC-PHASE-001–005 | Order, skip-all, DB error, E2E |
+| Boundary value analysis | TC-BVA-001–006 | Thresholds at ±1 |
+| Error/edge cases | TC-ERR-001–008 | Null embeddings, malformed input, cascades |
+| Regression | TC-REG-001–005 | Existing functionality preserved |
+| Source aggregation | TC-SRC-001 | Cross-key merge: source rows preserved, shared sources summed, source_url retained |
+| Embedding dimension mismatch | TC-DIM-001 | 1536-dim legacy embedding handled gracefully (skip/re-embed/error, no crash) |
+| Multi-fact clusters (3+) | TC-CLUSTER-001–003 | 3-way merge, 4-way merge, partial cluster (non-transitive similarity) |
+| Flag scope clarity | TC-FLAG-001–005 | --skip-dedup vs --skip-entity-dedup isolated; both-skip; negative confirmation |
+
+**Total test cases: 72** *(added 15: TC-SRC-001, TC-DIM-001, TC-CLUSTER-001–003, TC-FLAG-001–005; TC-EDUP-005 flag corrected)*
+
+---
+
+## Notes for Flint (QA Executor)
+
+1. **Staging only.** Never run these tests against production. Use `nova-staging@localhost` per team rules.
+2. **Seed data first.** Run the SQL in "Test Data Setup" before any test case.
+3. **Rollback after destructive tests.** Wrap destructive SQL tests (merge, delete) in transactions with ROLLBACK unless you specifically need to confirm the committed state. Use explicit `BEGIN; ... ROLLBACK;` unless testing commit behavior.
+4. **Embedding tests require Ollama.** TC-EMBED-* require `mxbai-embed-large` to be loaded. Confirm with `curl http://localhost:11434/api/tags`.
+5. **TC-MENT-003 requires a temp table.** Drop it after the test as instructed.
+6. **Cosine similarity seeding.** For TC-XKEY-001/002 and TC-BVA-001/002, verify similarity values before running: `SELECT 1 - (e1.embedding <=> e2.embedding) AS cosine_sim FROM memory_embeddings e1, memory_embeddings e2 WHERE e1.source_id = '90001' AND e2.source_id = '90002';`
+7. **Review queue table.** TC-EDUP-002, TC-GHOST-004, TC-ERR-005 reference a "manual review queue." The table name must be confirmed from the implementation spec before execution.
+8. **State file path.** The `--state-file` flag is assumed from spec. Confirm the actual flag name with the implementation.
+9. **TC-SRC-001 source_url column.** If `entity_fact_sources` does not have a `source_url` column in the current schema, confirm the column name from the implementation spec before executing TC-SRC-001.
+10. **TC-DIM-001 embedding seed.** The `array_fill(0.001::float4, ARRAY[1536])::vector` cast requires the `vector` type to accept variable-dimension input, or the `memory_embeddings.embedding` column to be untyped. Adjust the seed SQL if the column enforces a fixed 1024-dim type (use `vector(1536)` cast or a workaround agreed with the implementer).
+11. **TC-CLUSTER-001–003 embedding seeding.** Three-way cluster tests require all three pairwise cosine similarities >=0.92. Verify all three pairs before running, not just one pair.
+12. **TC-FLAG-001–005 flag names.** `--skip-entity-dedup` is the expected flag name per spec. If the implementation uses a different name (e.g., `--skip-entity-level-dedup`), update all TC-FLAG-* steps accordingly.


### PR DESCRIPTION
## Summary

Unified `memory-maintenance.py` replacing separate embedding, decay, and dedup scripts. Adds cross-key fact consolidation, ghost entity cleanup, and entity-level deduplication.

### Changes
- **memory/scripts/memory-maintenance.py**: Complete rewrite with 9 phases (cooldown → embed → cross-key consolidation → same-key dedup → confidence decay → ghost cleanup → entity dedup → re-embed → archive/purge)
- **memory/migrations/add-merge-entities-function.sql**: New `merge_entities()` DB function with dynamic FK discovery
- **memory/migrations/add-memory-embeddings-unique-constraint.sql**: Unique index for ON CONFLICT upserts
- **memory/scripts/embed-memories-cron.sh**: Deprecated (absorbed into memory-maintenance.py)
- **Deprecation notices** added to embed-full-database.py, embed-memories.py, embed-research.py
- **README.md, CHANGELOG.md, memory/README.md**: Documentation updates
- **tests/test-cases-entity-facts-quality.md**: 72 test cases

### Scheduling Change
Removed from crontab. Now triggered from HEARTBEAT idle cascade (priority #2, 4h cooldown gate).

### Staging Results
All phases pass. 65/72 test cases verified. 7 deferred (embed-phase, Ollama unavailable on staging).

### Issues
Closes #216, closes #202, closes #200, closes #203