### PR TITLE
fix(#244): per-gateway agent_config_sync + UPPERCASE get_agent_bootstrap source labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### Batch: agent-identity-batch (Issues #244 + nova-openclaw#243)
+
+#### Changed
+- **Per-gateway agent scoping in `agent-config-sync`** — `cognition/focus/agent-config-sync/src/sync.ts` now reads from the DB function `get_agent_export_rows()` instead of `SELECT ... WHERE instance_type != 'peer'`. Each peer gateway's `agents.json` is now scoped to that gateway's own session_user identity (the connecting peer plus its `parent_agents`-linked subagents). Fixes default-agent confusion on Newhart/Graybeard gateways. (#244)
+- **UPPERCASE source labels from `get_agent_bootstrap()`** — `database/schema.sql` now emits `UNIVERSAL`/`GLOBAL`/`DOMAIN:<name>`/`WORKFLOW:<name>`/`AGENT` instead of the lowercase variants. The bootstrap-context hook composes synthetic paths as `db:${source}/${filename}`, so injected file headers now read `db:UNIVERSAL/CORE.md`, `db:DOMAIN:Project Leadership/ORCHESTRATION.md`, etc. Aligns with `agent_bootstrap_context.context_type` column values. (#244)
+
+#### Tests
+- `cognition/focus/agent-config-sync/src/sync.test.ts` — 24 new unit assertions covering `buildAgentsList()` against `get_agent_export_rows()` (TC-244-U-01 through U-05): peer-as-default emission, subagent ownership filtering, `is_default` handling, empty-result safety, and absence of cross-peer leakage.
+- `tests/TEST-CASES-batch-agent-identity.md` — 1,045-line test design for the coordinated #244 + #243 staging rollout.
+
+#### Cross-repo coordination
+- Pairs with nova-openclaw [#243](https://github.com/NOVA-Openclaw/nova-openclaw/issues/243) which preserves the new `db:TIER/...` synthetic path identifiers through the gateway's `sanitizeBootstrapFiles()` sanitizer. Both branches must land together — staging install order is nova-openclaw first, then nova-mind.
+
+#### Issues Closed
+- #244 — agent_config_sync per-gateway scoping + UPPERCASE bootstrap source casing
+
 ### Batch: batch-se-run-8 (Issues #232, #234, #237)
 
 #### New Features

--- a/cognition/CHANGELOG.md
+++ b/cognition/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Changed (#244 — per-gateway agent scoping + UPPERCASE bootstrap source labels)
+
+- **`agent-config-sync` query switched to `get_agent_export_rows()`** ([#244](https://github.com/NOVA-Openclaw/nova-mind/issues/244)) — The inline `AGENTS_QUERY` in `cognition/focus/agent-config-sync/src/sync.ts` previously used `WHERE instance_type != 'peer' AND model IS NOT NULL`, which returned the same rows regardless of which peer gateway was connecting. It now calls the DB function `get_agent_export_rows()` (lives in `database/schema.sql`, owned by newhart) which uses `session_user` to scope results: the connecting peer's own row (emitted as `is_default = TRUE`) plus subagents linked to that peer via `parent_agents` array overlap. Each peer gateway therefore receives only its own agent set in `agents.json`, fixing the default-agent confusion on Newhart/Graybeard gateways where they were previously seeing NOVA's subagents and falling back to NOVA as default. Supersedes the prior `instance_type != 'peer'` filter described below.
+- **`get_agent_bootstrap()` source literals capitalized** ([#244](https://github.com/NOVA-Openclaw/nova-mind/issues/244)) — The five tier labels emitted by `get_agent_bootstrap()` in `database/schema.sql` are now UPPERCASE: `UNIVERSAL`, `GLOBAL`, `DOMAIN:<name(s)>`, `WORKFLOW:<name>`, `AGENT` (previously lowercase). The bootstrap-context hook handler composes paths as `` `db:${row.source}/${row.filename}` ``, so callers now see `db:UNIVERSAL/CORE.md`, `db:DOMAIN:Project Leadership/ORCHESTRATION.md`, `db:AGENT/SOUL.md`, etc. The casing aligns the source field with the `agent_bootstrap_context.context_type` column (UNIVERSAL/GLOBAL/DOMAIN/AGENT/SYSTEM/WORKFLOW) and makes path tiers visually distinct from the `db:` namespace prefix.
+- **Coordinated with nova-openclaw [#243](https://github.com/NOVA-Openclaw/nova-openclaw/issues/243)** — The new UPPERCASE `db:TIER/...` synthetic identifiers are preserved verbatim by the gateway's bootstrap-files sanitizer (`sanitizeBootstrapFiles()` in nova-openclaw), so they never get corrupted into workspace-rooted filesystem paths. Both PRs must ship together — see staging deploy notes on PR #244.
+- **`notify_agent_config_changed()` trigger fires on any row change** — Was already broadened in an earlier change; documenting here for completeness because the docs for the trigger now also reflect the wider net.
+
 ### Removed (#110 — installer schema cleanup)
 
 - **Duplicate schema management removed from installer** ([#110](https://github.com/nova-openclaw/nova-mind/issues/110)) — `pgschema` is now the single source of truth for database schema. Specifically:

--- a/cognition/README.md
+++ b/cognition/README.md
@@ -122,7 +122,10 @@ The **`agent-config-sync`** extension plugin keeps OpenClaw's agent model config
 
 - **`defaults.models`** — Allow-list of all unique models (primaries + fallbacks).
 - **`list`** — Per-agent config. `model` is a plain string when there are no fallbacks, or an object with `primary`/`fallbacks` when fallbacks exist.
-- Agents with `instance_type = 'peer'` are excluded (peers run their own gateways).
+- Each peer gateway's `agents.json` is scoped to that gateway: the connecting peer appears as
+  `default: true`, and subagents linked to that peer via `parent_agents` appear as non-default
+  entries. Both the peer and its own subagents appear in their respective gateway's `agents.json`.
+  Agents belonging to a different peer do not appear.
 
 ### Replaces: `agent-config-db` Hook
 

--- a/cognition/docs/bootstrap-context-workflow-changes.md
+++ b/cognition/docs/bootstrap-context-workflow-changes.md
@@ -39,7 +39,7 @@ The `get_agent_bootstrap()` function includes workflows in an agent's bootstrap 
 SELECT 
     'WORKFLOW_CONTEXT.md' as filename,
     'Workflow: ' || w.name || E'\n\n' || w.description as content,
-    'workflow:' || w.name as source,
+    'WORKFLOW:' || w.name as source,
     4 as priority
 FROM workflow_steps ws
 JOIN workflows w ON ws.workflow_id = w.id

--- a/cognition/focus/agent-config-sync/HOOK.md
+++ b/cognition/focus/agent-config-sync/HOOK.md
@@ -10,9 +10,11 @@ LISTEN/NOTIFY-driven sync that writes `~/.openclaw/agents.json`.
    config file reflects current DB state on gateway start.
 
 2. **On notification** — The `agents_config_changed` trigger fires
-   `pg_notify('agent_config_changed', ...)` whenever `model`,
-   `fallback_models`, `thinking`, or `instance_type` change on the `agents`
-   table.  The plugin queries the table and rewrites `agents.json`.
+   `pg_notify('agent_config_changed', ...)` whenever any column changes on the
+   `agents` table.  The plugin queries `get_agent_export_rows()`, which scopes
+   results to the connecting role (session_user) and subagents owning that role
+   via `parent_agents` array overlap, and rewrites `agents.json`. The function
+   lives in nova-mind/database/schema.sql and is owned by newhart.
 
 3. **Atomic writes** — The JSON is written to a temp file first, then
    `rename(2)`-d into place to prevent partial reads by the gateway.
@@ -59,7 +61,10 @@ LISTEN/NOTIFY-driven sync that writes `~/.openclaw/agents.json`.
 
 - `agents.defaults.models` is an allow-list of **all** unique models
   (primaries + every fallback).
-- Peer agents (`instance_type = 'peer'`) are **excluded**.
+- Results are scoped per-gateway: `get_agent_export_rows()` returns the connecting
+  peer's own row (as `is_default = TRUE`) plus subagents linked to that peer via
+  `parent_agents` array overlap. Peers and their own subagents both appear in their
+  respective agents.json.
 - Fallback order is preserved from the DB array.
 
 ## DB Schema Requirements
@@ -71,6 +76,7 @@ LISTEN/NOTIFY-driven sync that writes `~/.openclaw/agents.json`.
 --   fallback_models TEXT[]
 --   thinking        VARCHAR
 --   instance_type   VARCHAR   ('primary' | 'subagent' | 'peer')
+--   parent_agents   TEXT[]    (peer agent names that own this subagent)
 
 -- Trigger (already in place):
 --   agents_config_changed → pg_notify('agent_config_changed', ...)

--- a/cognition/focus/agent-config-sync/README.md
+++ b/cognition/focus/agent-config-sync/README.md
@@ -18,7 +18,7 @@ When the table changes, the plugin receives a PostgreSQL `NOTIFY` event, rebuild
 DB change
   └─► trigger fires pg_notify('agent_config_changed')
         └─► plugin receives notification (LISTEN)
-              └─► queries agents WHERE instance_type != 'peer'
+              └─► queries get_agent_export_rows() (session_user-scoped)
                     └─► builds bare JSON array
                           └─► atomic write (tmp + rename) → agents.json
                                 └─► SIGUSR1 → gateway hot-reload
@@ -98,14 +98,17 @@ The `$include` directive splices the bare array directly into `agents.list`. All
 
 ## DB Filter
 
-Only non-peer agents are synced:
+Agents are scoped per-gateway via `get_agent_export_rows()`:
 
 ```sql
-WHERE instance_type != 'peer'
-  AND model IS NOT NULL
+SELECT name, model, fallback_models, thinking, instance_type, is_default, allowed_subagents
+FROM get_agent_export_rows();
 ```
 
-Peer agents (connected remote instances) are excluded — they are managed dynamically by the gateway, not via `agents.json`.
+The function (defined in nova-mind/database/schema.sql, owned by newhart) uses `session_user`
+to scope results: it returns the connecting peer's own row (as `is_default = TRUE`) plus every
+subagent where `session_user = ANY(parent_agents)` (as `is_default = FALSE`). This ensures
+each peer gateway receives only its own agent set.
 
 ---
 
@@ -149,7 +152,7 @@ DB INSERT / UPDATE / DELETE on agents
                     │
                     └─► syncAgentsConfig()
                           │
-                          ├─► SELECT WHERE instance_type != 'peer'
+                          ├─► SELECT FROM get_agent_export_rows() (session_user-scoped)
                           │
                           └─► atomic write → agents.json
                                 │

--- a/cognition/focus/agent-config-sync/package.json
+++ b/cognition/focus/agent-config-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nova-cognition/agent_config_sync",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "DB-to-Config sync for agent model configuration (LISTEN/NOTIFY)",
   "type": "module",
   "main": "dist/index.js",

--- a/cognition/focus/agent-config-sync/package.json
+++ b/cognition/focus/agent-config-sync/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "npx tsx --test src/sync.test.ts"
   },
   "keywords": [
     "openclaw",

--- a/cognition/focus/agent-config-sync/src/sync.test.ts
+++ b/cognition/focus/agent-config-sync/src/sync.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Unit tests for buildAgentsList()
+ *
+ * TC-244-U-01  NOVA session — self as default, NOVA's subagents only
+ * TC-244-U-02  Newhart session — self as default, Newhart's subagents only
+ * TC-244-U-03  Mutual exclusion — NOVA and Newhart never see each other
+ * TC-244-U-04  Fallback model shape preserved from function rows
+ * TC-244-U-05  Row with is_default = null emits no `default` key
+ *
+ * Framework: Node built-in test runner (node:test) + tsx for TS execution.
+ * Run: npx tsx --test src/sync.test.ts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildAgentsList } from "./sync.js";
+import type { AgentRow } from "./sync.js";
+
+// ── TC-244-U-01: NOVA session ───────────────────────────────────────────────
+
+describe("TC-244-U-01: NOVA session — self as default, NOVA's subagents only", () => {
+  const novaRows: AgentRow[] = [
+    {
+      name: "nova",
+      model: "anthropic/claude-opus-4",
+      fallback_models: null,
+      thinking: "high",
+      instance_type: "primary",
+      is_default: true,
+      allowed_subagents: ["gem", "coder", "scout"],
+    },
+    {
+      name: "coder",
+      model: "anthropic/claude-sonnet-4",
+      fallback_models: null,
+      thinking: "medium",
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+    {
+      name: "gem",
+      model: "google/gemini-flash",
+      fallback_models: null,
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+    {
+      name: "scout",
+      model: "google/gemini-flash",
+      fallback_models: null,
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+  ];
+
+  const result = buildAgentsList(novaRows);
+
+  it("nova entry has default: true", () => {
+    assert.strictEqual(result.find((e) => e.id === "nova")?.default, true);
+  });
+
+  it("coder entry has no default key", () => {
+    assert.strictEqual(result.find((e) => e.id === "coder")?.default, undefined);
+  });
+
+  it("gem entry has no default key", () => {
+    assert.strictEqual(result.find((e) => e.id === "gem")?.default, undefined);
+  });
+
+  it("scout entry has no default key", () => {
+    assert.strictEqual(result.find((e) => e.id === "scout")?.default, undefined);
+  });
+
+  it("all four agents are present", () => {
+    assert.deepStrictEqual(
+      result.map((e) => e.id).sort(),
+      ["coder", "gem", "nova", "scout"],
+    );
+  });
+
+  it("nova's allowAgents are sorted", () => {
+    assert.deepStrictEqual(
+      result.find((e) => e.id === "nova")?.subagents?.allowAgents,
+      ["coder", "gem", "scout"],
+    );
+  });
+
+  it("thinking is not emitted for any entry", () => {
+    for (const entry of result) {
+      assert.ok(
+        !Object.prototype.hasOwnProperty.call(entry, "thinking"),
+        `Entry '${entry.id}' should not have a thinking property`,
+      );
+    }
+  });
+});
+
+// ── TC-244-U-02: Newhart session ────────────────────────────────────────────
+
+describe("TC-244-U-02: Newhart session — self as default, Newhart's subagents only", () => {
+  const newhartRows: AgentRow[] = [
+    {
+      name: "newhart",
+      model: "anthropic/claude-opus-4",
+      fallback_models: null,
+      thinking: "high",
+      instance_type: "peer",
+      is_default: true,
+      allowed_subagents: ["coder", "scout"],
+    },
+    {
+      name: "coder",
+      model: "anthropic/claude-sonnet-4",
+      fallback_models: null,
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+    {
+      name: "scout",
+      model: "google/gemini-flash",
+      fallback_models: null,
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+  ];
+
+  const result = buildAgentsList(newhartRows);
+
+  it("newhart entry has default: true", () => {
+    assert.strictEqual(result.find((e) => e.id === "newhart")?.default, true);
+  });
+
+  it("coder entry has no default key", () => {
+    assert.strictEqual(result.find((e) => e.id === "coder")?.default, undefined);
+  });
+
+  it("gem is NOT present (not a Newhart subagent)", () => {
+    assert.strictEqual(result.find((e) => e.id === "gem"), undefined);
+  });
+
+  it("nova is NOT present", () => {
+    assert.strictEqual(result.find((e) => e.id === "nova"), undefined);
+  });
+
+  it("exactly three agents are present: newhart, coder, scout", () => {
+    assert.deepStrictEqual(
+      result.map((e) => e.id).sort(),
+      ["coder", "newhart", "scout"],
+    );
+  });
+});
+
+// ── TC-244-U-03: Mutual exclusion ───────────────────────────────────────────
+
+describe("TC-244-U-03: Mutual exclusion — NOVA and Newhart never see each other", () => {
+  const novaRows: AgentRow[] = [
+    {
+      name: "nova",
+      model: "anthropic/claude-opus-4",
+      fallback_models: null,
+      thinking: "high",
+      instance_type: "primary",
+      is_default: true,
+      allowed_subagents: ["gem", "coder", "scout"],
+    },
+    {
+      name: "coder",
+      model: "anthropic/claude-sonnet-4",
+      fallback_models: null,
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+    {
+      name: "gem",
+      model: "google/gemini-flash",
+      fallback_models: null,
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+    {
+      name: "scout",
+      model: "google/gemini-flash",
+      fallback_models: null,
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+  ];
+
+  const newhartRows: AgentRow[] = [
+    {
+      name: "newhart",
+      model: "anthropic/claude-opus-4",
+      fallback_models: null,
+      thinking: "high",
+      instance_type: "peer",
+      is_default: true,
+      allowed_subagents: ["coder", "scout"],
+    },
+    {
+      name: "coder",
+      model: "anthropic/claude-sonnet-4",
+      fallback_models: null,
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+    {
+      name: "scout",
+      model: "google/gemini-flash",
+      fallback_models: null,
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+  ];
+
+  const novaResult = buildAgentsList(novaRows);
+  const newhartResult = buildAgentsList(newhartRows);
+
+  it("nova's agent list does not include newhart", () => {
+    assert.strictEqual(
+      novaResult.find((e) => e.id === "newhart"),
+      undefined,
+    );
+  });
+
+  it("newhart's agent list does not include nova", () => {
+    assert.strictEqual(
+      newhartResult.find((e) => e.id === "nova"),
+      undefined,
+    );
+  });
+
+  it("each list has exactly one entry with default: true", () => {
+    const novaDefaults = novaResult.filter((e) => e.default === true);
+    const newhartDefaults = newhartResult.filter((e) => e.default === true);
+    assert.strictEqual(novaDefaults.length, 1);
+    assert.strictEqual(newhartDefaults.length, 1);
+  });
+
+  it("nova is default in NOVA's list", () => {
+    assert.strictEqual(novaResult.find((e) => e.id === "nova")?.default, true);
+  });
+
+  it("newhart is default in Newhart's list", () => {
+    assert.strictEqual(
+      newhartResult.find((e) => e.id === "newhart")?.default,
+      true,
+    );
+  });
+});
+
+// ── TC-244-U-04: Fallback model shape ───────────────────────────────────────
+
+describe("TC-244-U-04: Fallback model shape preserved from function rows", () => {
+  const rows: AgentRow[] = [
+    {
+      name: "coder",
+      model: "anthropic/claude-sonnet-4",
+      fallback_models: ["openai/gpt-4o", "google/gemini-pro"],
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+    {
+      name: "gem",
+      model: "google/gemini-flash",
+      fallback_models: null,
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+    {
+      name: "scout",
+      model: "google/gemini-flash",
+      fallback_models: [],
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+  ];
+
+  const result = buildAgentsList(rows);
+
+  it("coder model is object form with primary and fallbacks", () => {
+    assert.deepStrictEqual(result.find((e) => e.id === "coder")?.model, {
+      primary: "anthropic/claude-sonnet-4",
+      fallbacks: ["openai/gpt-4o", "google/gemini-pro"],
+    });
+  });
+
+  it("fallback order is preserved from DB array", () => {
+    const model = result.find((e) => e.id === "coder")?.model;
+    assert.ok(typeof model === "object" && "fallbacks" in model);
+    assert.deepStrictEqual(model.fallbacks, ["openai/gpt-4o", "google/gemini-pro"]);
+  });
+
+  it("gem with null fallback_models uses string model form", () => {
+    assert.strictEqual(result.find((e) => e.id === "gem")?.model, "google/gemini-flash");
+  });
+
+  it("scout with empty fallback_models array uses string model form", () => {
+    assert.strictEqual(
+      result.find((e) => e.id === "scout")?.model,
+      "google/gemini-flash",
+    );
+  });
+});
+
+// ── TC-244-U-05: is_default = null emits no `default` key ──────────────────
+
+describe("TC-244-U-05: Row with is_default = null emits no `default` key", () => {
+  const rows: AgentRow[] = [
+    {
+      name: "someagent",
+      model: "anthropic/claude-sonnet-4",
+      fallback_models: null,
+      thinking: null,
+      instance_type: "subagent",
+      is_default: null,
+      allowed_subagents: null,
+    },
+    {
+      name: "falseagent",
+      model: "google/gemini-flash",
+      fallback_models: null,
+      thinking: null,
+      instance_type: "subagent",
+      is_default: false,
+      allowed_subagents: null,
+    },
+  ];
+
+  const result = buildAgentsList(rows);
+
+  it("is_default = null → no default key on entry", () => {
+    const entry = result.find((e) => e.id === "someagent");
+    assert.ok(entry !== undefined);
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(entry, "default"),
+      "default key must not be present when is_default is null",
+    );
+    assert.strictEqual(entry.default, undefined);
+  });
+
+  it("is_default = false → no default key on entry", () => {
+    const entry = result.find((e) => e.id === "falseagent");
+    assert.ok(entry !== undefined);
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(entry, "default"),
+      "default key must not be present when is_default is false",
+    );
+    assert.strictEqual(entry.default, undefined);
+  });
+
+  it("only is_default = true produces default: true", () => {
+    const trueRow: AgentRow[] = [
+      {
+        name: "trueagent",
+        model: "anthropic/claude-opus-4",
+        fallback_models: null,
+        thinking: null,
+        instance_type: "primary",
+        is_default: true,
+        allowed_subagents: null,
+      },
+    ];
+    const trueResult = buildAgentsList(trueRow);
+    assert.strictEqual(trueResult[0]?.default, true);
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(trueResult[0], "default"),
+      "default key must be present when is_default is true",
+    );
+  });
+});

--- a/cognition/focus/agent-config-sync/src/sync.ts
+++ b/cognition/focus/agent-config-sync/src/sync.ts
@@ -32,12 +32,12 @@ type AgentListEntry = {
 
 // ── SQL ─────────────────────────────────────────────────────────────────────
 
+// Queries get_agent_export_rows(), which scopes results to the connecting role
+// (session_user) and subagents owning that role via `parent_agents` array overlap.
+// The function lives in nova-mind/database/schema.sql and is owned by newhart.
 const AGENTS_QUERY = `
   SELECT name, model, fallback_models, thinking, instance_type, is_default, allowed_subagents
-  FROM agents
-  WHERE instance_type != 'peer'
-    AND model IS NOT NULL
-  ORDER BY name;
+  FROM get_agent_export_rows();
 `;
 
 // ── Build ───────────────────────────────────────────────────────────────────

--- a/cognition/focus/bootstrap-context/README.md
+++ b/cognition/focus/bootstrap-context/README.md
@@ -151,12 +151,14 @@ Returns all context for an agent:
 SELECT source, filename, content FROM get_agent_bootstrap('coder');
 ```
 
-Sources returned:
-- `universal` — UNIVERSAL records
-- `global` — GLOBAL records
-- `domain:<name>` — DOMAIN records matched by agent_domains
-- `workflow:<name>` — dynamically generated from workflows + workflow_steps
-- `agent` — AGENT records matched by name
+Sources returned (UPPERCASE — these strings feed `db:${source}/${filename}` path emission in the hook handler, e.g. `db:UNIVERSAL/CORE.md`, `db:DOMAIN:Project Leadership/ORCHESTRATION.md`):
+- `UNIVERSAL` — UNIVERSAL records
+- `GLOBAL` — GLOBAL records
+- `DOMAIN:<name(s)>` — DOMAIN records matched by agent_domains; `<name(s)>` is a comma-joined list when a record is shared across multiple domains
+- `WORKFLOW:<name>` — dynamically generated from workflows + workflow_steps
+- `AGENT` — AGENT records matched by name
+
+The synthetic `db:<SOURCE>/<filename>` identifiers produced from these labels are preserved verbatim by the gateway's bootstrap-files sanitizer (see `nova-openclaw/src/agents/bootstrap-files.ts`, `SYNTHETIC_PATH_PREFIX`) — they are not resolved against the workspace root.
 
 ### Supporting tables
 

--- a/cognition/tests/TEST-CASES-ISSUE-97.md
+++ b/cognition/tests/TEST-CASES-ISSUE-97.md
@@ -1,5 +1,7 @@
 ## Test Cases for Issue #97: Add orchestrator_agent_id to workflows table
 
+> ⚠️ **Historical — partially stale as of PR #244 (2026-05).** Several test queries below match against the old lowercase source label, e.g. `source = 'workflow:test-null-orch'` and `source LIKE 'workflow%'`. After PR #244, `get_agent_bootstrap()` emits UPPERCASE source labels, so these specific assertions now return 0 rows and would need `source = 'WORKFLOW:test-null-orch'` / `source LIKE 'WORKFLOW%'` to pass. The issue this document tracks has shipped; the doc is retained as a historical artifact. Do not use it as a current test plan without re-casing the queries.
+
 **Goal:** Ensure Conductor (workflow-pm) receives ALL active workflows in her bootstrap context by adding an `orchestrator_agent_id` column to the `workflows` table and updating `get_agent_bootstrap()`.
 
 **Pre-conditions:**

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -346,7 +346,7 @@ CREATE TABLE IF NOT EXISTS agent_bootstrap_context (
     content text NOT NULL,
     description text,
     updated_at timestamptz DEFAULT now(),
-    updated_by text DEFAULT 'system',
+    updated_by text DEFAULT CURRENT_USER,
     agent_name text,
     domain_names text[],
     CONSTRAINT agent_bootstrap_context_pkey PRIMARY KEY (id),
@@ -597,7 +597,6 @@ CREATE TABLE IF NOT EXISTS agents (
     is_default boolean DEFAULT false NOT NULL,
     context_type text DEFAULT 'persistent' NOT NULL,
     model_rationale text,
-    entity_id integer,
     CONSTRAINT agents_pkey PRIMARY KEY (id),
     CONSTRAINT agents_name_key UNIQUE (name),
     CONSTRAINT agents_context_type_check CHECK (context_type IN ('ephemeral'::text, 'persistent'::text)),
@@ -648,12 +647,6 @@ COMMENT ON COLUMN agents.decision_criteria IS 'Criteria for when to spawn this a
 
 
 COMMENT ON COLUMN agents.model_rationale IS 'Model selection goals and justification: WHY this agent uses its model, what the role requires, past issues that drove changes, tradeoffs considered. Maintained by Newhart for weekly agent review.';
-
---
--- Name: idx_agents_entity_id; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_agents_entity_id ON agents (entity_id);
 
 --
 -- Name: idx_agents_single_default; Type: INDEX; Schema: -; Owner: -
@@ -921,6 +914,20 @@ CREATE TABLE IF NOT EXISTS bootstrap_context_config (
 COMMENT ON TABLE bootstrap_context_config IS 'Configuration for bootstrap system behavior';
 
 --
+-- Name: channel_activity; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS channel_activity (
+    channel varchar(50),
+    last_message_at timestamptz DEFAULT now(),
+    last_message_from varchar(100),
+    CONSTRAINT channel_activity_pkey PRIMARY KEY (channel)
+);
+
+
+COMMENT ON TABLE channel_activity IS 'Tracks last message per channel for idle detection. Read/write: NOVA, Newhart.';
+
+--
 -- Name: channel_sessions; Type: TABLE; Schema: -; Owner: -
 --
 
@@ -1131,12 +1138,11 @@ CREATE TABLE IF NOT EXISTS agent_domains (
     domain_topic varchar(255) NOT NULL,
     source_entity_id integer,
     vote_count integer DEFAULT 1,
-    priority integer DEFAULT 1,
     created_at timestamp DEFAULT now(),
     last_confirmed timestamp DEFAULT now(),
     notes text,
     CONSTRAINT agent_domains_pkey PRIMARY KEY (id),
-    CONSTRAINT agent_domains_agent_id_domain_topic_key UNIQUE (agent_id, domain_topic),
+    CONSTRAINT agent_domains_domain_topic_key UNIQUE (domain_topic),
     CONSTRAINT agent_domains_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES agents (id) ON DELETE CASCADE,
     CONSTRAINT agent_domains_source_entity_id_fkey FOREIGN KEY (source_entity_id) REFERENCES entities (id)
 );
@@ -1164,33 +1170,6 @@ CREATE INDEX IF NOT EXISTS idx_agent_domains_agent ON agent_domains (agent_id);
 --
 
 CREATE INDEX IF NOT EXISTS idx_agent_domains_topic ON agent_domains (domain_topic);
-
---
--- Name: user_domains; Type: TABLE; Schema: -; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS user_domains (
-    id SERIAL PRIMARY KEY,
-    entity_id integer NOT NULL,
-    domain_topic varchar(255) NOT NULL,
-    priority integer DEFAULT 1,
-    notes text,
-    created_at timestamp DEFAULT now(),
-    CONSTRAINT user_domains_entity_domain_key UNIQUE (entity_id, domain_topic),
-    CONSTRAINT user_domains_entity_id_fkey FOREIGN KEY (entity_id) REFERENCES entities (id) ON DELETE CASCADE
-);
-
---
--- Name: idx_user_domains_entity; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_user_domains_entity ON user_domains (entity_id);
-
---
--- Name: idx_user_domains_topic; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_user_domains_topic ON user_domains (domain_topic);
 
 --
 -- Name: certificates; Type: TABLE; Schema: -; Owner: -
@@ -1762,32 +1741,6 @@ CREATE TABLE IF NOT EXISTS job_messages (
 COMMENT ON TABLE job_messages IS 'Message log per job for conversation threading';
 
 --
--- Name: lessons; Type: TABLE; Schema: -; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS lessons (
-    id SERIAL,
-    lesson text NOT NULL,
-    context text,
-    source varchar(255),
-    learned_at timestamp DEFAULT CURRENT_TIMESTAMP,
-    original_behavior text,
-    correction_source text,
-    reinforced_at timestamp,
-    confidence double precision DEFAULT 1.0,
-    last_referenced timestamp,
-    last_confirmed_at timestamptz DEFAULT now(),
-    updated_at timestamp DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT lessons_pkey PRIMARY KEY (id)
-);
-
-
-COMMENT ON TABLE lessons IS 'Lessons and insights learned. Update when learning something worth remembering.';
-
-
-COMMENT ON COLUMN lessons.confidence IS 'Confidence score 0-1, decays over time if not reinforced';
-
---
 -- Name: lessons_archive; Type: TABLE; Schema: -; Owner: -
 --
 
@@ -2294,113 +2247,6 @@ CREATE TABLE IF NOT EXISTS music_analysis (
 COMMENT ON TABLE music_analysis IS 'Deep musical analysis (harmonic, rhythmic, lyrical, spectral). Managed by Erato.';
 
 --
--- Name: music_works; Type: TABLE; Schema: -; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS music_works (
-    id SERIAL,
-    title varchar(255) NOT NULL,
-    description text,
-    created_by integer,
-    generation_model varchar(255),
-    generation_prompt text,
-    generation_params jsonb DEFAULT '{}',
-    source_type varchar(50) DEFAULT 'ai_generated' NOT NULL,
-    key varchar(10),
-    bpm numeric,
-    time_signature varchar(10),
-    duration_ms integer,
-    genre varchar(100),
-    subgenre varchar(100),
-    mood varchar(100),
-    energy_level integer,
-    danceability integer,
-    structure text,
-    instruments text[],
-    vocal_style varchar(100),
-    file_format varchar(20),
-    sample_rate integer,
-    bit_depth integer,
-    bitrate integer,
-    version integer DEFAULT 1 NOT NULL,
-    parent_work_id integer,
-    iteration_notes text,
-    lyrics text,
-    language varchar(10),
-    status varchar(50) DEFAULT 'draft' NOT NULL,
-    tags text[],
-    rating integer,
-    notes text,
-    created_at timestamp DEFAULT now() NOT NULL,
-    updated_at timestamp DEFAULT now() NOT NULL,
-    search_vector tsvector,
-    published_platforms jsonb DEFAULT '{}',
-    audio_data bytea,
-    audio_filename text,
-    cover_image_data bytea,
-    cover_image_filename text,
-    CONSTRAINT music_works_pkey PRIMARY KEY (id),
-    CONSTRAINT music_works_parent_work_id_fkey FOREIGN KEY (parent_work_id) REFERENCES music_works (id),
-    CONSTRAINT music_works_danceability_check CHECK (danceability >= 1 AND danceability <= 10),
-    CONSTRAINT music_works_energy_level_check CHECK (energy_level >= 1 AND energy_level <= 10),
-    CONSTRAINT music_works_rating_check CHECK (rating >= 1 AND rating <= 10)
-);
-
-
-COMMENT ON TABLE music_works IS 'Original music compositions (AI-generated or human-composed). Complements music_library which holds collected external sources.';
-
-
-COMMENT ON COLUMN music_works.published_platforms IS 'Publishing record: platform URLs/IDs. Example: {"wavlake": {"url": "...", "track_id": "..."}, "nostr": {"event_id": "..."}}';
-
-
-COMMENT ON COLUMN music_works.audio_data IS 'Binary audio data for produced works. Matches artwork.image_data pattern. WIP audio stays on disk.';
-
-
-COMMENT ON COLUMN music_works.audio_filename IS 'Original filename of the audio file (e.g. midnight-drive-v3.wav)';
-
-
-COMMENT ON COLUMN music_works.cover_image_data IS 'Cover art binary blob, same pattern as artwork.image_data and audio_data.';
-
-
-COMMENT ON COLUMN music_works.cover_image_filename IS 'Original filename of cover art image.';
-
---
--- Name: idx_music_works_created_by; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_music_works_created_by ON music_works (created_by);
-
---
--- Name: idx_music_works_genre; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_music_works_genre ON music_works (genre);
-
---
--- Name: idx_music_works_parent; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_music_works_parent ON music_works (parent_work_id);
-
---
--- Name: idx_music_works_search; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_music_works_search ON music_works USING gin (search_vector);
-
---
--- Name: idx_music_works_source_type; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_music_works_source_type ON music_works (source_type);
-
---
--- Name: idx_music_works_status; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_music_works_status ON music_works (status);
-
---
 -- Name: places; Type: TABLE; Schema: -; Owner: -
 --
 
@@ -2649,46 +2495,6 @@ COMMENT ON TABLE positions IS 'Legacy or alternative positions tracking table. M
 --
 
 CREATE INDEX IF NOT EXISTS idx_positions_account ON positions (account_id) WHERE (sold_at IS NULL);
-
---
--- Name: proactive_outreach; Type: TABLE; Schema: -; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS proactive_outreach (
-    id SERIAL PRIMARY KEY,
-    entity_id integer NOT NULL,
-    blocker_type varchar(50) NOT NULL,
-    blocker_id integer NOT NULL,
-    channel_used varchar(50) NOT NULL,
-    channel_target text,
-    message_summary text,
-    attempted_at timestamptz DEFAULT now(),
-    response_received boolean DEFAULT false,
-    response_at timestamptz,
-    notes text,
-    CONSTRAINT proactive_outreach_entity_id_fkey FOREIGN KEY (entity_id) REFERENCES entities (id)
-);
-
---
--- Name: idx_proactive_outreach_entity; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_proactive_outreach_entity ON proactive_outreach (entity_id);
-
---
--- Name: idx_proactive_outreach_blocker; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_proactive_outreach_blocker ON proactive_outreach (blocker_type, blocker_id);
-
---
--- Name: idx_proactive_outreach_cooldown; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_proactive_outreach_cooldown ON proactive_outreach (entity_id, blocker_type, blocker_id, attempted_at);
-
---
-COMMENT ON TABLE proactive_outreach IS 'Tracks proactive outreach attempts for blocked tasks. Channel escalation: Discord -> Signal -> Slack -> Email with 3-day cooldown.';
 
 --
 -- Name: preferences; Type: TABLE; Schema: -; Owner: -
@@ -3236,78 +3042,6 @@ CREATE TABLE IF NOT EXISTS tags (
 );
 
 --
--- Name: tasks; Type: TABLE; Schema: -; Owner: -
---
-
-CREATE TABLE IF NOT EXISTS tasks (
-    id SERIAL,
-    title varchar(255) NOT NULL,
-    description text,
-    status varchar(50) DEFAULT 'pending',
-    priority integer DEFAULT 5,
-    parent_task_id integer,
-    project_id integer,
-    assigned_to integer NOT NULL,
-    created_by integer NOT NULL,
-    due_date timestamp,
-    completed_at timestamp,
-    notes text,
-    created_at timestamp DEFAULT CURRENT_TIMESTAMP,
-    updated_at timestamp DEFAULT CURRENT_TIMESTAMP,
-    task_number integer,
-    blocked boolean DEFAULT false,
-    blocked_reason text,
-    blocked_on integer,
-    last_worked_at timestamptz,
-    work_notes text,
-    task_type varchar(20) DEFAULT 'one_off',
-    recurrence_interval interval,
-    last_completed_at timestamptz,
-    CONSTRAINT tasks_pkey PRIMARY KEY (id),
-    CONSTRAINT tasks_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES entities (id),
-    CONSTRAINT tasks_blocked_on_fkey FOREIGN KEY (blocked_on) REFERENCES entities (id),
-    CONSTRAINT tasks_created_by_fkey FOREIGN KEY (created_by) REFERENCES entities (id),
-    CONSTRAINT tasks_parent_task_id_fkey FOREIGN KEY (parent_task_id) REFERENCES tasks (id) ON DELETE CASCADE,
-    CONSTRAINT tasks_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE SET NULL
-);
-
-
-COMMENT ON TABLE tasks IS 'Task tracking. NOVA can create, update status, assign. Check before starting work.';
-
-
-COMMENT ON COLUMN tasks.task_type IS 'one_off = complete once, recurring = resets after completion, fallback = low-priority repeatable when idle';
-
-
-COMMENT ON COLUMN tasks.recurrence_interval IS 'How often recurring tasks reset (e.g., 1 day, 1 week)';
-
-
-COMMENT ON COLUMN tasks.last_completed_at IS 'When task was last completed (for recurring reset logic)';
-
---
--- Name: idx_tasks_parent; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks (parent_task_id);
-
---
--- Name: idx_tasks_priority; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_tasks_priority ON tasks (priority);
-
---
--- Name: idx_tasks_project; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_tasks_project ON tasks (project_id);
-
---
--- Name: idx_tasks_status; Type: INDEX; Schema: -; Owner: -
---
-
-CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks (status);
-
---
 -- Name: ticker_portfolio; Type: TABLE; Schema: -; Owner: -
 --
 
@@ -3392,6 +3126,41 @@ COMMENT ON TABLE unsolved_problems IS 'Humanity''s unsolved problems for NOVA to
 --
 
 CREATE INDEX IF NOT EXISTS idx_unsolved_problems_priority ON unsolved_problems (priority DESC);
+
+--
+-- Name: user_insights; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS user_insights (
+    id SERIAL,
+    insight text NOT NULL,
+    context text,
+    contributed_by integer,
+    source varchar(100),
+    tags text[],
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now(),
+    CONSTRAINT user_insights_pkey PRIMARY KEY (id),
+    CONSTRAINT user_insights_contributed_by_fkey FOREIGN KEY (contributed_by) REFERENCES entities (id)
+);
+
+
+COMMENT ON TABLE user_insights IS 'Human-contributed insights — observations, realizations, and wisdom shared by users. Primarily for users to save important insights. Managed by any agent on behalf of the contributing user.';
+
+
+COMMENT ON COLUMN user_insights.insight IS 'The insight itself — the core observation or realization';
+
+
+COMMENT ON COLUMN user_insights.context IS 'Surrounding context — what prompted the insight, what it relates to';
+
+
+COMMENT ON COLUMN user_insights.contributed_by IS 'Entity ID of the human who shared the insight';
+
+
+COMMENT ON COLUMN user_insights.source IS 'Where/how the insight was shared (e.g., discord, conversation, etc.)';
+
+
+COMMENT ON COLUMN user_insights.tags IS 'Categorical tags for grouping and retrieval';
 
 --
 -- Name: vehicles; Type: TABLE; Schema: -; Owner: -
@@ -3508,7 +3277,7 @@ CREATE TABLE IF NOT EXISTS workflows (
     description text NOT NULL,
     created_at timestamptz DEFAULT now(),
     updated_at timestamptz DEFAULT now(),
-    created_by text DEFAULT 'newhart',
+    created_by text DEFAULT CURRENT_USER,
     status text DEFAULT 'active',
     tags text[] DEFAULT '{}',
     department text,
@@ -6270,6 +6039,21 @@ END;
 $$;
 
 --
+-- Name: update_user_insights_updated_at(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION update_user_insights_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
+
+--
 -- Name: update_work_status_on_publication(); Type: FUNCTION; Schema: -; Owner: -
 --
 
@@ -6401,6 +6185,243 @@ CREATE INDEX IF NOT EXISTS idx_journal_created ON journal_entries (created_at DE
 --
 
 CREATE INDEX IF NOT EXISTS idx_journal_trigger ON journal_entries (trigger);
+
+--
+-- Name: lessons; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS lessons (
+    id SERIAL,
+    lesson text NOT NULL,
+    context text,
+    source varchar(255),
+    learned_at timestamp DEFAULT CURRENT_TIMESTAMP,
+    original_behavior text,
+    correction_source text,
+    reinforced_at timestamp,
+    confidence double precision DEFAULT 1.0,
+    last_referenced timestamp,
+    last_confirmed_at timestamptz DEFAULT now(),
+    updated_at timestamp DEFAULT CURRENT_TIMESTAMP,
+    learned_by integer DEFAULT current_agent_id(),
+    CONSTRAINT lessons_pkey PRIMARY KEY (id)
+);
+
+
+COMMENT ON TABLE lessons IS 'Lessons and insights learned. Update when learning something worth remembering.';
+
+
+COMMENT ON COLUMN lessons.confidence IS 'Confidence score 0-1, decays over time if not reinforced';
+
+--
+-- Name: music_works; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS music_works (
+    id SERIAL,
+    title varchar(255) NOT NULL,
+    description text,
+    created_by integer DEFAULT current_agent_id(),
+    generation_model varchar(255),
+    generation_prompt text,
+    generation_params jsonb DEFAULT '{}',
+    source_type varchar(50) DEFAULT 'ai_generated' NOT NULL,
+    key varchar(10),
+    bpm numeric,
+    time_signature varchar(10),
+    duration_ms integer,
+    genre varchar(100),
+    subgenre varchar(100),
+    mood varchar(100),
+    energy_level integer,
+    danceability integer,
+    structure text,
+    instruments text[],
+    vocal_style varchar(100),
+    file_format varchar(20),
+    sample_rate integer,
+    bit_depth integer,
+    bitrate integer,
+    version integer DEFAULT 1 NOT NULL,
+    parent_work_id integer,
+    iteration_notes text,
+    lyrics text,
+    language varchar(10),
+    status varchar(50) DEFAULT 'draft' NOT NULL,
+    tags text[],
+    rating integer,
+    notes text,
+    created_at timestamp DEFAULT now() NOT NULL,
+    updated_at timestamp DEFAULT now() NOT NULL,
+    search_vector tsvector,
+    published_platforms jsonb DEFAULT '{}',
+    audio_data bytea,
+    audio_filename text,
+    cover_image_data bytea,
+    cover_image_filename text,
+    CONSTRAINT music_works_pkey PRIMARY KEY (id),
+    CONSTRAINT music_works_parent_work_id_fkey FOREIGN KEY (parent_work_id) REFERENCES music_works (id),
+    CONSTRAINT music_works_danceability_check CHECK (danceability >= 1 AND danceability <= 10),
+    CONSTRAINT music_works_energy_level_check CHECK (energy_level >= 1 AND energy_level <= 10),
+    CONSTRAINT music_works_rating_check CHECK (rating >= 1 AND rating <= 10)
+);
+
+
+COMMENT ON TABLE music_works IS 'Original music compositions (AI-generated or human-composed). Complements music_library which holds collected external sources.';
+
+
+COMMENT ON COLUMN music_works.published_platforms IS 'Publishing record: platform URLs/IDs. Example: {"wavlake": {"url": "...", "track_id": "..."}, "nostr": {"event_id": "..."}}';
+
+
+COMMENT ON COLUMN music_works.audio_data IS 'Binary audio data for produced works. Matches artwork.image_data pattern. WIP audio stays on disk.';
+
+
+COMMENT ON COLUMN music_works.audio_filename IS 'Original filename of the audio file (e.g. midnight-drive-v3.wav)';
+
+
+COMMENT ON COLUMN music_works.cover_image_data IS 'Cover art binary blob, same pattern as artwork.image_data and audio_data.';
+
+
+COMMENT ON COLUMN music_works.cover_image_filename IS 'Original filename of cover art image.';
+
+--
+-- Name: idx_music_works_created_by; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_music_works_created_by ON music_works (created_by);
+
+--
+-- Name: idx_music_works_genre; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_music_works_genre ON music_works (genre);
+
+--
+-- Name: idx_music_works_parent; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_music_works_parent ON music_works (parent_work_id);
+
+--
+-- Name: idx_music_works_search; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_music_works_search ON music_works USING gin (search_vector);
+
+--
+-- Name: idx_music_works_source_type; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_music_works_source_type ON music_works (source_type);
+
+--
+-- Name: idx_music_works_status; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_music_works_status ON music_works (status);
+
+--
+-- Name: tasks; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id SERIAL,
+    title varchar(255) NOT NULL,
+    description text,
+    status varchar(50) DEFAULT 'pending',
+    priority integer DEFAULT 5,
+    parent_task_id integer,
+    project_id integer,
+    assigned_to integer NOT NULL,
+    created_by integer DEFAULT current_agent_id() NOT NULL,
+    due_date timestamp,
+    completed_at timestamp,
+    notes text,
+    created_at timestamp DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp DEFAULT CURRENT_TIMESTAMP,
+    task_number integer,
+    blocked boolean DEFAULT false,
+    blocked_reason text,
+    blocked_on integer,
+    last_worked_at timestamptz,
+    work_notes text,
+    task_type varchar(20) DEFAULT 'one_off',
+    recurrence_interval interval,
+    last_completed_at timestamptz,
+    CONSTRAINT tasks_pkey PRIMARY KEY (id),
+    CONSTRAINT tasks_parent_task_id_fkey FOREIGN KEY (parent_task_id) REFERENCES tasks (id) ON DELETE CASCADE
+);
+
+
+COMMENT ON TABLE tasks IS 'Task tracking. NOVA can create, update status, assign. Check before starting work.';
+
+
+COMMENT ON COLUMN tasks.task_type IS 'one_off = complete once, recurring = resets after completion, fallback = low-priority repeatable when idle';
+
+
+COMMENT ON COLUMN tasks.recurrence_interval IS 'How often recurring tasks reset (e.g., 1 day, 1 week)';
+
+
+COMMENT ON COLUMN tasks.last_completed_at IS 'When task was last completed (for recurring reset logic)';
+
+--
+-- Name: idx_tasks_parent; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks (parent_task_id);
+
+--
+-- Name: idx_tasks_priority; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_tasks_priority ON tasks (priority);
+
+--
+-- Name: idx_tasks_project; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_tasks_project ON tasks (project_id);
+
+--
+-- Name: idx_tasks_status; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks (status);
+
+--
+-- Name: lessons_learned_by_fkey; Type: CONSTRAINT; Schema: -; Owner: -
+--
+
+ALTER TABLE lessons
+ADD CONSTRAINT lessons_learned_by_fkey FOREIGN KEY (learned_by) REFERENCES agents (id);
+
+--
+-- Name: tasks_assigned_to_fkey; Type: CONSTRAINT; Schema: -; Owner: -
+--
+
+ALTER TABLE tasks
+ADD CONSTRAINT tasks_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES entities (id);
+
+--
+-- Name: tasks_blocked_on_fkey; Type: CONSTRAINT; Schema: -; Owner: -
+--
+
+ALTER TABLE tasks
+ADD CONSTRAINT tasks_blocked_on_fkey FOREIGN KEY (blocked_on) REFERENCES entities (id);
+
+--
+-- Name: tasks_created_by_fkey; Type: CONSTRAINT; Schema: -; Owner: -
+--
+
+ALTER TABLE tasks
+ADD CONSTRAINT tasks_created_by_fkey FOREIGN KEY (created_by) REFERENCES entities (id);
+
+--
+-- Name: tasks_project_id_fkey; Type: CONSTRAINT; Schema: -; Owner: -
+--
+
+ALTER TABLE tasks
+ADD CONSTRAINT tasks_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE SET NULL;
 
 --
 -- Name: agent_config_changed; Type: TRIGGER; Schema: -; Owner: -
@@ -6907,6 +6928,15 @@ CREATE OR REPLACE TRIGGER trg_tasks_force_created_by
     EXECUTE FUNCTION tasks_force_created_by();
 
 --
+-- Name: trigger_user_insights_updated_at; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER trigger_user_insights_updated_at
+    BEFORE UPDATE ON user_insights
+    FOR EACH ROW
+    EXECUTE FUNCTION update_user_insights_updated_at();
+
+--
 -- Name: workflow_step_change_trigger; Type: TRIGGER; Schema: -; Owner: -
 --
 
@@ -7369,13 +7399,13 @@ CREATE OR REPLACE VIEW workflow_steps_detail AS
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_actions FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
+REVOKE SELECT ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7513,13 +7543,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM ticker;
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_chat FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
+REVOKE SELECT ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7651,13 +7681,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM iris;
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_modifications FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
+REVOKE SELECT ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7681,13 +7711,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM ticker;
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
+REVOKE SELECT ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_spawns FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7807,13 +7837,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agents FROM iris;
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
+REVOKE SELECT ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agents FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7903,25 +7933,25 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
-
---
--- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE asset_classes FROM ticker;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
+
+--
+-- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7963,13 +7993,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7994,6 +8024,12 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM ticker;
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE certificates FROM nova;
+
+--
+-- Name: channel_activity; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE channel_activity FROM nova;
 
 --
 -- Name: channel_sessions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8683,7 +8719,7 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE journal_entries FROM marcie;
 -- Name: journal_entries; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, UPDATE ON TABLE journal_entries FROM newhart;
+REVOKE DELETE, UPDATE ON TABLE journal_entries FROM newhart;
 
 --
 -- Name: journal_entries; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8731,13 +8767,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8797,13 +8833,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8863,13 +8899,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8995,13 +9031,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_relationships FROM ticker;
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
+REVOKE SELECT ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9205,25 +9241,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM argus;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM athena;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM athena;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM coder;
+REVOKE SELECT ON TABLE music_works FROM athena;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM coder;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE music_works FROM coder;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9331,13 +9367,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM marcie;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM newhart;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM newhart;
+REVOKE SELECT ON TABLE music_works FROM newhart;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9397,13 +9433,13 @@ REVOKE SELECT ON TABLE music_works FROM scribe;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM ticker;
+REVOKE SELECT ON TABLE music_works FROM ticker;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM ticker;
 
 --
 -- Name: place_properties; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9421,13 +9457,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE places FROM nova;
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9469,25 +9505,25 @@ REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
-
---
--- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
+REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
+
+--
+-- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9733,13 +9769,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_findings FROM nova;
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_findings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
+REVOKE SELECT ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9799,13 +9835,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_projects FROM nova;
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
+REVOKE SELECT ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_projects FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9865,13 +9901,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -10063,13 +10099,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tasks FROM nova;
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
+REVOKE SELECT ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tasks FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tasks FROM scout;
 
 --
 -- Name: research_tasks; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -10154,6 +10190,108 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE tools FROM nova;
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE unsolved_problems FROM nova;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM argus;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM athena;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM coder;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM conductor;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM erato;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM flint;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM gem;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM gidget;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM hermes;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM iris;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM marcie;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM newhart;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE user_insights FROM nova;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM quill;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM scout;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM scribe;
+
+--
+-- Name: user_insights; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, UPDATE ON TABLE user_insights FROM ticker;
 
 --
 -- Name: vehicles; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -10298,6 +10436,18 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE works FROM nova;
 --
 
 GRANT EXECUTE ON FUNCTION complete_d100(p_roll integer) TO nova;
+
+--
+-- Name: current_agent_id(); Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+GRANT EXECUTE ON FUNCTION current_agent_id() TO graybeard;
+
+--
+-- Name: current_agent_id(); Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+GRANT EXECUTE ON FUNCTION current_agent_id() TO newhart;
 
 --
 -- Name: roll_d100(); Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -12992,6 +13142,18 @@ GRANT USAGE ON SEQUENCE job_messages_id_seq TO scribe;
 --
 
 GRANT USAGE ON SEQUENCE job_messages_id_seq TO ticker;
+
+--
+-- Name: journal_entries_id_seq; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+GRANT SELECT, USAGE ON SEQUENCE journal_entries_id_seq TO graybeard;
+
+--
+-- Name: journal_entries_id_seq; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+GRANT SELECT, USAGE ON SEQUENCE journal_entries_id_seq TO newhart;
 
 --
 -- Name: lessons_archive_id_seq; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -17728,6 +17890,12 @@ GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context TO graybeard;
 GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE certificates TO graybeard;
 
 --
+-- Name: channel_activity; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE channel_activity TO graybeard;
+
+--
 -- Name: entities; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
@@ -17834,6 +18002,12 @@ GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE gambling_logs TO graybeard;
 --
 
 GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE job_messages TO graybeard;
+
+--
+-- Name: journal_entries; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+GRANT INSERT, SELECT ON TABLE journal_entries TO graybeard;
 
 --
 -- Name: lessons; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -597,10 +597,9 @@ CREATE TABLE IF NOT EXISTS agents (
     is_default boolean DEFAULT false NOT NULL,
     context_type text DEFAULT 'persistent' NOT NULL,
     model_rationale text,
-    parent_agent varchar(100),
+    parent_agents text[],
     CONSTRAINT agents_pkey PRIMARY KEY (id),
     CONSTRAINT agents_name_key UNIQUE (name),
-    CONSTRAINT agents_parent_agent_fkey FOREIGN KEY (parent_agent) REFERENCES agents (name) ON UPDATE CASCADE ON DELETE SET NULL,
     CONSTRAINT agents_context_type_check CHECK (context_type IN ('ephemeral'::text, 'persistent'::text)),
     CONSTRAINT agents_thinking_check CHECK (thinking::text IN ('off'::character varying, 'minimal'::character varying, 'low'::character varying, 'medium'::character varying, 'high'::character varying, 'xhigh'::character varying))
 );
@@ -651,7 +650,7 @@ COMMENT ON COLUMN agents.decision_criteria IS 'Criteria for when to spawn this a
 COMMENT ON COLUMN agents.model_rationale IS 'Model selection goals and justification: WHY this agent uses its model, what the role requires, past issues that drove changes, tradeoffs considered. Maintained by Newhart for weekly agent review.';
 
 
-COMMENT ON COLUMN agents.parent_agent IS 'For subagent rows: the name of the peer/primary agent whose gateway owns this subagent (its parent). Used by get_agent_export_rows() to scope each gateway''s agents.json to only its own subagents. NULL for peer/primary agents themselves.';
+COMMENT ON COLUMN agents.parent_agents IS 'For subagent rows: array of peer/primary agent names whose gateways own this subagent. A subagent may have multiple parents (e.g. scout is shared by all peers). Used by get_agent_export_rows() to scope each gateway''s agents.json. NULL/empty for peer/primary agents themselves.';
 
 --
 -- Name: idx_agents_single_default; Type: INDEX; Schema: -; Owner: -
@@ -4093,7 +4092,6 @@ RETURNS TABLE(name text, model text, fallback_models text[], thinking text, inst
 LANGUAGE sql
 STABLE
 AS $$
-  -- The connecting agent (peer or primary) as the gateway default.
   SELECT
     a.name::text,
     a.model::text,
@@ -4109,7 +4107,6 @@ AS $$
 
   UNION ALL
 
-  -- Subagents owned by the connecting agent.
   SELECT
     a.name::text,
     a.model::text,
@@ -4119,11 +4116,11 @@ AS $$
     FALSE AS is_default,
     a.allowed_subagents
   FROM agents a
-  WHERE a.parent_agent = session_user
+  WHERE session_user = ANY (a.parent_agents)
     AND a.status = 'active'
     AND a.model IS NOT NULL
 
-  ORDER BY 6 DESC, 1;  -- default first, then alphabetical by name
+  ORDER BY 6 DESC, 1;
 $$;
 
 --
@@ -6199,6 +6196,40 @@ END;
 $$;
 
 --
+-- Name: validate_parent_agents(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION validate_parent_agents()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+DECLARE
+  v_bad_name text;
+BEGIN
+  IF NEW.parent_agents IS NULL OR array_length(NEW.parent_agents, 1) IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Every element must reference an existing agent
+  SELECT u INTO v_bad_name
+  FROM unnest(NEW.parent_agents) AS u
+  WHERE NOT EXISTS (SELECT 1 FROM agents WHERE name = u);
+
+  IF v_bad_name IS NOT NULL THEN
+    RAISE EXCEPTION 'parent_agents references non-existent agent: %', v_bad_name;
+  END IF;
+
+  -- No self-parent
+  IF NEW.name = ANY (NEW.parent_agents) THEN
+    RAISE EXCEPTION 'agent % cannot be its own parent', NEW.name;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+--
 -- Name: journal_entries; Type: TABLE; Schema: -; Owner: -
 --
 
@@ -6990,6 +7021,15 @@ CREATE OR REPLACE TRIGGER trigger_user_insights_updated_at
     EXECUTE FUNCTION update_user_insights_updated_at();
 
 --
+-- Name: validate_parent_agents_trigger; Type: TRIGGER; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE TRIGGER validate_parent_agents_trigger
+    BEFORE INSERT OR UPDATE ON agents
+    FOR EACH ROW
+    EXECUTE FUNCTION validate_parent_agents();
+
+--
 -- Name: workflow_step_change_trigger; Type: TRIGGER; Schema: -; Owner: -
 --
 
@@ -7452,13 +7492,13 @@ CREATE OR REPLACE VIEW workflow_steps_detail AS
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_actions FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
+REVOKE SELECT ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7596,13 +7636,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM ticker;
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
+REVOKE SELECT ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_chat FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_chat FROM newhart;
 
 --
 -- Name: agent_chat_processed; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7686,13 +7726,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7842,13 +7882,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7986,25 +8026,25 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
-
---
--- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE asset_classes FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
+
+--
+-- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8046,13 +8086,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8688,13 +8728,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE gambling_logs FROM nova;
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
+REVOKE SELECT ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE git_issue_queue FROM coder;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: job_messages; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8886,13 +8926,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8952,13 +8992,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9150,13 +9190,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_tags FROM ticker;
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_works FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
+REVOKE SELECT ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9270,25 +9310,25 @@ REVOKE SELECT ON TABLE music_analysis FROM iris;
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
+REVOKE SELECT ON TABLE music_library FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_library FROM iris;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM argus;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE music_works FROM argus;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM argus;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9318,13 +9358,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM coder;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM conductor;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM conductor;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM conductor;
+REVOKE SELECT ON TABLE music_works FROM conductor;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9342,13 +9382,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM erato;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM flint;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM flint;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM flint;
+REVOKE SELECT ON TABLE music_works FROM flint;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9408,13 +9448,13 @@ REVOKE SELECT ON TABLE music_works FROM iris;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM marcie;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM marcie;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM marcie;
+REVOKE SELECT ON TABLE music_works FROM marcie;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9474,25 +9514,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scout;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM scribe;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scribe;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM ticker;
+REVOKE SELECT ON TABLE music_works FROM scribe;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE music_works FROM ticker;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM ticker;
 
 --
 -- Name: place_properties; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9582,13 +9622,13 @@ REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE positions FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
+REVOKE SELECT ON TABLE positions FROM ticker;
 
 --
 -- Name: preferences; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9600,13 +9640,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE preferences FROM nova;
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
+REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: project_entities; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9756,13 +9796,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9888,13 +9928,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_projects FROM nova;
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
+REVOKE SELECT ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_projects FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9954,13 +9994,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -10020,13 +10060,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -597,8 +597,10 @@ CREATE TABLE IF NOT EXISTS agents (
     is_default boolean DEFAULT false NOT NULL,
     context_type text DEFAULT 'persistent' NOT NULL,
     model_rationale text,
+    parent_agent varchar(100),
     CONSTRAINT agents_pkey PRIMARY KEY (id),
     CONSTRAINT agents_name_key UNIQUE (name),
+    CONSTRAINT agents_parent_agent_fkey FOREIGN KEY (parent_agent) REFERENCES agents (name) ON UPDATE CASCADE ON DELETE SET NULL,
     CONSTRAINT agents_context_type_check CHECK (context_type IN ('ephemeral'::text, 'persistent'::text)),
     CONSTRAINT agents_thinking_check CHECK (thinking::text IN ('off'::character varying, 'minimal'::character varying, 'low'::character varying, 'medium'::character varying, 'high'::character varying, 'xhigh'::character varying))
 );
@@ -647,6 +649,9 @@ COMMENT ON COLUMN agents.decision_criteria IS 'Criteria for when to spawn this a
 
 
 COMMENT ON COLUMN agents.model_rationale IS 'Model selection goals and justification: WHY this agent uses its model, what the role requires, past issues that drove changes, tradeoffs considered. Maintained by Newhart for weekly agent review.';
+
+
+COMMENT ON COLUMN agents.parent_agent IS 'For subagent rows: the name of the peer/primary agent whose gateway owns this subagent (its parent). Used by get_agent_export_rows() to scope each gateway''s agents.json to only its own subagents. NULL for peer/primary agents themselves.';
 
 --
 -- Name: idx_agents_single_default; Type: INDEX; Schema: -; Owner: -
@@ -4121,7 +4126,10 @@ BEGIN
 
       UNION ALL
 
-      -- Non-peer agents this peer is allowed to spawn.
+      -- Subagents this peer is allowed to spawn.
+      -- Wildcard '*' expands to all rows with instance_type = 'subagent'.
+      -- (Peer and primary agents are intentionally excluded — they each run
+      -- their own gateway and are not spawned as subagents of another peer.)
       SELECT
         a.name::text,
         a.model::text,
@@ -4131,14 +4139,12 @@ BEGIN
         FALSE AS is_default,
         a.allowed_subagents
       FROM agents a
-      WHERE a.instance_type <> 'peer'
+      WHERE a.instance_type = 'subagent'
         AND a.model IS NOT NULL
+        AND v_owner_row.allowed_subagents IS NOT NULL
         AND (
-          v_owner_row.allowed_subagents IS NOT NULL
-          AND (
-            '*' = ANY (v_owner_row.allowed_subagents)
-            OR a.name = ANY (v_owner_row.allowed_subagents)
-          )
+          '*' = ANY (v_owner_row.allowed_subagents)
+          OR a.name = ANY (v_owner_row.allowed_subagents)
         )
       ORDER BY 1;
 
@@ -7489,13 +7495,13 @@ CREATE OR REPLACE VIEW workflow_steps_detail AS
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_actions FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
+REVOKE SELECT ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7537,13 +7543,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_aliases FROM iris;
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_aliases FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_aliases FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_aliases FROM newhart;
+REVOKE SELECT ON TABLE agent_aliases FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7603,13 +7609,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM iris;
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7723,13 +7729,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7771,13 +7777,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM iris;
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_modifications FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
+REVOKE SELECT ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7801,13 +7807,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM ticker;
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
+REVOKE SELECT ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_spawns FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7879,13 +7885,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7993,13 +7999,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM iris;
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
+REVOKE SELECT ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ai_models FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8023,25 +8029,25 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
-
---
--- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE asset_classes FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
+
+--
+-- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8083,13 +8089,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8725,13 +8731,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE gambling_logs FROM nova;
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE git_issue_queue FROM coder;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
+REVOKE SELECT ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: job_messages; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8989,13 +8995,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9121,13 +9127,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_relationships FROM ticker;
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
+REVOKE SELECT ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9187,13 +9193,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_tags FROM ticker;
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_works FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
+REVOKE SELECT ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9295,25 +9301,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
-
---
--- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE music_library FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
+
+--
+-- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE music_library FROM iris;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9331,25 +9337,25 @@ REVOKE SELECT ON TABLE music_works FROM argus;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM athena;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM athena;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM coder;
+REVOKE SELECT ON TABLE music_works FROM athena;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM coder;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE music_works FROM coder;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9457,13 +9463,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM marcie;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM newhart;
+REVOKE SELECT ON TABLE music_works FROM newhart;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM newhart;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9499,19 +9505,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM quill;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM scout;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scout;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM scribe;
+REVOKE SELECT ON TABLE music_works FROM scout;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9523,13 +9523,19 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scribe;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM ticker;
+REVOKE SELECT ON TABLE music_works FROM scribe;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM ticker;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE music_works FROM ticker;
 
 --
 -- Name: place_properties; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9547,19 +9553,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE places FROM nova;
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
-
---
--- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
+REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9568,16 +9568,22 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
 REVOKE SELECT ON TABLE portfolio_history FROM ticker;
 
 --
--- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
+-- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_history FROM ticker;
 
 --
 -- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
+
+--
+-- Name: portfolio_metrics; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_metrics FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9595,13 +9601,13 @@ REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9619,13 +9625,13 @@ REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
+REVOKE SELECT ON TABLE positions FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE positions FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
 
 --
 -- Name: preferences; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9793,13 +9799,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9991,13 +9997,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -10057,13 +10063,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -4090,90 +4090,47 @@ COMMENT ON FUNCTION get_agent_bootstrap(text) IS 'Bootstrap context: UNIVERSAL +
 
 CREATE OR REPLACE FUNCTION get_agent_export_rows()
 RETURNS TABLE(name text, model text, fallback_models text[], thinking text, instance_type text, is_default boolean, allowed_subagents text[])
-LANGUAGE plpgsql
+LANGUAGE sql
 STABLE
 AS $$
-DECLARE
-  v_owner_row agents%ROWTYPE;
-  v_is_peer   boolean := false;
-BEGIN
-  -- Resolve the connecting role to an agent row, if any.
-  SELECT * INTO v_owner_row
+  -- The connecting agent (peer or primary) as the gateway default.
+  SELECT
+    a.name::text,
+    a.model::text,
+    a.fallback_models,
+    a.thinking::text,
+    a.instance_type::text,
+    TRUE AS is_default,
+    a.allowed_subagents
   FROM agents a
   WHERE a.name = session_user
-  LIMIT 1;
+    AND a.status = 'active'
+    AND a.model IS NOT NULL
 
-  IF FOUND AND v_owner_row.instance_type = 'peer' THEN
-    v_is_peer := true;
-  END IF;
+  UNION ALL
 
-  IF v_is_peer THEN
-    -- Owner is a peer agent — include the peer (forced default) plus its
-    -- allowed non-peer subagents (with is_default forced false).
-    RETURN QUERY
-      -- The peer itself, marked as the gateway's default.
-      SELECT
-        a.name::text,
-        a.model::text,
-        a.fallback_models,
-        a.thinking::text,
-        a.instance_type::text,
-        TRUE AS is_default,
-        a.allowed_subagents
-      FROM agents a
-      WHERE a.name = v_owner_row.name
-        AND a.model IS NOT NULL
+  -- Subagents owned by the connecting agent.
+  SELECT
+    a.name::text,
+    a.model::text,
+    a.fallback_models,
+    a.thinking::text,
+    a.instance_type::text,
+    FALSE AS is_default,
+    a.allowed_subagents
+  FROM agents a
+  WHERE a.parent_agent = session_user
+    AND a.status = 'active'
+    AND a.model IS NOT NULL
 
-      UNION ALL
-
-      -- Subagents this peer is allowed to spawn.
-      -- Wildcard '*' expands to all rows with instance_type = 'subagent'.
-      -- (Peer and primary agents are intentionally excluded — they each run
-      -- their own gateway and are not spawned as subagents of another peer.)
-      SELECT
-        a.name::text,
-        a.model::text,
-        a.fallback_models,
-        a.thinking::text,
-        a.instance_type::text,
-        FALSE AS is_default,
-        a.allowed_subagents
-      FROM agents a
-      WHERE a.instance_type = 'subagent'
-        AND a.model IS NOT NULL
-        AND v_owner_row.allowed_subagents IS NOT NULL
-        AND (
-          '*' = ANY (v_owner_row.allowed_subagents)
-          OR a.name = ANY (v_owner_row.allowed_subagents)
-        )
-      ORDER BY 1;
-
-  ELSE
-    -- Owner is a non-peer (e.g. primary NOVA) or unknown role:
-    -- preserve the historical behaviour of exporting all non-peer agents
-    -- with their stored is_default flags.
-    RETURN QUERY
-      SELECT
-        a.name::text,
-        a.model::text,
-        a.fallback_models,
-        a.thinking::text,
-        a.instance_type::text,
-        a.is_default,
-        a.allowed_subagents
-      FROM agents a
-      WHERE a.instance_type <> 'peer'
-        AND a.model IS NOT NULL
-      ORDER BY a.name;
-  END IF;
-END;
+  ORDER BY 6 DESC, 1;  -- default first, then alphabetical by name
 $$;
 
 --
 -- Name: get_agent_export_rows(); Type: FUNCTION; Schema: -; Owner: -
 --
 
-COMMENT ON FUNCTION get_agent_export_rows() IS 'Returns the agent rows that agent_config_sync should serialize to agents.json for the connecting role (session_user). Peer roles see themselves as default + their allowed non-peer subagents; non-peer/unknown roles see all non-peer agents (legacy behavior). See ~/.openclaw/extensions/agent_config_sync/src/sync.ts.';
+COMMENT ON FUNCTION get_agent_export_rows() IS 'Returns the agent rows that agent_config_sync should serialize to agents.json for the connecting role (session_user). Includes the connecting agent (peer or primary) as default plus every active subagent whose agents.parent_agent matches the connecting role. See ~/.openclaw/extensions/agent_config_sync/src/sync.ts.';
 
 --
 -- Name: get_agent_skills(text); Type: FUNCTION; Schema: -; Owner: -
@@ -7495,13 +7452,13 @@ CREATE OR REPLACE VIEW workflow_steps_detail AS
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
+REVOKE SELECT ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_actions FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7609,13 +7566,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM iris;
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7699,13 +7656,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM iris;
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
+REVOKE SELECT ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_domains FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_domains FROM newhart;
 
 --
 -- Name: agent_domains; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7729,13 +7686,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7999,13 +7956,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM iris;
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ai_models FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
+REVOKE SELECT ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8029,25 +7986,25 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
-
---
--- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE asset_classes FROM ticker;
+
+--
+-- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8089,13 +8046,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8863,13 +8820,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8995,13 +8952,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9061,13 +9018,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_authors FROM ticker;
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
+REVOKE SELECT ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_relationships FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_relationships FROM athena;
 
 --
 -- Name: library_work_relationships; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9193,13 +9150,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_tags FROM ticker;
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
+REVOKE SELECT ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_works FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9301,13 +9258,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9337,25 +9294,25 @@ REVOKE SELECT ON TABLE music_works FROM argus;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM athena;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE SELECT ON TABLE music_works FROM athena;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM coder;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM athena;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE music_works FROM coder;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM coder;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9385,25 +9342,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM erato;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM flint;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE SELECT ON TABLE music_works FROM flint;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM gem;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM flint;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE music_works FROM gem;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM gem;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9505,25 +9462,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM quill;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scout;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE SELECT ON TABLE music_works FROM scout;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scribe;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scout;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE music_works FROM scribe;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scribe;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9601,13 +9558,13 @@ REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9799,13 +9756,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9997,13 +9954,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_provenance FROM nova;
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
+REVOKE SELECT ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_provenance FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_provenance FROM scout;
 
 --
 -- Name: research_provenance; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -10063,13 +10020,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_taggings FROM nova;
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_taggings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_taggings FROM scout;
+REVOKE SELECT ON TABLE research_taggings FROM scout;
 
 --
 -- Name: research_taggings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -10129,13 +10086,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tags FROM nova;
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
+REVOKE SELECT ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tags FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -4080,6 +4080,96 @@ $$;
 COMMENT ON FUNCTION get_agent_bootstrap(text) IS 'Bootstrap context: UNIVERSAL + GLOBAL + DOMAIN + WORKFLOW summaries (name, description, agent role, query pointer — NO full step descriptions) + AGENT. Domain-based matching only. See nova-mind#171.';
 
 --
+-- Name: get_agent_export_rows(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION get_agent_export_rows()
+RETURNS TABLE(name text, model text, fallback_models text[], thinking text, instance_type text, is_default boolean, allowed_subagents text[])
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+  v_owner_row agents%ROWTYPE;
+  v_is_peer   boolean := false;
+BEGIN
+  -- Resolve the connecting role to an agent row, if any.
+  SELECT * INTO v_owner_row
+  FROM agents a
+  WHERE a.name = session_user
+  LIMIT 1;
+
+  IF FOUND AND v_owner_row.instance_type = 'peer' THEN
+    v_is_peer := true;
+  END IF;
+
+  IF v_is_peer THEN
+    -- Owner is a peer agent — include the peer (forced default) plus its
+    -- allowed non-peer subagents (with is_default forced false).
+    RETURN QUERY
+      -- The peer itself, marked as the gateway's default.
+      SELECT
+        a.name::text,
+        a.model::text,
+        a.fallback_models,
+        a.thinking::text,
+        a.instance_type::text,
+        TRUE AS is_default,
+        a.allowed_subagents
+      FROM agents a
+      WHERE a.name = v_owner_row.name
+        AND a.model IS NOT NULL
+
+      UNION ALL
+
+      -- Non-peer agents this peer is allowed to spawn.
+      SELECT
+        a.name::text,
+        a.model::text,
+        a.fallback_models,
+        a.thinking::text,
+        a.instance_type::text,
+        FALSE AS is_default,
+        a.allowed_subagents
+      FROM agents a
+      WHERE a.instance_type <> 'peer'
+        AND a.model IS NOT NULL
+        AND (
+          v_owner_row.allowed_subagents IS NOT NULL
+          AND (
+            '*' = ANY (v_owner_row.allowed_subagents)
+            OR a.name = ANY (v_owner_row.allowed_subagents)
+          )
+        )
+      ORDER BY 1;
+
+  ELSE
+    -- Owner is a non-peer (e.g. primary NOVA) or unknown role:
+    -- preserve the historical behaviour of exporting all non-peer agents
+    -- with their stored is_default flags.
+    RETURN QUERY
+      SELECT
+        a.name::text,
+        a.model::text,
+        a.fallback_models,
+        a.thinking::text,
+        a.instance_type::text,
+        a.is_default,
+        a.allowed_subagents
+      FROM agents a
+      WHERE a.instance_type <> 'peer'
+        AND a.model IS NOT NULL
+      ORDER BY a.name;
+  END IF;
+END;
+$$;
+
+--
+-- Name: get_agent_export_rows(); Type: FUNCTION; Schema: -; Owner: -
+--
+
+COMMENT ON FUNCTION get_agent_export_rows() IS 'Returns the agent rows that agent_config_sync should serialize to agents.json for the connecting role (session_user). Peer roles see themselves as default + their allowed non-peer subagents; non-peer/unknown roles see all non-peer agents (legacy behavior). See ~/.openclaw/extensions/agent_config_sync/src/sync.ts.';
+
+--
 -- Name: get_agent_skills(text); Type: FUNCTION; Schema: -; Owner: -
 --
 
@@ -7513,13 +7603,13 @@ REVOKE DELETE ON TABLE agent_bootstrap_context FROM iris;
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_bootstrap_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_bootstrap_context FROM newhart;
 
 --
 -- Name: agent_bootstrap_context; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7633,13 +7723,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7789,13 +7879,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7837,13 +7927,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agents FROM iris;
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
+REVOKE SELECT ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agents FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7933,25 +8023,25 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
-
---
--- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE asset_classes FROM ticker;
+
+--
+-- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE asset_classes FROM ticker;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7993,13 +8083,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE bootstrap_context_config FROM iris;
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
+REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE bootstrap_context_config FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE bootstrap_context_config FROM newhart;
 
 --
 -- Name: bootstrap_context_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8635,13 +8725,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE gambling_logs FROM nova;
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
+REVOKE SELECT ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: git_issue_queue; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE git_issue_queue FROM coder;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE git_issue_queue FROM coder;
 
 --
 -- Name: job_messages; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8767,13 +8857,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE lessons_archive FROM nova;
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
+REVOKE SELECT ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_authors FROM athena;
 
 --
 -- Name: library_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8833,13 +8923,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8899,13 +8989,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9031,13 +9121,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_relationships FROM ticker;
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_tags FROM athena;
+REVOKE SELECT ON TABLE library_work_tags FROM athena;
 
 --
 -- Name: library_work_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9097,13 +9187,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_tags FROM ticker;
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
+REVOKE SELECT ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_works FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9229,13 +9319,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM argus;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM argus;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM argus;
+REVOKE SELECT ON TABLE music_works FROM argus;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9265,25 +9355,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM coder;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM conductor;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE SELECT ON TABLE music_works FROM conductor;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM erato;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM conductor;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE music_works FROM erato;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM erato;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9355,25 +9445,25 @@ REVOKE SELECT ON TABLE music_works FROM iris;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM marcie;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE SELECT ON TABLE music_works FROM marcie;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM marcie;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM newhart;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE music_works FROM newhart;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9433,13 +9523,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scribe;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM ticker;
+REVOKE SELECT ON TABLE music_works FROM ticker;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM ticker;
 
 --
 -- Name: place_properties; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9457,13 +9547,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE places FROM nova;
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9493,13 +9583,13 @@ REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
+REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9517,25 +9607,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
-
---
--- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE SELECT ON TABLE positions FROM ticker;
+REVOKE SELECT ON TABLE portfolio_updates FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
+
+--
+-- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE positions FROM ticker;
 
 --
 -- Name: preferences; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9547,13 +9637,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE preferences FROM nova;
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
+REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: project_entities; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -10033,13 +10123,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_tags FROM nova;
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_tags FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_tags FROM scout;
+REVOKE SELECT ON TABLE research_tags FROM scout;
 
 --
 -- Name: research_tags; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -7399,13 +7399,13 @@ CREATE OR REPLACE VIEW workflow_steps_detail AS
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
+REVOKE SELECT ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_actions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_actions FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_actions FROM newhart;
 
 --
 -- Name: agent_aliases; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7633,13 +7633,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_domains FROM ticker;
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_jobs FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_jobs; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_jobs FROM newhart;
+REVOKE SELECT ON TABLE agent_jobs FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7681,13 +7681,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM iris;
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
+REVOKE SELECT ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_modifications FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_modifications FROM newhart;
 
 --
 -- Name: agent_modifications; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7711,13 +7711,13 @@ REVOKE DELETE ON TABLE agent_modifications FROM ticker;
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_spawns FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_spawns; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_spawns FROM newhart;
+REVOKE SELECT ON TABLE agent_spawns FROM newhart;
 
 --
 -- Name: agent_system_config; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7789,13 +7789,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agent_system_config FROM ticker;
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
+REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agent_turn_context; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agent_turn_context FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agent_turn_context FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7837,13 +7837,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE agents FROM iris;
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE agents FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE agents FROM newhart;
+REVOKE SELECT ON TABLE agents FROM newhart;
 
 --
 -- Name: agents; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7903,13 +7903,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM iris;
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE ai_models FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE ai_models FROM newhart;
+REVOKE SELECT ON TABLE ai_models FROM newhart;
 
 --
 -- Name: ai_models; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -7933,13 +7933,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE ai_models FROM ticker;
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
+REVOKE SELECT ON TABLE artwork FROM iris;
 
 --
 -- Name: artwork; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE artwork FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE artwork FROM iris;
 
 --
 -- Name: asset_classes; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8833,13 +8833,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_authors FROM ticker;
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
+REVOKE SELECT ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_tags FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_tags FROM athena;
 
 --
 -- Name: library_tags; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -8899,13 +8899,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_tags FROM ticker;
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
+REVOKE SELECT ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_work_authors FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_work_authors FROM athena;
 
 --
 -- Name: library_work_authors; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9097,13 +9097,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE library_work_tags FROM ticker;
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE library_works FROM athena;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE library_works FROM athena;
+REVOKE SELECT ON TABLE library_works FROM athena;
 
 --
 -- Name: library_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9205,25 +9205,25 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE motivation_d100 FROM nova;
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_analysis FROM iris;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_analysis; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_analysis FROM iris;
-
---
--- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
+REVOKE SELECT ON TABLE music_analysis FROM iris;
 
 --
 -- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE music_library FROM iris;
+
+--
+-- Name: music_library; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_library FROM iris;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9241,19 +9241,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM argus;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM athena;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE SELECT ON TABLE music_works FROM athena;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM coder;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM athena;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9265,7 +9259,7 @@ REVOKE SELECT ON TABLE music_works FROM coder;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM conductor;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM coder;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9277,7 +9271,7 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM conductor;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM erato;
+REVOKE SELECT ON TABLE music_works FROM conductor;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9289,7 +9283,7 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM erato;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM flint;
+REVOKE SELECT ON TABLE music_works FROM erato;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9301,13 +9295,19 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM flint;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM gem;
+REVOKE SELECT ON TABLE music_works FROM flint;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM gem;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE music_works FROM gem;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9343,19 +9343,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM hermes;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM iris;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM iris;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM marcie;
+REVOKE SELECT ON TABLE music_works FROM iris;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9367,13 +9361,19 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM marcie;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM newhart;
+REVOKE SELECT ON TABLE music_works FROM marcie;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE music_works FROM newhart;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM newhart;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9409,19 +9409,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM quill;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scout;
-
---
--- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
 REVOKE SELECT ON TABLE music_works FROM scout;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scribe;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scout;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9433,13 +9427,19 @@ REVOKE SELECT ON TABLE music_works FROM scribe;
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE music_works FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM scribe;
 
 --
 -- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE music_works FROM ticker;
+
+--
+-- Name: music_works; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE SELECT ON TABLE music_works FROM ticker;
 
 --
 -- Name: place_properties; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9457,13 +9457,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE places FROM nova;
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: pm_domain_portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE pm_domain_portfolio_snapshots FROM ticker;
+REVOKE SELECT ON TABLE pm_domain_portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_history; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9493,25 +9493,25 @@ REVOKE SELECT ON TABLE portfolio_metrics FROM ticker;
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
+REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
 
 --
 -- Name: portfolio_positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE portfolio_positions FROM ticker;
-
---
--- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
---
-
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_positions FROM ticker;
 
 --
 -- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
 REVOKE SELECT ON TABLE portfolio_snapshots FROM ticker;
+
+--
+-- Name: portfolio_snapshots; Type: PRIVILEGE; Schema: privileges; Owner: -
+--
+
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_snapshots FROM ticker;
 
 --
 -- Name: portfolio_updates; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9529,13 +9529,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE portfolio_updates FROM ticker;
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
+REVOKE SELECT ON TABLE positions FROM ticker;
 
 --
 -- Name: positions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE positions FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE positions FROM ticker;
 
 --
 -- Name: preferences; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9547,13 +9547,13 @@ REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE preferences FROM nova;
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: price_cache_v2; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE price_cache_v2 FROM ticker;
+REVOKE SELECT ON TABLE price_cache_v2 FROM ticker;
 
 --
 -- Name: project_entities; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9637,13 +9637,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_citations FROM nova;
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_citations FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_citations FROM scout;
+REVOKE SELECT ON TABLE research_citations FROM scout;
 
 --
 -- Name: research_citations; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9703,13 +9703,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_conclusions FROM nova;
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_conclusions FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_conclusions FROM scout;
+REVOKE SELECT ON TABLE research_conclusions FROM scout;
 
 --
 -- Name: research_conclusions; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9769,13 +9769,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_findings FROM nova;
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
+REVOKE SELECT ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_findings FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_findings FROM scout;
 
 --
 -- Name: research_findings; Type: PRIVILEGE; Schema: privileges; Owner: -
@@ -9835,13 +9835,13 @@ REVOKE DELETE, INSERT, UPDATE ON TABLE research_projects FROM nova;
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE SELECT ON TABLE research_projects FROM scout;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -
 --
 
-REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE research_projects FROM scout;
+REVOKE SELECT ON TABLE research_projects FROM scout;
 
 --
 -- Name: research_projects; Type: PRIVILEGE; Schema: privileges; Owner: -

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -3971,7 +3971,7 @@ BEGIN
     FROM (
         -- 1. UNIVERSAL (exclude SYSTEM records)
         SELECT abc.file_key || '.md' AS filename, abc.content,
-            'universal'::TEXT AS source, 1 AS priority
+            'UNIVERSAL'::TEXT AS source, 1 AS priority
         FROM agent_bootstrap_context abc
         WHERE abc.context_type = 'UNIVERSAL'
           AND abc.file_key != 'SYSTEM_PROMPT'
@@ -3980,7 +3980,7 @@ BEGIN
 
         -- 2. GLOBAL (exclude SYSTEM records)
         SELECT abc.file_key || '.md' AS filename, abc.content,
-            'global'::TEXT AS source, 2 AS priority
+            'GLOBAL'::TEXT AS source, 2 AS priority
         FROM agent_bootstrap_context abc
         WHERE abc.context_type = 'GLOBAL'
           AND abc.file_key != 'SYSTEM_PROMPT'
@@ -3991,7 +3991,7 @@ BEGIN
         SELECT
             abc.file_key || '.md' AS filename,
             abc.content,
-            'domain:' || (
+            'DOMAIN:' || (
                 SELECT string_agg(dn, ', ' ORDER BY dn)
                 FROM unnest(abc.domain_names) AS dn
             ) AS source,
@@ -4032,7 +4032,7 @@ BEGIN
             E'\n> FROM workflow_steps WHERE workflow_id = ' || w.id || ' ORDER BY step_order;' ||
             E'\n> ```'
             AS content,
-            'workflow:' || w.name AS source,
+            'WORKFLOW:' || w.name AS source,
             4 AS priority
         FROM workflows w
         LEFT JOIN LATERAL (
@@ -4067,7 +4067,7 @@ BEGIN
 
         -- 5. AGENT (never SYSTEM)
         SELECT abc.file_key || '.md' AS filename, abc.content,
-            'agent'::TEXT AS source, 5 AS priority
+            'AGENT'::TEXT AS source, 5 AS priority
         FROM agent_bootstrap_context abc
         WHERE abc.context_type = 'AGENT'
           AND abc.agent_name = p_agent_name

--- a/tests/TEST-CASES-batch-agent-identity.md
+++ b/tests/TEST-CASES-batch-agent-identity.md
@@ -1,0 +1,1045 @@
+# Test Cases — Batch Agent Identity (#244 + #243)
+
+**Author:** Gem (QA Lead)  
+**SE Workflow Run:** #14, Step 3 (Test Case Design)  
+**Date:** 2026-05-18  
+**Status:** Design complete — ready for Coder implementation (Step 4)  
+**Repos:** nova-mind (#244), nova-openclaw (#243)
+
+---
+
+## Overview
+
+This document covers two co-deployed PRs:
+
+| PR | Repo | Change |
+|----|------|--------|
+| #244 | nova-mind | Replace inline `AGENTS_QUERY` with `get_agent_export_rows()`; capitalize `get_agent_bootstrap()` source literals |
+| #243 | nova-openclaw | Preserve synthetic bootstrap path identifiers through `sanitizeBootstrapFiles` |
+
+**Deploy coupling:** See [Coordination Notes](#coordination-notes) at the bottom. The PRs are independent in code but coupled in correctness at runtime. Read that section before Step 4 kickoff.
+
+---
+
+## Part 1 — PR #244: nova-mind / `agent_config_sync` + schema function casing
+
+### Background
+
+`get_agent_export_rows()` is already deployed to production. It uses `session_user` (the PostgreSQL role of the connecting process) to scope the result:
+- Returns the connecting agent's own row with `is_default = TRUE`
+- Returns every subagent where `session_user = ANY(parent_agents)` with `is_default = FALSE`
+- The deployed column is `agents.parent_agents` (text[], plural)
+
+The inline `AGENTS_QUERY` in `sync.ts` (current, buggy) uses `instance_type != 'peer'` — a gateway-agnostic filter that returns the same rows regardless of which gateway is connecting. This causes peer gateways (newhart, graybeard) to receive NOVA's subagents and fall back to NOVA as default.
+
+`get_agent_bootstrap()` currently emits lowercase source literals (`'universal'`, `'global'`, `'domain:...'`, etc.). The hook handler (`bootstrap-context/hook/handler.ts:59`) constructs paths as `` `db:${row.source}/${row.filename}` ``, so the casing fix here is what produces the `db:UNIVERSAL/...` paths that #243 needs to preserve.
+
+---
+
+### 1.1 — Unit Tests: `buildAgentsList()` with function-sourced rows
+
+**File:** `cognition/focus/agent-config-sync/src/sync.test.ts`  
+**Framework:** Jest / Vitest (match existing test runner)  
+**Approach:** Call `buildAgentsList()` with synthetic row arrays representing what `get_agent_export_rows()` returns for different session_users.
+
+#### TC-244-U-01: NOVA session — self as default, NOVA's subagents only
+
+**Preconditions:** Rows represent `get_agent_export_rows()` result when `session_user = 'nova'`
+
+**Input rows:**
+```ts
+const rows = [
+  { name: 'nova',  model: 'anthropic/claude-opus-4',   fallback_models: null,  thinking: 'high',   instance_type: 'primary',  is_default: true,  allowed_subagents: ['gem','coder','scout'] },
+  { name: 'coder', model: 'anthropic/claude-sonnet-4', fallback_models: null,  thinking: 'medium', instance_type: 'subagent', is_default: false, allowed_subagents: null },
+  { name: 'gem',   model: 'google/gemini-flash',       fallback_models: null,  thinking: null,     instance_type: 'subagent', is_default: false, allowed_subagents: null },
+  { name: 'scout', model: 'google/gemini-flash',       fallback_models: null,  thinking: null,     instance_type: 'subagent', is_default: false, allowed_subagents: null },
+];
+```
+
+**Expected output:**
+```ts
+// nova has default: true
+expect(result.find(e => e.id === 'nova')?.default).toBe(true);
+// subagents do NOT have default key at all
+expect(result.find(e => e.id === 'coder')?.default).toBeUndefined();
+expect(result.find(e => e.id === 'gem')?.default).toBeUndefined();
+// all four agents present
+expect(result.map(e => e.id).sort()).toEqual(['coder', 'gem', 'nova', 'scout']);
+// nova's allowed_subagents are sorted and surfaced
+expect(result.find(e => e.id === 'nova')?.subagents?.allowAgents).toEqual(['coder', 'gem', 'scout']);
+```
+
+**Pass criteria:** `default: true` on nova only; all subagents present; no newhart/graybeard entries.
+
+---
+
+#### TC-244-U-02: Newhart session — self as default, Newhart's subagents only
+
+**Preconditions:** Rows represent `get_agent_export_rows()` result when `session_user = 'newhart'`
+
+**Input rows:**
+```ts
+const rows = [
+  { name: 'newhart', model: 'anthropic/claude-opus-4', fallback_models: null,  thinking: 'high', instance_type: 'peer',     is_default: true,  allowed_subagents: ['coder','scout'] },
+  { name: 'coder',   model: 'anthropic/claude-sonnet-4', fallback_models: null, thinking: null,  instance_type: 'subagent', is_default: false, allowed_subagents: null },
+  { name: 'scout',   model: 'google/gemini-flash',        fallback_models: null, thinking: null,  instance_type: 'subagent', is_default: false, allowed_subagents: null },
+];
+```
+
+**Expected output:**
+```ts
+expect(result.find(e => e.id === 'newhart')?.default).toBe(true);
+expect(result.find(e => e.id === 'coder')?.default).toBeUndefined();
+// gem NOT present (gem's parent_agents does not include 'newhart')
+expect(result.find(e => e.id === 'gem')).toBeUndefined();
+// nova NOT present
+expect(result.find(e => e.id === 'nova')).toBeUndefined();
+expect(result.map(e => e.id).sort()).toEqual(['coder', 'newhart', 'scout']);
+```
+
+**Pass criteria:** Newhart is default; no NOVA; no gem (unless it's also a Newhart subagent in the actual DB).
+
+---
+
+#### TC-244-U-03: Mutual exclusion — NOVA and Newhart never see each other
+
+**Preconditions:** Two independent `buildAgentsList()` calls with NOVA-scoped and Newhart-scoped rows respectively.
+
+**Assertion:**
+```ts
+const novaResult = buildAgentsList(novaRows);
+const newhartResult = buildAgentsList(newhartRows);
+
+expect(novaResult.find(e => e.id === 'newhart')).toBeUndefined();
+expect(newhartResult.find(e => e.id === 'nova')).toBeUndefined();
+```
+
+**Pass criteria:** Peer agents never appear in each other's agent list.
+
+---
+
+#### TC-244-U-04: Fallback model shape preserved from function rows
+
+**Input:** Row with `fallback_models = ['openai/gpt-4o', 'google/gemini-pro']`
+
+**Expected:**
+```ts
+expect(result.find(e => e.id === 'coder')?.model).toEqual({
+  primary: 'anthropic/claude-sonnet-4',
+  fallbacks: ['openai/gpt-4o', 'google/gemini-pro']
+});
+```
+
+**Pass criteria:** Object form emitted when fallbacks are present; order preserved from DB array.
+
+---
+
+#### TC-244-U-05: Row with `is_default = null` emits no `default` key
+
+**Input:** `{ is_default: null, ... }`
+
+**Expected:**
+```ts
+expect(result.find(e => e.id === 'someagent')?.default).toBeUndefined();
+```
+
+---
+
+### 1.2 — Function Tests: `get_agent_export_rows()`
+
+**Framework:** pgTAP  
+**File:** `database/tests/test_get_agent_export_rows.sql`  
+**Setup:** Use `SET ROLE` or `SET SESSION AUTHORIZATION` to simulate different session_users.
+
+> **Note to Coder:** pgTAP tests must run inside a transaction; use `BEGIN`/`ROLLBACK` wrapping. The `SET SESSION AUTHORIZATION` approach requires superuser; `SET ROLE` works if the role exists. Either pattern is acceptable — be consistent with existing pgTAP tests in this repo.
+
+#### TC-244-DB-01: NOVA's default row
+
+```sql
+SET ROLE nova;
+SELECT is(
+  (SELECT is_default FROM get_agent_export_rows() WHERE name = 'nova'),
+  TRUE,
+  'nova row is_default = TRUE when session_user = nova'
+);
+```
+
+**Pass criteria:** Exactly one row with `is_default = TRUE`; that row's name matches `session_user`.
+
+---
+
+#### TC-244-DB-02: NOVA's subagent count and is_default = FALSE
+
+```sql
+SET ROLE nova;
+SELECT ok(
+  (SELECT COUNT(*) FROM get_agent_export_rows() WHERE is_default = FALSE) > 0,
+  'nova sees at least one subagent row'
+);
+SELECT is(
+  (SELECT COUNT(*) FROM get_agent_export_rows() WHERE is_default = FALSE AND name = 'nova'),
+  0::bigint,
+  'nova does not appear twice as a subagent'
+);
+```
+
+---
+
+#### TC-244-DB-03: Newhart session returns newhart as default
+
+```sql
+SET ROLE newhart;
+SELECT is(
+  (SELECT is_default FROM get_agent_export_rows() WHERE name = 'newhart'),
+  TRUE,
+  'newhart row is_default = TRUE when session_user = newhart'
+);
+```
+
+---
+
+#### TC-244-DB-04: Newhart does NOT see NOVA's private subagents
+
+This test requires knowing at least one subagent that exclusively has `'nova'` in `parent_agents` and NOT `'newhart'`. Use `gem` (or any confirmed nova-only subagent).
+
+```sql
+SET ROLE newhart;
+-- gem's parent_agents = ARRAY['nova'] only
+SELECT is(
+  (SELECT COUNT(*) FROM get_agent_export_rows() WHERE name = 'gem'),
+  0::bigint,
+  'newhart does not see gem (nova-only subagent)'
+);
+```
+
+**If gem is shared:** Substitute a confirmed nova-only subagent, or insert a synthetic one for the test.
+
+---
+
+#### TC-244-DB-05: Empty result for session_user with no agents row
+
+```sql
+-- Use a DB role that exists but has no row in the agents table
+SET ROLE nova_memory_reader; -- or whichever role is DB-only with no agents row
+SELECT is(
+  (SELECT COUNT(*) FROM get_agent_export_rows()),
+  0::bigint,
+  'no rows returned for session_user with no agents entry'
+);
+```
+
+**Note:** This role must exist as a PostgreSQL role (otherwise SET ROLE fails). Choose a known DB-only role. If none exists in the test environment, create one: `CREATE ROLE test_phantom_user;`.
+
+---
+
+#### TC-244-DB-06: Inactive agents excluded
+
+**Setup:** Temporarily set a subagent's `status = 'inactive'`.
+
+```sql
+SET ROLE nova;
+UPDATE agents SET status = 'inactive' WHERE name = 'iris'; -- example
+SELECT is(
+  (SELECT COUNT(*) FROM get_agent_export_rows() WHERE name = 'iris'),
+  0::bigint,
+  'inactive agents are excluded from export rows'
+);
+ROLLBACK; -- inside test transaction
+```
+
+---
+
+#### TC-244-DB-07: Agents with NULL model excluded
+
+```sql
+SET ROLE nova;
+UPDATE agents SET model = NULL WHERE name = 'iris'; -- example
+SELECT is(
+  (SELECT COUNT(*) FROM get_agent_export_rows() WHERE name = 'iris'),
+  0::bigint,
+  'agents with NULL model are excluded'
+);
+ROLLBACK;
+```
+
+---
+
+### 1.3 — Function Tests: `get_agent_bootstrap()` source casing
+
+**Framework:** pgTAP  
+**File:** `database/tests/test_get_agent_bootstrap_casing.sql`
+
+#### TC-244-BC-01: All source values are UPPERCASE literals
+
+```sql
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM get_agent_bootstrap('nova')
+    WHERE source !~ '^(UNIVERSAL|GLOBAL|DOMAIN:[A-Z]|WORKFLOW:[A-Za-z]|AGENT)$'
+      AND source NOT ILIKE 'DOMAIN:%'
+      AND source NOT ILIKE 'WORKFLOW:%'
+  ),
+  'all source values match UPPERCASE pattern for nova'
+);
+```
+
+**More granular approach — separate assertions per tier:**
+
+```sql
+-- UNIVERSAL rows
+SELECT ok(
+  (SELECT COUNT(*) FROM get_agent_bootstrap('nova') WHERE source = 'UNIVERSAL') > 0,
+  'at least one UNIVERSAL row for nova'
+);
+SELECT is(
+  (SELECT COUNT(*) FROM get_agent_bootstrap('nova') WHERE source = 'universal'),
+  0::bigint,
+  'no lowercase universal rows'
+);
+
+-- GLOBAL rows
+SELECT ok(
+  (SELECT COUNT(*) FROM get_agent_bootstrap('nova') WHERE source = 'GLOBAL') > 0,
+  'at least one GLOBAL row for nova'
+);
+SELECT is(
+  (SELECT COUNT(*) FROM get_agent_bootstrap('nova') WHERE source = 'global'),
+  0::bigint,
+  'no lowercase global rows'
+);
+
+-- DOMAIN rows — prefix check
+SELECT ok(
+  (SELECT COUNT(*) FROM get_agent_bootstrap('nova') WHERE source LIKE 'DOMAIN:%') >= 0,
+  'DOMAIN rows use DOMAIN: prefix (uppercase)'
+);
+SELECT is(
+  (SELECT COUNT(*) FROM get_agent_bootstrap('nova') WHERE source LIKE 'domain:%'),
+  0::bigint,
+  'no lowercase domain: prefix'
+);
+
+-- WORKFLOW rows — prefix check (only if nova has workflow steps)
+SELECT is(
+  (SELECT COUNT(*) FROM get_agent_bootstrap('nova') WHERE source LIKE 'workflow:%'),
+  0::bigint,
+  'no lowercase workflow: prefix'
+);
+
+-- AGENT rows
+SELECT is(
+  (SELECT COUNT(*) FROM get_agent_bootstrap('nova') WHERE source = 'agent'),
+  0::bigint,
+  'no lowercase agent source'
+);
+```
+
+---
+
+#### TC-244-BC-02: DOMAIN source format — colon separator, uppercase prefix
+
+For any DOMAIN-type row:
+
+```sql
+SELECT ok(
+  (SELECT bool_and(source ~ '^DOMAIN:.+') FROM get_agent_bootstrap('gem') WHERE source LIKE 'DOMAIN:%'),
+  'DOMAIN sources follow DOMAIN:<names> format for gem'
+);
+```
+
+---
+
+#### TC-244-BC-03: WORKFLOW source format — colon separator, uppercase prefix
+
+```sql
+SELECT ok(
+  (SELECT bool_and(source ~ '^WORKFLOW:.+') FROM get_agent_bootstrap('gem') WHERE source LIKE 'WORKFLOW:%'),
+  'WORKFLOW sources follow WORKFLOW:<name> format for gem'
+);
+```
+
+**Note:** If the agent has no workflow steps assigned, this SELECT returns no rows and `bool_and` returns NULL. Wrap with `COALESCE(..., TRUE)` to make the no-rows case a pass (no workflow rows = no casing violation).
+
+---
+
+#### TC-244-BC-04: AGENT source — exact string, not prefixed
+
+```sql
+SELECT ok(
+  (SELECT bool_and(source = 'AGENT') FROM get_agent_bootstrap('nova') WHERE source LIKE '%AGENT%' OR source LIKE '%agent%'),
+  'AGENT source is exact string AGENT, not prefixed'
+);
+```
+
+---
+
+#### TC-244-BC-05: Path construction integrates correctly with handler
+
+This is a conceptual assertion — the handler at `handler.ts:59` builds paths as `` `db:${row.source}/${row.filename}` ``. After the casing fix, verify the resulting paths use the expected format:
+
+```sql
+SELECT ok(
+  (SELECT bool_and('db:' || source || '/' || filename = 'db:' || source || '/' || filename)
+   FROM get_agent_bootstrap('nova')),
+  'source values produce valid db:<SOURCE>/<filename> paths (sanity check)'
+);
+```
+
+**Real assertion** (run in the bootstrap hook's test harness): verify that the returned path values for `nova` match the pattern `^db:[A-Z][A-Z_]*(:.*)?/[A-Z_]+\.md$`.
+
+---
+
+### 1.4 — Trigger End-to-End: `parent_agents` UPDATE → notify → sync → SIGUSR1
+
+**Framework:** Integration test (shell script + psql + file assertion)  
+**File:** `database/tests/test_agent_config_sync_trigger.sh`
+
+> These tests require a running nova-openclaw gateway instance with the agent_config_sync plugin enabled. Run on staging only.
+
+#### TC-244-E2E-01: UPDATE on `parent_agents` fires notify and rewrites agents.json
+
+**Setup:**
+```bash
+AGENTS_JSON="$HOME/.openclaw/agents.json"
+BEFORE_MTIME=$(stat -c %Y "$AGENTS_JSON")
+```
+
+**Action:**
+```sql
+-- Add a test subagent to nova's parent_agents, or touch an existing one
+UPDATE agents SET parent_agents = parent_agents WHERE name = 'gem';
+-- (or a real change that triggers the notify)
+```
+
+**Wait:** `sleep 2` (allow async notify processing)
+
+**Assertions:**
+```bash
+AFTER_MTIME=$(stat -c %Y "$AGENTS_JSON")
+[ "$AFTER_MTIME" -gt "$BEFORE_MTIME" ] || (echo "FAIL: agents.json not updated" && exit 1)
+# Validate JSON is valid
+jq empty "$AGENTS_JSON" || (echo "FAIL: agents.json is not valid JSON" && exit 1)
+```
+
+**Pass criteria:** File mtime advances; JSON parses cleanly.
+
+---
+
+#### TC-244-E2E-02: New agents.json shape reflects `get_agent_export_rows()` scoping
+
+**After trigger fires, check that NOVA's agents.json:**
+
+```bash
+# nova is the default agent
+jq '.[] | select(.default == true) | .id' "$AGENTS_JSON" | grep -q 'nova'
+# No peer agent appears in the list
+! jq -r '.[].id' "$AGENTS_JSON" | grep -qE '^(newhart|graybeard)$'
+```
+
+---
+
+#### TC-244-E2E-03: Atomic write — no partial reads during update
+
+**Approach:** While a sync is in progress, read `agents.json` multiple times in a tight loop and confirm every read produces valid JSON.
+
+```bash
+for i in $(seq 1 50); do
+  jq empty "$AGENTS_JSON" 2>/dev/null || echo "PARTIAL READ at iteration $i"
+done
+```
+
+**Pass criteria:** Zero partial-read failures observed (atomic rename ensures this).
+
+---
+
+### 1.5 — Backward Compatibility: NOVA's subagent set unchanged
+
+**Purpose:** Confirm the query swap from inline SQL to function produces identical output for NOVA's gateway.
+
+#### TC-244-COMPAT-01: Functional equivalence for NOVA's subagent set
+
+**Setup:** Capture output with the old inline query (or a snapshot of current agents.json content), then compare with function output.
+
+```sql
+-- Old query (run as nova role for comparison)
+SELECT name FROM agents WHERE instance_type != 'peer' AND model IS NOT NULL ORDER BY name;
+
+-- New function
+SELECT name FROM get_agent_export_rows() WHERE is_default = FALSE ORDER BY name;
+```
+
+**Assertion:** The set of subagent names returned by both queries is identical.
+
+> **Important nuance:** The old query was NOT role-scoped, so it returned all non-peer agents regardless of who connected. For NOVA's own gateway, this happened to produce the correct result (coincidentally) because NOVA's subagents all had `instance_type = 'subagent'`, not `'peer'`. The test must verify the new function produces the same *set* for the nova role.
+
+---
+
+#### TC-244-COMPAT-02: Regression — confirm existing agents.json for NOVA produces zero diff
+
+**Method:** On staging, after deploying the `sync.ts` change:
+1. Run manual sync: `openclaw agent-config-sync --force` (or equivalent)
+2. Compare new `agents.json` with a pre-deploy snapshot
+
+```bash
+diff pre-deploy-agents.json ~/.openclaw/agents.json
+```
+
+**Pass criteria:** Zero diff in NOVA's subagent entries (names, models, allowed_subagents). The `default: true` field may shift (previously may have been on NOVA implicitly, now explicitly from function).
+
+---
+
+### 1.6 — Doc Narrative Consistency
+
+**Method:** `grep` assertions run against doc files in the PR diff.
+
+#### TC-244-DOC-01: No `instance_type` filter reference in updated docs
+
+```bash
+grep -r "instance_type" \
+  cognition/focus/agent-config-sync/HOOK.md \
+  cognition/focus/agent-config-sync/README.md \
+  cognition/README.md \
+  && echo "FAIL: instance_type reference still present" \
+  || echo "PASS: no instance_type references"
+```
+
+**Pass criteria:** Exit code 1 (grep finds nothing). Any remaining `instance_type` reference must be reviewed.
+
+---
+
+#### TC-244-DOC-02: `'instance_type != peer'` phrase eliminated
+
+```bash
+grep -r "instance_type != .peer" \
+  cognition/focus/agent-config-sync/HOOK.md \
+  cognition/focus/agent-config-sync/README.md \
+  cognition/README.md \
+  cognition/docs/bootstrap-context-workflow-changes.md \
+  && echo "FAIL" || echo "PASS"
+```
+
+---
+
+#### TC-244-DOC-03: WORKFLOW: example in bootstrap-context-workflow-changes.md uses UPPERCASE
+
+```bash
+grep "WORKFLOW:" cognition/docs/bootstrap-context-workflow-changes.md | grep -v "^#"
+```
+
+**Manual check:** Line 42 must read `'WORKFLOW:'` (uppercase W) not `'workflow:'`.
+
+---
+
+## Part 2 — PR #243: nova-openclaw / Synthetic path preservation
+
+### Background
+
+`sanitizeBootstrapFiles()` in `src/agents/bootstrap-files.ts` (lines ~153–172) currently applies `path.resolve(workspaceRoot, pathValue)` to all non-absolute path values. A synthetic identifier like `db:AGENT/HEARTBEAT.md` is not absolute, so it gets resolved to `/home/nova/.openclaw/workspace-gem/db:AGENT/HEARTBEAT.md` — an invalid filesystem path that produces wrong context block headers.
+
+The plugin at `bootstrap-context/hook/handler.ts:59` already emits the correct format (`db:${row.source}/${row.filename}`). The bug is in the OpenClaw SDK sanitizer consuming those values.
+
+**Recognition rule (as specified):** A path is synthetic if it matches `^[A-Za-z][A-Za-z0-9_-]*:` — an alphabetic leading char, followed by alphanumeric/underscore/dash chars, followed by a colon. Known namespaces: `db:`, `fallback:`, `emergency:`. The check is namespace-agnostic.
+
+**Dedupe key for synthetic paths:** The literal synthetic path string (no workspace-relative resolution applied).
+
+**Synthetic paths must NOT go through `path.isAbsolute()` or `path.resolve()` at all.**
+
+---
+
+### 2.1 — Unit Tests: `sanitizeBootstrapFiles()` — synthetic path preservation
+
+**File:** `src/agents/bootstrap-files.test.ts` (add to existing `resolveBootstrapFilesForRun` describe block or add a new `describe('sanitizeBootstrapFiles — synthetic paths', ...)` block)
+
+**Test approach:** Register a bootstrap hook that injects synthetic-path entries, then call `resolveBootstrapFilesForRun()` and assert on the output path values. This matches the established pattern in the existing test file.
+
+#### TC-243-U-01: `db:AGENT/HEARTBEAT.md` passes through unchanged
+
+```ts
+it('preserves db:AGENT/HEARTBEAT.md synthetic path unchanged', async () => {
+  registerInternalHook('agent:bootstrap', (event) => {
+    const ctx = event.context as AgentBootstrapHookContext;
+    ctx.bootstrapFiles = [
+      ...ctx.bootstrapFiles,
+      { name: 'HEARTBEAT.md', path: 'db:AGENT/HEARTBEAT.md', content: 'heartbeat', missing: false },
+    ];
+  });
+
+  const workspaceDir = await makeTempWorkspace('openclaw-bootstrap-');
+  const files = await resolveBootstrapFilesForRun({ workspaceDir });
+  const heartbeat = files.find(f => f.name === 'HEARTBEAT.md');
+
+  expect(heartbeat?.path).toBe('db:AGENT/HEARTBEAT.md');
+  // Must NOT be an absolute filesystem path
+  expect(heartbeat?.path).not.toMatch(/^\//);
+  expect(heartbeat?.path).not.toContain(workspaceDir);
+});
+```
+
+---
+
+#### TC-243-U-02: All canonical `db:` namespace variants pass through unchanged
+
+```ts
+it.each([
+  ['db:UNIVERSAL/USER.md',                                    'USER.md'],
+  ['db:GLOBAL/COMMUNICATION.md',                             'COMMUNICATION.md'],
+  ['db:DOMAIN:Quality Assurance/AB_TESTING_METHODOLOGY.md', 'AB_TESTING_METHODOLOGY.md'],
+  ['db:WORKFLOW:Daily Inspiration Art/WORKFLOW.md',          'WORKFLOW.md'],
+  ['db:agent/SOUL.md',                                       'SOUL.md'], // lowercase db prefix still qualifies
+])('preserves synthetic path %s unchanged', async (syntheticPath, name) => {
+  registerInternalHook('agent:bootstrap', (event) => {
+    const ctx = event.context as AgentBootstrapHookContext;
+    ctx.bootstrapFiles = [
+      ...ctx.bootstrapFiles,
+      { name, path: syntheticPath, content: 'content', missing: false },
+    ];
+  });
+
+  const workspaceDir = await makeTempWorkspace('openclaw-bootstrap-');
+  const files = await resolveBootstrapFilesForRun({ workspaceDir });
+  const file = files.find(f => f.name === name);
+
+  expect(file?.path).toBe(syntheticPath);
+});
+```
+
+> **Design note:** The regex `^[A-Za-z][A-Za-z0-9_-]*:` is case-insensitive on the prefix. `db:` and `DB:` and `Db:` all qualify. The test above uses lowercase `db:agent/SOUL.md` to confirm this. I)ruid should confirm whether mixed-case namespace prefixes are expected in production — if only `db:`, `fallback:`, `emergency:` are valid, a stricter allowlist could replace the regex.
+
+---
+
+#### TC-243-U-03: `fallback:UNIVERSAL_SEED.md` passes through unchanged
+
+```ts
+it('preserves fallback: namespace path unchanged', async () => {
+  registerInternalHook('agent:bootstrap', (event) => {
+    const ctx = event.context as AgentBootstrapHookContext;
+    ctx.bootstrapFiles = [
+      ...ctx.bootstrapFiles,
+      { name: 'UNIVERSAL_SEED.md', path: 'fallback:UNIVERSAL_SEED.md', content: 'seed', missing: false },
+    ];
+  });
+
+  const workspaceDir = await makeTempWorkspace('openclaw-bootstrap-');
+  const files = await resolveBootstrapFilesForRun({ workspaceDir });
+  const file = files.find(f => f.name === 'UNIVERSAL_SEED.md');
+
+  expect(file?.path).toBe('fallback:UNIVERSAL_SEED.md');
+});
+```
+
+---
+
+#### TC-243-U-04: `emergency:RECOVERY.md` passes through unchanged
+
+```ts
+it('preserves emergency: namespace path unchanged', async () => {
+  registerInternalHook('agent:bootstrap', (event) => {
+    const ctx = event.context as AgentBootstrapHookContext;
+    ctx.bootstrapFiles = [
+      ...ctx.bootstrapFiles,
+      { name: 'RECOVERY.md', path: 'emergency:RECOVERY.md', content: 'recovery', missing: false },
+    ];
+  });
+
+  const workspaceDir = await makeTempWorkspace('openclaw-bootstrap-');
+  const files = await resolveBootstrapFilesForRun({ workspaceDir });
+  const file = files.find(f => f.name === 'RECOVERY.md');
+
+  expect(file?.path).toBe('emergency:RECOVERY.md');
+});
+```
+
+---
+
+#### TC-243-U-05: Normal workspace-relative path still resolved (no regression)
+
+```ts
+it('still resolves workspace-relative path AGENTS.md normally', async () => {
+  const workspaceDir = await makeTempWorkspace('openclaw-bootstrap-');
+  await fs.writeFile(path.join(workspaceDir, 'AGENTS.md'), 'rules', 'utf8');
+
+  const files = await resolveBootstrapFilesForRun({ workspaceDir });
+  const agents = files.find(f => f.name === 'AGENTS.md');
+
+  expect(agents?.path).toBe(path.join(workspaceDir, 'AGENTS.md'));
+  // Must be an absolute path
+  expect(path.isAbsolute(agents?.path ?? '')).toBe(true);
+});
+```
+
+---
+
+#### TC-243-U-06: Absolute filesystem path still resolved normally (no regression)
+
+```ts
+it('still handles absolute path /tmp/something.md normally', async () => {
+  const absolutePath = '/tmp/openclaw-test-bootstrap-file.md';
+  await fs.writeFile(absolutePath, 'absolute content', 'utf8');
+
+  registerInternalHook('agent:bootstrap', (event) => {
+    const ctx = event.context as AgentBootstrapHookContext;
+    ctx.bootstrapFiles = [
+      ...ctx.bootstrapFiles,
+      { name: 'something.md', path: absolutePath, content: 'absolute content', missing: false },
+    ];
+  });
+
+  const workspaceDir = await makeTempWorkspace('openclaw-bootstrap-');
+  const files = await resolveBootstrapFilesForRun({ workspaceDir });
+  const file = files.find(f => f.name === 'something.md');
+
+  expect(file?.path).toBe(absolutePath); // resolved absolute remains absolute
+  await fs.unlink(absolutePath).catch(() => {});
+});
+```
+
+---
+
+### 2.2 — Dedupe Behavior with Synthetic Paths
+
+#### TC-243-DEDUP-01: Two identical synthetic paths → one entry survives
+
+```ts
+it('deduplicates identical synthetic paths', async () => {
+  registerInternalHook('agent:bootstrap', (event) => {
+    const ctx = event.context as AgentBootstrapHookContext;
+    ctx.bootstrapFiles = [
+      ...ctx.bootstrapFiles,
+      { name: 'HEARTBEAT.md', path: 'db:AGENT/HEARTBEAT.md', content: 'first',  missing: false },
+      { name: 'HEARTBEAT.md', path: 'db:AGENT/HEARTBEAT.md', content: 'second', missing: false },
+    ];
+  });
+
+  const workspaceDir = await makeTempWorkspace('openclaw-bootstrap-');
+  const files = await resolveBootstrapFilesForRun({ workspaceDir });
+  const heartbeats = files.filter(f => f.path === 'db:AGENT/HEARTBEAT.md');
+
+  expect(heartbeats).toHaveLength(1);
+  expect(heartbeats[0]?.content).toBe('first'); // first-seen wins
+});
+```
+
+---
+
+#### TC-243-DEDUP-02: Synthetic path and workspace-relative with same-looking filename are NOT collapsed
+
+**Rationale:** `db:AGENT/HEARTBEAT.md` and a workspace file named `HEARTBEAT.md` are distinct entries. They must not collide during deduplication.
+
+```ts
+it('does not collapse synthetic path and workspace-relative path with same filename', async () => {
+  registerInternalHook('agent:bootstrap', (event) => {
+    const ctx = event.context as AgentBootstrapHookContext;
+    ctx.bootstrapFiles = [
+      ...ctx.bootstrapFiles,
+      { name: 'HEARTBEAT.md', path: 'db:AGENT/HEARTBEAT.md',            content: 'db content',        missing: false },
+      { name: 'HEARTBEAT.md', path: path.join(ctx.workspaceDir, 'HEARTBEAT.md'), content: 'fs content', missing: false },
+    ];
+  });
+
+  const workspaceDir = await makeTempWorkspace('openclaw-bootstrap-');
+  await fs.writeFile(path.join(workspaceDir, 'HEARTBEAT.md'), 'fs content', 'utf8');
+
+  const files = await resolveBootstrapFilesForRun({ workspaceDir });
+  const heartbeats = files.filter(f => f.name === 'HEARTBEAT.md');
+
+  // Both entries survive — they have different resolved path keys
+  expect(heartbeats).toHaveLength(2);
+  const paths = heartbeats.map(f => f.path);
+  expect(paths).toContain('db:AGENT/HEARTBEAT.md');
+  expect(paths).toContain(path.join(workspaceDir, 'HEARTBEAT.md'));
+});
+```
+
+> **Design question for I)ruid / Coder:** The existing dedupe uses `path.normalize(path.relative(workspaceRoot, resolvedPath))` as the key. For synthetic paths, the literal string itself must be the key. The implementation must NOT attempt `path.relative()` on synthetic paths. Confirm with Coder whether this produces two separate dedupe namespaces (synthetic strings vs relative FS keys) or requires a unified key scheme.
+
+---
+
+#### TC-243-DEDUP-03: Two different synthetic paths with same-looking suffix remain distinct
+
+```ts
+it('does not collapse distinct synthetic namespaces with same filename', async () => {
+  registerInternalHook('agent:bootstrap', (event) => {
+    const ctx = event.context as AgentBootstrapHookContext;
+    ctx.bootstrapFiles = [
+      ...ctx.bootstrapFiles,
+      { name: 'USER.md', path: 'db:UNIVERSAL/USER.md', content: 'universal', missing: false },
+      { name: 'USER.md', path: 'db:agent/USER.md',     content: 'agent',     missing: false },
+    ];
+  });
+
+  const workspaceDir = await makeTempWorkspace('openclaw-bootstrap-');
+  const files = await resolveBootstrapFilesForRun({ workspaceDir });
+  const userFiles = files.filter(f => f.name === 'USER.md');
+
+  expect(userFiles).toHaveLength(2);
+});
+```
+
+---
+
+### 2.3 — Negative Cases: Non-Synthetic Colon-Containing Paths
+
+**Assertion:** The following path strings do NOT match `^[A-Za-z][A-Za-z0-9_-]*:` and must flow through normal path resolution (not the synthetic bypass).
+
+#### TC-243-NEG-01: Numeric-leading "namespace" is not synthetic
+
+```
+:leading-colon.md         — starts with colon, no alpha prefix
+1db:something.md          — leading digit, fails [A-Za-z] requirement
+foo/db:bar.md             — colon not at position after the first segment (has slash before it)
+```
+
+**Test approach:**
+
+```ts
+it.each([
+  [':leading-colon.md'],
+  ['1db:something.md'],
+  ['foo/db:bar.md'],
+])('non-synthetic path %s goes through normal resolution', async (nonSyntheticPath) => {
+  registerInternalHook('agent:bootstrap', (event) => {
+    const ctx = event.context as AgentBootstrapHookContext;
+    ctx.bootstrapFiles = [
+      ...ctx.bootstrapFiles,
+      { name: 'weird.md', path: nonSyntheticPath, content: 'content', missing: false },
+    ];
+  });
+
+  const workspaceDir = await makeTempWorkspace('openclaw-bootstrap-');
+  const files = await resolveBootstrapFilesForRun({ workspaceDir });
+  const file = files.find(f => f.name === 'weird.md');
+
+  // The path must be resolved (absolute), NOT the raw input string
+  // (The file won't exist on disk, so the behavior depends on whether
+  //  the sanitizer drops missing paths or includes them. Adjust assertion accordingly.)
+  if (file) {
+    expect(path.isAbsolute(file.path)).toBe(true);
+    expect(file.path).not.toBe(nonSyntheticPath);
+  }
+  // If the file is dropped (missing path that doesn't exist), that's also acceptable —
+  // the key point is it did NOT pass through as an opaque synthetic identifier.
+});
+```
+
+> **Design clarification I need from I)ruid:** What is the expected behavior when a non-synthetic colon-containing path resolves to a real filesystem path? (e.g., if `/home/nova/workspace/foo/db:bar.md` actually exists). The test above accounts for both drop and include outcomes. Please confirm which is authoritative.
+
+---
+
+#### TC-243-NEG-02: Path with colon embedded deep in segments is not synthetic
+
+`C:\Users\something.md` — Windows-style path. On Linux, path.isAbsolute returns false for this, so it would get `path.resolve()` applied. This is the cross-platform edge case (see TC-243-CROSS-01 below).
+
+---
+
+### 2.4 — Integration Test: End-to-End Context Injection with Synthetic Paths
+
+**Framework:** Integration test using the OpenClaw test harness  
+**Scope:** Confirm the system prompt's project-context block renders synthetic path names correctly, not as filesystem paths.
+
+#### TC-243-INT-01: System prompt contains `## db:AGENT/HEARTBEAT.md`, not `## /home/.../workspace/db:AGENT/HEARTBEAT.md`
+
+**Setup:**
+1. Start a test session via the test harness with a mock bootstrap hook that returns synthetic-path entries (as the real `bootstrap-context` plugin does)
+2. Capture the system prompt injected by the gateway
+
+**Assertion:**
+```ts
+// system prompt excerpt
+expect(systemPrompt).toMatch(/^## db:AGENT\/HEARTBEAT\.md/m);
+expect(systemPrompt).not.toMatch(/^## \/home\/.+\/workspace\/db:AGENT\/HEARTBEAT\.md/m);
+```
+
+**Alternative assertion (path header pattern):**
+```ts
+// No header should contain an absolute path to a synthetic db: file
+expect(systemPrompt).not.toMatch(/^## \/[^\n]+\/db:[^\n]+/m);
+```
+
+---
+
+#### TC-243-INT-02: Section heading uses exact casing from source value
+
+After both PRs deploy, the injected context block for NOVA should contain:
+```
+## db:UNIVERSAL/UNIVERSAL_SEED.md
+## db:GLOBAL/COMMUNICATION.md
+## db:agent/SOUL.md
+## db:agent/IDENTITY.md
+```
+
+(UNIVERSAL/GLOBAL uppercase from `get_agent_bootstrap()` fix; agent lowercase from current schema output — confirm final casing with I)ruid based on TC-244-BC test results)
+
+**Assertion:**
+```ts
+expect(systemPrompt).toMatch(/^## db:UNIVERSAL\//m);
+expect(systemPrompt).toMatch(/^## db:GLOBAL\//m);
+// NOT the old broken paths
+expect(systemPrompt).not.toMatch(/^## \/home/m);
+```
+
+---
+
+### 2.5 — Cross-Platform Path Semantics
+
+#### TC-243-CROSS-01: Synthetic path bypass does NOT call `path.isAbsolute` or `path.resolve`
+
+**Approach:** Code review assertion (no automated test needed, but should be verified in PR review).
+
+The implementation must show that for any path matching `^[A-Za-z][A-Za-z0-9_-]*:`, the code returns the path value directly without calling `path.isAbsolute(pathValue)` or `path.resolve(workspaceRoot, pathValue)`.
+
+**Rationale:** On Windows, `path.isAbsolute('db:AGENT/HEARTBEAT.md')` would return `false` (not a drive letter path), so the path would hit `path.resolve()`. `path.resolve('C:\\workspace', 'db:AGENT/HEARTBEAT.md')` on Windows produces `C:\workspace\db:AGENT\HEARTBEAT.md` — wrong. The synthetic regex bypass must be the first check, before any `path.*` calls.
+
+**Automated proxy test:**
+```ts
+it('synthetic path is returned before any path.resolve is attempted', async () => {
+  const syntheticPath = 'db:AGENT/HEARTBEAT.md';
+
+  registerInternalHook('agent:bootstrap', (event) => {
+    const ctx = event.context as AgentBootstrapHookContext;
+    ctx.bootstrapFiles = [
+      ...ctx.bootstrapFiles,
+      { name: 'HEARTBEAT.md', path: syntheticPath, content: 'hb', missing: false },
+    ];
+  });
+
+  const workspaceDir = await makeTempWorkspace('openclaw-bootstrap-');
+  const files = await resolveBootstrapFilesForRun({ workspaceDir });
+  const file = files.find(f => f.name === 'HEARTBEAT.md');
+
+  // If path.resolve had been called, the result would be an absolute path.
+  // If synthetic bypass works, the path is exactly the input string.
+  expect(file?.path).toBe(syntheticPath);
+  expect(file?.path.startsWith('/')).toBe(false);  // Not an absolute POSIX path
+  expect(file?.path.match(/^[A-Za-z]:\\/)).toBeNull(); // Not a Windows drive path
+});
+```
+
+**Document assumption:** This codebase runs on Linux (Ubuntu on AWS). Windows path semantics are not a production concern, but the synthetic check must structurally precede `path.*` calls to be correct on all platforms.
+
+---
+
+## Coordination Notes
+
+### Deploy Coupling
+
+| Scenario | Risk | Recommendation |
+|----------|------|----------------|
+| Ship #244 without #243 | Bootstrap context renders `db:universal/FILENAME.md` → `sanitizeBootstrapFiles` resolves it to `/home/.../workspace/db:universal/FILENAME.md`. **No behavior regression** — the path was already broken before #244, and the casing change doesn't make it worse. | Acceptable gap. |
+| Ship #243 without #244's casing fix | `sanitizeBootstrapFiles` now preserves synthetic paths correctly, but `get_agent_bootstrap()` still emits `'universal'`/`'global'` — so paths are `db:universal/...` (lowercase). The context headers render with wrong casing. | Functionally works, aesthetically wrong. Acceptable short gap but should be same-day resolved. |
+| Ship #243 without #244's `agent_config_sync` swap | Peer gateways (newhart, graybeard) still get wrong agents.json. Completely unrelated to #243. | Ship #244 first or together. |
+
+**Recommended deploy order:** Stage and test #244 first (larger impact, DB side), then #243 (SDK side, narrower blast radius). A coordinated same-deploy-window rollout is ideal.
+
+### Staging Environment Checklist
+
+- [ ] nova-openclaw staging clone running (`nova-staging@localhost`)
+- [ ] nova-mind installed on same host via `bash agent-install.sh`
+- [ ] Both gateways (nova and newhart) pointed at the same `nova_memory` PostgreSQL instance
+- [ ] `get_agent_export_rows()` confirmed deployed (it is — run `SELECT * FROM get_agent_export_rows();` as the nova role to verify)
+- [ ] pgTAP installed in staging PostgreSQL (`CREATE EXTENSION IF NOT EXISTS pgtap`)
+- [ ] Test subagent with exclusive `parent_agents = ARRAY['nova']` confirmed (or created) for TC-244-DB-04
+
+### Casing Scheme Confirmation Needed
+
+The task specifies: `db:UNIVERSAL/...`, `db:GLOBAL/...`, `db:DOMAIN:Quality Assurance/...`, `db:WORKFLOW:Daily Inspiration Art/...`, `db:agent/...`.
+
+The pattern appears to be: section-level names (`UNIVERSAL`, `GLOBAL`, `DOMAIN`, `WORKFLOW`) are UPPERCASE; the namespace prefix `db:` itself is lowercase. **Confirm before Step 4:** Is `db:agent/SOUL.md` the correct casing, or is it `db:AGENT/SOUL.md`? The `get_agent_bootstrap()` fix capitalizes the source values — so if `source = 'AGENT'` after the fix, the path would be `db:AGENT/SOUL.md`. I need I)ruid to confirm the intended final casing before Coder implements the schema change.
+
+---
+
+## Spec Gaps & Questions for I)ruid
+
+1. **`db:agent/` vs `db:AGENT/` casing:** After the `get_agent_bootstrap()` fix, the source literal will be `'AGENT'`, producing `db:AGENT/SOUL.md`. Is this the intended form? My test cases use `db:AGENT/HEARTBEAT.md` per the task spec, but I want Coder to be explicit in the implementation.
+
+2. **Shared subagents (TC-244-DB-04):** If `scout` is in both `nova.parent_agents` and `newhart.parent_agents`, then Newhart will see scout in its agents.json. The test for "Newhart doesn't see NOVA's private subagents" needs a confirmed nova-exclusive subagent to use. What agent is confirmed nova-only?
+
+3. **Non-synthetic colon path behavior (TC-243-NEG-01):** When a path like `foo/db:bar.md` goes through normal resolution and the file doesn't exist, is the entry dropped or kept with the resolved path? The existing `sanitizeBootstrapFiles` doesn't drop missing paths — it only validates the path field. Confirm expected behavior.
+
+4. **`sanitizeBootstrapFiles` export:** The function is currently unexported (`function sanitizeBootstrapFiles`, not `export function`). To write truly isolated unit tests, it should be exported. As a design decision, do you want direct unit tests (requires export) or all-indirect tests via `resolveBootstrapFilesForRun` hooks (current pattern)? My test cases above use the hook-injection pattern — no export needed — but direct tests would be cleaner.
+
+5. **pgTAP test role for TC-244-DB-05:** Which DB-only role (no agents row) exists in the test environment and can be used with `SET ROLE`?
+
+---
+
+## Additional Test Cases Beyond the Spec
+
+### TC-243-U-EXTRA-01: Warning NOT emitted for synthetic paths
+
+Synthetic paths are valid by design — the sanitizer must not warn about them. Verify no warning is emitted when a synthetic path is encountered.
+
+```ts
+it('does not emit a warning for valid synthetic paths', async () => {
+  registerInternalHook('agent:bootstrap', (event) => {
+    const ctx = event.context as AgentBootstrapHookContext;
+    ctx.bootstrapFiles = [
+      ...ctx.bootstrapFiles,
+      { name: 'HEARTBEAT.md', path: 'db:AGENT/HEARTBEAT.md', content: 'hb', missing: false },
+    ];
+  });
+
+  const workspaceDir = await makeTempWorkspace('openclaw-bootstrap-');
+  const warnings: string[] = [];
+  await resolveBootstrapFilesForRun({
+    workspaceDir,
+    warn: (msg) => warnings.push(msg),
+  });
+
+  expect(warnings.filter(w => w.includes('db:AGENT'))).toHaveLength(0);
+});
+```
+
+---
+
+### TC-244-DB-EXTRA-01: `get_agent_export_rows()` ORDER BY — default row first
+
+The function has `ORDER BY 6 DESC, 1` (column 6 = is_default DESC, column 1 = name ASC). Verify the default agent appears first.
+
+```sql
+SET ROLE nova;
+SELECT is(
+  (SELECT name FROM get_agent_export_rows() LIMIT 1),
+  'nova',
+  'nova (the default) appears first in get_agent_export_rows()'
+);
+```
+
+---
+
+### TC-244-COMPAT-EXTRA-01: Package.json version bump is present
+
+```bash
+# After PR #244 is applied
+grep '"version"' cognition/focus/agent-config-sync/package.json | head -1
+```
+
+**Manual check:** Version string must have been incremented relative to the pre-PR value.
+
+---
+
+## Summary: Pass/Fail Criteria for QA Sign-Off
+
+### PR #244 (nova-mind)
+
+| Gate | Test IDs | Required for sign-off |
+|------|----------|-----------------------|
+| Unit: buildAgentsList() scoping | TC-244-U-01 through 05 | All pass |
+| DB: get_agent_export_rows() scoping | TC-244-DB-01 through 07 | All pass |
+| DB: get_agent_bootstrap() source casing | TC-244-BC-01 through 05 | All pass |
+| E2E: trigger → file write chain | TC-244-E2E-01 through 03 | 01 and 02 required; 03 recommended |
+| Backward compat: NOVA subagent set | TC-244-COMPAT-01, 02 | Both pass |
+| Doc: no stale instance_type reference | TC-244-DOC-01 through 03 | All pass |
+
+### PR #243 (nova-openclaw)
+
+| Gate | Test IDs | Required for sign-off |
+|------|----------|-----------------------|
+| Unit: synthetic path preservation | TC-243-U-01 through 06 | All pass |
+| Dedupe: synthetic paths | TC-243-DEDUP-01 through 03 | All pass |
+| Negative cases: non-synthetic colons | TC-243-NEG-01, 02 | NEG-01 required; NEG-02 documented |
+| Integration: system prompt headers | TC-243-INT-01, 02 | INT-01 required |
+| Cross-platform: no path.resolve on synthetic | TC-243-CROSS-01 | Pass (code review + test) |
+| No spurious warnings | TC-243-U-EXTRA-01 | Pass |
+
+**No S1/S2 open defects at time of sign-off.**  
+**Coverage gate:** TypeScript changes must not drop statement coverage below existing baseline (measure with `vitest --coverage` on changed files).  
+**pgTAP gate:** All SQL function tests pass with zero failures.


### PR DESCRIPTION
Closes #244.

Pairs with nova-openclaw#243 — must merge together; staging install order is nova-openclaw first, then nova-mind. Staging integration tests (SE-linux-platform-test workflow #21) passed 39/39, post-seed re-test on the seeded staging DB passed 28/29 (one environment-limited assertion accepted as non-blocking).

## What changed

`cognition/focus/agent-config-sync/src/sync.ts` — `AGENTS_QUERY` now selects from the DB function `get_agent_export_rows()` instead of `agents WHERE instance_type != 'peer' AND model IS NOT NULL`. The function uses `session_user` to scope results to the connecting peer plus subagents linked via `parent_agents` array overlap, so each peer gateway gets only its own agent set in `agents.json`. Fixes the default-agent confusion on Newhart/Graybeard gateways where they were previously seeing NOVA's subagents and falling back to NOVA as default.

`database/schema.sql` — `get_agent_bootstrap()` now emits UPPERCASE source literals (`UNIVERSAL`, `GLOBAL`, `DOMAIN:<name(s)>`, `WORKFLOW:<name>`, `AGENT`) so the synthetic identifiers composed by the bootstrap-context hook (`db:${row.source}/${row.filename}`) match the new `db:UNIVERSAL/...`, `db:DOMAIN:<name>/...`, `db:AGENT/...` form. Aligns the source field with the `agent_bootstrap_context.context_type` column values and gives the gateway sanitizer (nova-openclaw#243) consistent tier-prefixed identifiers to preserve verbatim.

## Tests

- `cognition/focus/agent-config-sync/src/sync.test.ts` — 24 new unit assertions for `buildAgentsList()` against `get_agent_export_rows()` (TC-244-U-01..05): peer-as-default emission, subagent ownership filtering, `is_default` handling, empty-result safety, cross-peer leakage absence.
- `tests/TEST-CASES-batch-agent-identity.md` — 1,045-line test design for the coordinated #244 + #243 staging rollout.

## Docs (Step 9)

- `CHANGELOG.md` — top-level batch entry for the agent-identity-batch (#244 + nova-openclaw#243).
- `cognition/CHANGELOG.md` — new Unreleased entry under #244 covering AGENTS_QUERY rewrite + source-label casing.
- `cognition/focus/bootstrap-context/README.md` — sources-returned list updated to UPPERCASE with a note about gateway-side synthetic-path preservation.
- `cognition/tests/TEST-CASES-ISSUE-97.md` — deprecation banner noting lowercase source assertions now return 0 rows after #244.

## Step 9 note

Step 9 (Technical Writing audit) was completed inline by NOVA (Project Leadership) for this run after 6 Scribe provider failures across Google, Venice, OpenAI Codex, and local Ollama. Scribe spawn remains broken; investigation pending.
