### PR TITLE
fix: also catch UndefinedColumn for missing tables in memory-maintenance.py

### DIFF
--- a/memory/scripts/memory-maintenance.py
+++ b/memory/scripts/memory-maintenance.py
@@ -247,7 +247,7 @@ def _embed_table(cur, query, source_type, cfg):
     cur.execute("SAVEPOINT embed_check")
     try:
         cur.execute(query)
-    except psycopg2.errors.UndefinedTable:
+    except (psycopg2.errors.UndefinedTable, psycopg2.errors.UndefinedColumn):
         cur.execute("ROLLBACK TO SAVEPOINT embed_check")
         logger.warning("[WARN] Table not found, skipping: %s", source_type)
         return 0


### PR DESCRIPTION
Follow-up fix for #283: broadens the except clause in `_embed_table` to catch both `psycopg2.errors.UndefinedTable` and `psycopg2.errors.UndefinedColumn`.

PostgreSQL can raise `UndefinedColumn` for missing tables when the query references columns with COALESCE wrappers — the planner may error on columns before the table. This ensures both error types are handled gracefully with the same SAVEPOINT rollback and warning log.

Closes #283