### PR TITLE
fix: correct research_conclusions column name and add error handling in phase_embed_research

### DIFF
--- a/memory/scripts/memory-maintenance.py
+++ b/memory/scripts/memory-maintenance.py
@@ -283,37 +283,55 @@ def phase_embed_research(conn, cfg, dry_run=False, verbose=False):
     total = 0
 
     # research_task
-    cur.execute("SELECT id, query AS text FROM research_tasks WHERE query IS NOT NULL")
-    rows = cur.fetchall()
-    items = [{"id": r[0], "text": r[1]} for r in rows if not _already_embedded(cur, "research_task", r[0])]
-    if items:
-        for i in range(0, len(items), EMBED_BATCH_SIZE):
-            batch = items[i : i + EMBED_BATCH_SIZE]
-            embeddings = embed_texts([it["text"] for it in batch], cfg)
-            _store_embeddings(cur, "research_task", batch, embeddings)
-            total += len(batch)
+    cur.execute("SAVEPOINT embed_research_task")
+    try:
+        cur.execute("SELECT id, query AS text FROM research_tasks WHERE query IS NOT NULL")
+    except (psycopg2.errors.UndefinedTable, psycopg2.errors.UndefinedColumn):
+        cur.execute("ROLLBACK TO SAVEPOINT embed_research_task")
+        logger.warning("[WARN] Table not found, skipping: research_task")
+    else:
+        rows = cur.fetchall()
+        items = [{"id": r[0], "text": r[1]} for r in rows if not _already_embedded(cur, "research_task", r[0])]
+        if items:
+            for i in range(0, len(items), EMBED_BATCH_SIZE):
+                batch = items[i : i + EMBED_BATCH_SIZE]
+                embeddings = embed_texts([it["text"] for it in batch], cfg)
+                _store_embeddings(cur, "research_task", batch, embeddings)
+                total += len(batch)
 
     # research_finding (is_current=true)
-    cur.execute("SELECT id, content AS text FROM research_findings WHERE is_current = true AND content IS NOT NULL")
-    rows = cur.fetchall()
-    items = [{"id": r[0], "text": r[1]} for r in rows if not _already_embedded(cur, "research_finding", r[0])]
-    if items:
-        for i in range(0, len(items), EMBED_BATCH_SIZE):
-            batch = items[i : i + EMBED_BATCH_SIZE]
-            embeddings = embed_texts([it["text"] for it in batch], cfg)
-            _store_embeddings(cur, "research_finding", batch, embeddings)
-            total += len(batch)
+    cur.execute("SAVEPOINT embed_research_finding")
+    try:
+        cur.execute("SELECT id, content AS text FROM research_findings WHERE is_current = true AND content IS NOT NULL")
+    except (psycopg2.errors.UndefinedTable, psycopg2.errors.UndefinedColumn):
+        cur.execute("ROLLBACK TO SAVEPOINT embed_research_finding")
+        logger.warning("[WARN] Table not found, skipping: research_finding")
+    else:
+        rows = cur.fetchall()
+        items = [{"id": r[0], "text": r[1]} for r in rows if not _already_embedded(cur, "research_finding", r[0])]
+        if items:
+            for i in range(0, len(items), EMBED_BATCH_SIZE):
+                batch = items[i : i + EMBED_BATCH_SIZE]
+                embeddings = embed_texts([it["text"] for it in batch], cfg)
+                _store_embeddings(cur, "research_finding", batch, embeddings)
+                total += len(batch)
 
     # research_conclusion (is_current=true)
-    cur.execute("SELECT id, content AS text FROM research_conclusions WHERE is_current = true AND content IS NOT NULL")
-    rows = cur.fetchall()
-    items = [{"id": r[0], "text": r[1]} for r in rows if not _already_embedded(cur, "research_conclusion", r[0])]
-    if items:
-        for i in range(0, len(items), EMBED_BATCH_SIZE):
-            batch = items[i : i + EMBED_BATCH_SIZE]
-            embeddings = embed_texts([it["text"] for it in batch], cfg)
-            _store_embeddings(cur, "research_conclusion", batch, embeddings)
-            total += len(batch)
+    cur.execute("SAVEPOINT embed_research_conclusion")
+    try:
+        cur.execute("SELECT id, full_content AS text FROM research_conclusions WHERE is_current = true AND full_content IS NOT NULL")
+    except (psycopg2.errors.UndefinedTable, psycopg2.errors.UndefinedColumn):
+        cur.execute("ROLLBACK TO SAVEPOINT embed_research_conclusion")
+        logger.warning("[WARN] Table not found, skipping: research_conclusion")
+    else:
+        rows = cur.fetchall()
+        items = [{"id": r[0], "text": r[1]} for r in rows if not _already_embedded(cur, "research_conclusion", r[0])]
+        if items:
+            for i in range(0, len(items), EMBED_BATCH_SIZE):
+                batch = items[i : i + EMBED_BATCH_SIZE]
+                embeddings = embed_texts([it["text"] for it in batch], cfg)
+                _store_embeddings(cur, "research_conclusion", batch, embeddings)
+                total += len(batch)
 
     if verbose and total:
         logger.info(f"  Embedded {total} research records")


### PR DESCRIPTION
## Summary

Fixes #286

### Changes

**Bug fix:**  was querying `research_conclusions.content` which doesn't exist — the actual column is `full_content`. This caused the embedding phase to fail with an `UndefinedColumn` error.

**Hardening:** Wrapped all three `cur.execute()` calls in `phase_embed_research` (research_tasks, research_findings, research_conclusions) with the same SAVEPOINT/ROLLBACK error handling pattern used in `_embed_table`, so missing tables or columns are caught gracefully and logged as warnings instead of crashing the maintenance run.

### Files changed
- `memory/scripts/memory-maintenance.py`: Fixed column name + added SAVEPOINT error handling for all three research embed queries