### PR TITLE
fix(bootstrap-context): add pg dependency to package.json and npm install to installer

### DIFF
--- a/cognition/focus/bootstrap-context/hook/package.json
+++ b/cognition/focus/bootstrap-context/hook/package.json
@@ -1,5 +1,8 @@
 {
   "name": "db-bootstrap-context",
   "version": "1.0.0",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "pg": "^8.21.0"
+  }
 }

--- a/cognition/focus/bootstrap-context/install.sh
+++ b/cognition/focus/bootstrap-context/install.sh
@@ -43,7 +43,21 @@ echo "Installing OpenClaw hook..."
 mkdir -p "$HOOK_DIR"
 cp "$SCRIPT_DIR/hook/handler.ts" "$HOOK_DIR/"
 cp "$SCRIPT_DIR/hook/HOOK.md" "$HOOK_DIR/"
-echo "✅ Hook installed at $HOOK_DIR"
+cp "$SCRIPT_DIR/hook/package.json" "$HOOK_DIR/"
+echo "✅ Hook files installed at $HOOK_DIR"
+
+# Install hook Node.js dependencies
+echo "Installing hook dependencies..."
+if command -v npm &> /dev/null; then
+    (cd "$HOOK_DIR" && npm install --production 2>&1) || {
+        echo "❌ Error: npm install failed in $HOOK_DIR"
+        exit 1
+    }
+    echo "✅ Hook dependencies installed"
+else
+    echo "❌ Error: npm not found. Required to install hook dependencies (pg)."
+    exit 1
+fi
 echo ""
 
 # Create fallback directory


### PR DESCRIPTION
The hook imports `pg` but it was never declared in package.json and the installer never ran npm install. This caused the hook to fail silently whenever it couldn't resolve pg from a parent node_modules.

- Added pg ^8.21.0 to hook/package.json dependencies
- Added npm install step to install.sh after copying hook files