### PR TITLE
feat: Domain routing, tiered recall, visibility filtering (#150, #140, #168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+### Batch: domain-routing-tiered-recall (Issues #150, #140, #168)
+
+#### Added
+- **Message Type Classifier** (`classifier.ts`) — Rule-based classification of inbound messages into `info_request`, `action`, `conversation`, `continuation`, `command`. Ollama LLM fallback for ambiguous cases. Handles ~60-70% of messages without LLM.
+- **Domain Identifier** (`domain-identifier.ts`) — Matches messages to subject-matter domains via keyword matching + embedding similarity against `agent_domains` table. Returns top 1-3 ranked domains with assigned agent names (resolved via JOIN, not hardcoded).
+- **`prompt_helper_config` table** — Configurable per-message-type gating for turn-context subsystems. Per-agent overrides supported.
+- **`agent_domains.keywords` column** — Keyword arrays for fast domain matching. All 38 domains seeded.
+- **Domain embedding seeder** (`seed-domain-embeddings.py`) — Embeds domain descriptions into `memory_embeddings` for vector similarity matching.
+- **Visibility filtering** in `proactive-recall.py` — Group channels filter entity_facts to `visibility = 'public'` only via JOIN. DM channels show all facts.
+- **Tiered recall** — Domain-scoped search first when domain hints available, full vector search as fallback.
+
+#### Changed
+- **`index.ts`** — Classifier-first dispatch architecture. Subsystems gated by `prompt_helper_config` table. Turn reminders always fire regardless of message type.
+- **`entity-resolver.ts`** — Cache key changed from `sessionKey` to `sessionKey:senderId` (bugfix for group channels). Now returns `{ text, entityId }` tuple.
+- **`semantic-recall.ts`** — Accepts `domainHints`, `entityId`, `isGroup` params. Passes through to `proactive-recall.py`.
+- **`proactive-recall.py`** — Accepts `entity_id`, `is_group`, `domain_hints` via stdin JSON. Tiered recall with domain-scoped SQL query. Visibility filtering via LEFT JOIN on entity_facts.
+
+#### Migrations
+- `081_prompt_helper_config.sql` — Creates `prompt_helper_config` table, adds `keywords TEXT[]` to `agent_domains`, populates notes/keywords for all 38 domains. **Note:** Must be run split — `agent_domains` changes as newhart (table owner), `prompt_helper_config` as nova.
+
+#### Issues Closed
+- #150 — Selective semantic recall + prompt preprocessing for domain routing
+- #140 — Tiered recall strategy
+- #168 — Visibility filter in semantic-recall hook
+
+---
+
 ### Batch: ghost-entity-prevention (Issues #230, #267, #295)
 
 #### Changed

--- a/cognition/focus/agent-config-sync/tests/test-cases-273.md
+++ b/cognition/focus/agent-config-sync/tests/test-cases-273.md
@@ -1,0 +1,33 @@
+# Test Cases — Issue #273: Heartbeat config in agents.json
+
+## TC-1: Agent with heartbeat enabled + full config
+**Input row:** `{ name: "nova", heartbeat_enabled: true, heartbeat_every: "5m", heartbeat_target: "discord", heartbeat_to: "channel:123" }`
+**Expected:** Entry includes `heartbeat: { every: "5m", target: "discord", to: "channel:123" }`
+
+## TC-2: Agent with heartbeat explicitly disabled
+**Input row:** `{ name: "scout", heartbeat_enabled: false, heartbeat_every: null, heartbeat_target: null, heartbeat_to: null }`
+**Expected:** Entry includes `heartbeat: false`
+
+## TC-3: Agent with heartbeat_enabled = null (legacy/unset)
+**Input row:** `{ name: "legacy", heartbeat_enabled: null }`
+**Expected:** Entry does NOT include a `heartbeat` key (omitted entirely)
+
+## TC-4: heartbeat_enabled = true but heartbeat_every is null
+**Input row:** `{ name: "misconfigured", heartbeat_enabled: true, heartbeat_every: null, heartbeat_target: "discord", heartbeat_to: "channel:123" }`
+**Expected:** Entry includes `heartbeat: false` (enabled but no interval = effectively disabled)
+
+## TC-5: heartbeat_enabled = true with partial config (no target/to)
+**Input row:** `{ name: "partial", heartbeat_enabled: true, heartbeat_every: "10m", heartbeat_target: null, heartbeat_to: null }`
+**Expected:** Entry includes `heartbeat: { every: "10m" }` (only non-null fields emitted)
+
+## TC-6: Mixed agents in same batch
+**Input rows:** nova (enabled), scout (disabled), legacy (null)
+**Expected:** Each agent has correct heartbeat config per TC-1/TC-2/TC-3
+
+## TC-7: Existing fields unaffected
+**Input row:** Agent with model, fallbacks, default, subagents, AND heartbeat config
+**Expected:** All existing fields (id, model, default, subagents) are identical to pre-change output; heartbeat is additive only
+
+## TC-8: End-to-end sync round-trip
+**Action:** Update heartbeat config in DB → trigger NOTIFY → check agents.json
+**Expected:** agents.json reflects the heartbeat config from the DB

--- a/memory/migrations/081_prompt_helper_config.sql
+++ b/memory/migrations/081_prompt_helper_config.sql
@@ -1,0 +1,399 @@
+-- Migration 081: Prompt Helper Config, agent_domains keywords/notes, domain seeding
+-- Issues: #150 (classifier-first dispatch), #140 (tiered recall), #168 (visibility filter)
+--
+-- Parts that modify agent_domains (ALTER TABLE, UPDATE) require the table owner
+-- (newhart) or a superuser. Run this migration as newhart or postgres.
+--
+-- Idempotent: all statements use IF NOT EXISTS / ON CONFLICT / conditional UPDATE.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Part 1: Create prompt_helper_config table
+-- Controls which turn-context subsystems are enabled per message_type per agent.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS prompt_helper_config (
+    id           SERIAL PRIMARY KEY,
+    message_type TEXT    NOT NULL,
+    helper_name  TEXT    NOT NULL,
+    enabled      BOOLEAN NOT NULL DEFAULT true,
+    priority     INT     NOT NULL DEFAULT 0,
+    config       JSONB   NOT NULL DEFAULT '{}',
+    agent_name   TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT prompt_helper_config_message_type_check CHECK (
+        message_type IN ('info_request', 'action', 'conversation', 'continuation', 'command')
+    )
+);
+
+-- Functional unique index: one row per (message_type, helper_name, agent_name|default)
+-- NULL agent_name = default config; agent-specific rows override defaults.
+CREATE UNIQUE INDEX IF NOT EXISTS prompt_helper_config_unique_idx
+    ON prompt_helper_config (message_type, helper_name, COALESCE(agent_name, '__default__'));
+
+CREATE INDEX IF NOT EXISTS idx_prompt_helper_config_lookup
+    ON prompt_helper_config (message_type, agent_name);
+
+COMMENT ON TABLE prompt_helper_config IS
+    'Per-message-type gating for turn-context subsystems (entity_resolver, semantic_recall, domain_identifier, turn_reminders). '
+    'Rows with agent_name IS NULL are defaults; agent-specific rows override them. '
+    'turn_reminders always fires regardless of config.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Part 2: Add keywords column to agent_domains
+-- NOTE: Requires table owner (newhart) or superuser.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE agent_domains ADD COLUMN IF NOT EXISTS keywords TEXT[];
+
+CREATE INDEX IF NOT EXISTS idx_agent_domains_keywords_gin
+    ON agent_domains USING GIN (keywords);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Part 3: Populate notes for the 20 domains missing them
+-- NOTE: Requires table owner (newhart) or superuser (trigger: protect_agent_writes).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+UPDATE agent_domains SET notes = 'Agent lifecycle management — creating, configuring, and maintaining AI agents'
+    WHERE domain_topic = 'Agent Management' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Financial asset trading, portfolio management, and market analysis'
+    WHERE domain_topic = 'Asset Trading' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Cross-platform messaging, notifications, and communication routing'
+    WHERE domain_topic = 'Communications' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Fiction, poetry, storytelling, and narrative composition'
+    WHERE domain_topic = 'Creative Writing' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'PostgreSQL administration, schema design, query optimization, and data management'
+    WHERE domain_topic = 'Database' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Delaware corporate law, LLC formation, and business entity regulations'
+    WHERE domain_topic = 'Delaware Law' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Infrastructure automation, CI/CD pipelines, and deployment orchestration'
+    WHERE domain_topic = 'DevOps' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Technical documentation writing, README maintenance, and API docs'
+    WHERE domain_topic = 'Documentation' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Git version control operations — branching, merging, rebasing, and conflict resolution'
+    WHERE domain_topic = 'Git operations' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'General IT infrastructure, networking, and system configuration'
+    WHERE domain_topic = 'Information Technology' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Web research, information gathering, and source verification'
+    WHERE domain_topic = 'Internet Search' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'General legal research, analysis, and compliance'
+    WHERE domain_topic = 'Law' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Knowledge curation, cataloging, and reference management'
+    WHERE domain_topic = 'Library' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Music composition, production, and audio engineering'
+    WHERE domain_topic = 'Music' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'NOVA agent system operations, orchestration, and workflow management'
+    WHERE domain_topic = 'NOVA Operations' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Server and dependency updates, patch management'
+    WHERE domain_topic = 'Node updates' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'General software development, coding, and architecture design'
+    WHERE domain_topic = 'Software Development' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Linux server administration, service management, and monitoring'
+    WHERE domain_topic = 'Systems Administration' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Texas state law, regulations, and legal procedures'
+    WHERE domain_topic = 'Texas Law' AND (notes IS NULL OR notes = '');
+
+UPDATE agent_domains SET notes = 'Digital art creation, image generation, and visual design'
+    WHERE domain_topic = 'Visual Art' AND (notes IS NULL OR notes = '');
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Part 4: Seed keywords for all 38 domains
+-- NOTE: Requires table owner (newhart) or superuser (trigger: protect_agent_writes).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'agent', 'agent design', 'agent architecture', 'agent creation', 'agent onboarding',
+    'system prompt', 'persona', 'SOUL.md', 'IDENTITY.md', 'bootstrap context',
+    'agent config', 'agent schema', 'new agent', 'agent definition', 'agent role'
+] WHERE domain_topic = 'Agent Architecture';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'agent', 'manage agent', 'agent lifecycle', 'agent setup', 'configure agent',
+    'agent maintenance', 'spawn agent', 'agent update', 'agent modification',
+    'agent list', 'agent status', 'disable agent', 'enable agent'
+] WHERE domain_topic = 'Agent Management';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'trade', 'trading', 'buy stock', 'sell stock', 'crypto', 'bitcoin', 'portfolio',
+    'market', 'investment', 'asset', 'ticker', 'NASDAQ', 'NYSE', 'equity',
+    'option', 'futures', 'technical analysis', 'fundamental analysis', 'price chart',
+    'bull', 'bear', 'ETF', 'dividend', 'yield', 'position', 'shares'
+] WHERE domain_topic = 'Asset Trading';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'message', 'send message', 'notification', 'notify', 'alert', 'email',
+    'SMS', 'chat', 'channel', 'telegram', 'signal', 'slack', 'discord',
+    'WhatsApp', 'broadcast', 'comms', 'communication', 'messaging', 'route message'
+] WHERE domain_topic = 'Communications';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'write', 'writing', 'story', 'fiction', 'poem', 'poetry', 'narrative',
+    'character', 'plot', 'creative', 'author', 'novel', 'short story', 'prose',
+    'script', 'dialogue', 'worldbuilding', 'fantasy', 'sci-fi', 'genre'
+] WHERE domain_topic = 'Creative Writing';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'sql', 'postgres', 'postgresql', 'psql', 'query', 'schema', 'migration',
+    'table', 'index', 'trigger', 'function', 'database', 'db', 'pgvector',
+    'embedding', 'constraint', 'foreign key', 'primary key', 'transaction',
+    'DDL', 'DML', 'view', 'stored procedure', 'pg', 'nova_memory'
+] WHERE domain_topic = 'Database';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'deal', 'price', 'pricing', 'coupon', 'discount', 'sale', 'offer',
+    'promo', 'promotion', 'bargain', 'compare price', 'best price', 'lowest price',
+    'coupon code', 'voucher', 'cashback', 'rebate', 'clearance'
+] WHERE domain_topic = 'Deals & Pricing';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'delaware', 'DE', 'delaware law', 'LLC', 'incorporation', 'delaware corporation',
+    'registered agent', 'corporate charter', 'bylaws', 'court of chancery',
+    'delaware code', 'DGCL', 'articles of incorporation', 'operating agreement'
+] WHERE domain_topic = 'Delaware Law';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'devops', 'CI', 'CD', 'CI/CD', 'pipeline', 'deploy', 'deployment',
+    'kubernetes', 'k8s', 'docker', 'container', 'automation', 'infrastructure',
+    'IaC', 'terraform', 'ansible', 'github actions', 'jenkins', 'helm',
+    'ArgoCD', 'GitOps', 'build pipeline', 'release'
+] WHERE domain_topic = 'DevOps';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'document', 'documentation', 'docs', 'README', 'wiki', 'guide', 'manual',
+    'API docs', 'docstring', 'changelog', 'release notes', 'write docs',
+    'update docs', 'technical guide', 'how-to', 'reference doc'
+] WHERE domain_topic = 'Documentation';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'fable', 'fables', 'moral', 'aesop', 'allegory', 'parable', 'fairy tale',
+    'story with moral', 'animal story', 'tale', 'moral story', 'lesson story'
+] WHERE domain_topic = 'Fables';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'gift', 'gift ideas', 'present', 'birthday', 'anniversary', 'holiday gift',
+    'what to buy', 'gift suggestion', 'gift for', 'surprise', 'gift recommendation',
+    'wish list', 'gift shopping'
+] WHERE domain_topic = 'Gift Ideas';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'git', 'github', 'branch', 'merge', 'pull request', 'PR', 'commit',
+    'repo', 'repository', 'rebase', 'cherry-pick', 'stash', 'diff', 'clone',
+    'fork', 'push', 'pull', 'git log', 'git blame', 'conflict', 'merge conflict',
+    'git status', 'remote', 'origin', 'upstream', 'tag', 'git fetch'
+] WHERE domain_topic = 'Git operations';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'security', 'vulnerability', 'CVE', 'patch', 'hardening', 'firewall',
+    'IDS', 'IPS', 'SIEM', 'security audit', 'compliance', 'SSL', 'TLS',
+    'certificate', 'WAF', 'network security', 'ACL', 'access control'
+] WHERE domain_topic = 'IT Security';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'infosec', 'information security', 'cyber', 'cybersecurity', 'threat',
+    'attack', 'defense', 'encryption', 'authentication', 'authorization',
+    'zero trust', 'IAM', 'RBAC', 'SAST', 'DAST', 'security policy',
+    'incident response', 'risk', 'vulnerability management'
+] WHERE domain_topic = 'Information Security';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'IT', 'infrastructure', 'network', 'networking', 'DNS', 'DHCP', 'server',
+    'hardware', 'operating system', 'OS', 'Windows', 'Linux', 'macOS',
+    'cloud', 'AWS', 'Azure', 'GCP', 'virtualization', 'VPN', 'router',
+    'switch', 'firewall', 'IP address', 'subnet'
+] WHERE domain_topic = 'Information Technology';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'search', 'google', 'web search', 'research', 'find information', 'look up',
+    'browse', 'internet', 'online', 'website', 'URL', 'scrape', 'crawl',
+    'aggregate', 'fact check', 'verify', 'web research'
+] WHERE domain_topic = 'Internet Search';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'law', 'legal', 'attorney', 'lawyer', 'contract', 'lawsuit', 'litigation',
+    'court', 'judge', 'statute', 'regulation', 'compliance', 'legal advice',
+    'terms', 'agreement', 'NDA', 'IP', 'intellectual property', 'legal research'
+] WHERE domain_topic = 'Law';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'library', 'book', 'reference', 'catalog', 'knowledge', 'source',
+    'citation', 'bibliography', 'archive', 'collection', 'knowledge base',
+    'curate', 'library work', 'reading list', 'literature'
+] WHERE domain_topic = 'Library';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'music', 'song', 'audio', 'composition', 'melody', 'harmony', 'chord',
+    'beat', 'rhythm', 'lyrics', 'track', 'album', 'artist', 'genre',
+    'production', 'mixing', 'mastering', 'DAW', 'MIDI', 'instrument',
+    'recording', 'sound design', 'music theory'
+] WHERE domain_topic = 'Music';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'nova', 'agent system', 'NOVA', 'orchestration', 'workflow', 'agent ecosystem',
+    'coordination', 'task routing', 'openclaw', 'nova-mind', 'system config',
+    'operations', 'nova agent', 'agent routing', 'agent coordination'
+] WHERE domain_topic = 'NOVA Operations';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'node', 'node.js', 'npm', 'yarn', 'pnpm', 'package', 'dependency',
+    'update package', 'upgrade package', 'patch', 'node version', 'nvm',
+    'security patch', 'npm audit', 'package.json', 'lock file'
+] WHERE domain_topic = 'Node updates';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'openclaw', 'openclaw config', 'plugin', 'hook', 'skill', 'clawhub',
+    'gateway', 'channel config', 'agent config', 'openclaw.json', 'plugin SDK',
+    'hook system', 'before_prompt_build', 'message_received', 'turn-context',
+    'openclaw plugin', 'openclaw hook', 'openclaw skill', 'openclaw gateway'
+] WHERE domain_topic = 'OpenClaw Development';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'pentest', 'penetration test', 'pen test', 'red team', 'exploit',
+    'vulnerability', 'attack vector', 'privilege escalation', 'lateral movement',
+    'payload', 'metasploit', 'nmap', 'burp suite', 'OWASP', 'CTF',
+    'recon', 'enumeration', 'post exploitation', 'phishing', 'social engineering'
+] WHERE domain_topic = 'Penetration Testing';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'product', 'review', 'spec', 'specification', 'comparison', 'benchmark',
+    'feature', 'evaluate', 'product research', 'consumer', 'rating',
+    'best product', 'compare products', 'buy guide', 'pros cons'
+] WHERE domain_topic = 'Product Research';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'project', 'planning', 'coordination', 'leadership', 'strategy', 'roadmap',
+    'milestone', 'deadline', 'stakeholder', 'team', 'sprint', 'agile',
+    'kanban', 'prioritize', 'delegate', 'project management', 'PM'
+] WHERE domain_topic = 'Project Leadership';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'QA', 'quality', 'testing', 'test', 'test case', 'bug', 'defect',
+    'validation', 'verification', 'acceptance criteria', 'regression',
+    'test plan', 'smoke test', 'UAT', 'quality assurance', 'test coverage'
+] WHERE domain_topic = 'Quality Assurance';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'research', 'investigate', 'analysis', 'data', 'study', 'survey', 'report',
+    'source', 'reference', 'fact-check', 'background', 'deep dive', 'explore',
+    'gather information', 'literature review', 'investigation'
+] WHERE domain_topic = 'Research';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'restock', 'inventory', 'replenish', 'stock', 'supply', 'order',
+    'consumable', 'out of stock', 'low stock', 'purchase order', 'vendor',
+    'supplier', 'track inventory', 'reorder', 'stock level'
+] WHERE domain_topic = 'Restock Management';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'shop', 'shopping', 'buy', 'purchase', 'order', 'Amazon', 'checkout',
+    'cart', 'product', 'item', 'store', 'retailer', 'price', 'cost',
+    'sale', 'deal', 'online shopping', 'e-commerce', 'add to cart'
+] WHERE domain_topic = 'Shopping';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'code', 'coding', 'develop', 'development', 'software', 'program',
+    'programming', 'implement', 'feature', 'refactor', 'API', 'backend',
+    'frontend', 'full stack', 'architecture', 'design pattern', 'codebase',
+    'library', 'framework', 'module', 'class', 'function', 'method'
+] WHERE domain_topic = 'Software Development';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'engineer', 'engineering', 'system design', 'scalability', 'performance',
+    'optimization', 'algorithm', 'data structure', 'OOP', 'SOLID', 'clean code',
+    'TDD', 'DDD', 'microservices', 'distributed', 'software engineering',
+    'architecture review', 'technical debt', 'code review'
+] WHERE domain_topic = 'Software Engineering';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'test', 'testing', 'unit test', 'integration test', 'e2e', 'end-to-end',
+    'test execution', 'test runner', 'jest', 'pytest', 'mocha', 'cypress',
+    'selenium', 'automated testing', 'test suite', 'run tests', 'flaky test'
+] WHERE domain_topic = 'Software Testing';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'sysadmin', 'system admin', 'linux', 'ubuntu', 'debian', 'centos', 'RHEL',
+    'systemd', 'service', 'cron', 'bash', 'shell', 'server management',
+    'process', 'daemon', 'log', 'monitoring', 'disk', 'CPU', 'memory',
+    'top', 'htop', 'journalctl', 'systemctl'
+] WHERE domain_topic = 'Systems Administration';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'technical writing', 'documentation', 'API doc', 'user guide', 'manual',
+    'specification', 'runbook', 'playbook', 'procedure', 'SOP', 'style guide',
+    'release notes', 'CHANGELOG', 'tech doc', 'write specification'
+] WHERE domain_topic = 'Technical Writing';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'texas', 'TX', 'texas law', 'texas statute', 'texas court', 'texas regulations',
+    'texas business', 'texas LLC', 'texas corporation', 'Texas Family Code',
+    'Texas Property Code', 'Texas Penal Code', 'TexasBar'
+] WHERE domain_topic = 'Texas Law';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'git', 'version control', 'github', 'gitlab', 'bitbucket', 'branch', 'tag',
+    'release', 'versioning', 'merge request', 'code review', 'PR review',
+    'git flow', 'trunk based', 'merge', 'rebase', 'cherry-pick', 'commit history'
+] WHERE domain_topic = 'Version Control';
+
+UPDATE agent_domains SET keywords = ARRAY[
+    'art', 'visual', 'design', 'image', 'illustration', 'graphic', 'digital art',
+    'painting', 'drawing', 'color', 'typography', 'UI design', 'UX design',
+    'canvas', 'generative art', 'stable diffusion', 'DALL-E', 'midjourney',
+    'image generation', 'prompt', 'visual style', 'palette', 'composition'
+] WHERE domain_topic = 'Visual Art';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Part 5: Seed default prompt_helper_config rows
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Gating rules per message type:
+--   info_request:  all subsystems enabled (user wants info, need full context)
+--   action:        all subsystems enabled (user wants action, need routing + recall)
+--   conversation:  entity_resolver only; skip recall+domain (casual chat, no context needed)
+--   continuation:  reminders only; skip all others (short ack, no lookup overhead)
+--   command:       reminders only; skip all others (command handling, no context needed)
+
+INSERT INTO prompt_helper_config (message_type, helper_name, enabled, agent_name)
+VALUES
+    -- info_request: all enabled
+    ('info_request', 'entity_resolver',   true,  NULL),
+    ('info_request', 'semantic_recall',   true,  NULL),
+    ('info_request', 'domain_identifier', true,  NULL),
+    ('info_request', 'turn_reminders',    true,  NULL),
+    -- action: all enabled
+    ('action', 'entity_resolver',   true,  NULL),
+    ('action', 'semantic_recall',   true,  NULL),
+    ('action', 'domain_identifier', true,  NULL),
+    ('action', 'turn_reminders',    true,  NULL),
+    -- conversation: entity_resolver only; recall+domain skipped
+    ('conversation', 'entity_resolver',   true,  NULL),
+    ('conversation', 'semantic_recall',   false, NULL),
+    ('conversation', 'domain_identifier', false, NULL),
+    ('conversation', 'turn_reminders',    true,  NULL),
+    -- continuation: reminders only
+    ('continuation', 'entity_resolver',   false, NULL),
+    ('continuation', 'semantic_recall',   false, NULL),
+    ('continuation', 'domain_identifier', false, NULL),
+    ('continuation', 'turn_reminders',    true,  NULL),
+    -- command: reminders only
+    ('command', 'entity_resolver',   false, NULL),
+    ('command', 'semantic_recall',   false, NULL),
+    ('command', 'domain_identifier', false, NULL),
+    ('command', 'turn_reminders',    true,  NULL)
+ON CONFLICT DO NOTHING;

--- a/memory/plugins/turn-context/README.md
+++ b/memory/plugins/turn-context/README.md
@@ -1,0 +1,72 @@
+# Turn Context Plugin
+
+OpenClaw plugin that injects per-turn context into agent prompts via the `before_prompt_build` hook.
+
+## Architecture
+
+```
+message_received → cache sender info (keyed by sessionKey:senderId)
+                        ↓
+before_prompt_build:
+  1. Classifier (rule-based + Ollama fallback) → message_type
+  2. prompt_helper_config lookup → which subsystems are enabled
+  3. Run enabled subsystems in parallel (Promise.allSettled)
+  4. Assemble prependSystemContext + appendSystemContext
+```
+
+## Subsystems
+
+| Subsystem | File | Description |
+|-----------|------|-------------|
+| **Classifier** | `classifier.ts` | Classifies messages into `info_request`, `action`, `conversation`, `continuation`, `command`. Rule-based first pass (~60-70%), Ollama LLM fallback for ambiguous cases. |
+| **Domain Identifier** | `domain-identifier.ts` | Matches messages to subject-matter domains via keyword matching + embedding similarity against `agent_domains` table. Returns top 1-3 domains with assigned agents (via JOIN, not hardcoded). |
+| **Entity Resolver** | `entity-resolver.ts` | Resolves sender identity via the entity-resolver library. Cache keyed by `sessionKey:senderId` (not just sessionKey) to support group channels. Returns both formatted text and numeric `entityId`. |
+| **Semantic Recall** | `semantic-recall.ts` | Spawns `proactive-recall.py` for memory retrieval. Supports tiered recall (domain-scoped first, full fallback) and visibility filtering (group channels → public facts only). |
+| **Turn Reminders** | `turn-reminders.ts` | Queries `agent_turn_context` table for per-turn reminder text. **Always fires regardless of message type** — not gated by prompt_helper_config. |
+
+## Message Type → Subsystem Gating
+
+Controlled by the `prompt_helper_config` table. Default configuration:
+
+| Message Type | entity_resolver | semantic_recall | domain_identifier | turn_reminders |
+|---|---|---|---|---|
+| `info_request` | ✅ | ✅ | ✅ | ✅ (always) |
+| `action` | ✅ | ✅ | ✅ | ✅ (always) |
+| `conversation` | ✅ | ❌ | ❌ | ✅ (always) |
+| `continuation` | ❌ | ❌ | ❌ | ✅ (always) |
+| `command` | ❌ | ❌ | ❌ | ✅ (always) |
+
+Per-agent overrides: insert rows with `agent_name` set to override defaults for a specific agent.
+
+On classifier failure, defaults to `info_request` (full pipeline) — safe fallback.
+
+## Database Dependencies
+
+- **`prompt_helper_config`** — subsystem gating config (migration 081)
+- **`agent_domains`** — domain topics with `keywords TEXT[]` column and `notes` descriptions
+- **`agent_turn_context`** — per-turn reminder records
+- **`memory_embeddings`** — domain description embeddings (`source_type='agent_domain'`)
+- **Entity resolver library** — `~/.openclaw/lib/entity-resolver/index.ts`
+
+## Migration Notes
+
+Migration `081_prompt_helper_config.sql` must be run in two parts due to table ownership:
+1. **As newhart** (owns `agent_domains`): `ALTER TABLE`, `UPDATE` statements for keywords/notes
+2. **As nova** (owns `prompt_helper_config`): `CREATE TABLE`, `INSERT` seed data
+
+After migration, run `memory/scripts/seed-domain-embeddings.py` to embed domain descriptions.
+
+## Configuration
+
+- Plugin timeout: 8000ms for `before_prompt_build` (configurable via OpenClaw plugin config)
+- Domain cache TTL: 5 minutes
+- Helper config cache TTL: 5 minutes
+- Ollama classifier timeout: 2000ms
+- Embedding model: configured via `memory/scripts/embedding-config.json`
+
+## Issues
+
+- #150 — Selective semantic recall + prompt preprocessing for domain routing
+- #140 — Tiered recall strategy
+- #168 — Visibility filter in semantic-recall hook
+- #182 — Original plugin consolidation (semantic-recall + agent-turn-context hooks)

--- a/memory/plugins/turn-context/package-lock.json
+++ b/memory/plugins/turn-context/package-lock.json
@@ -8,19 +8,17 @@
       "name": "@nova/turn-context",
       "version": "1.0.0",
       "dependencies": {
-        "pg": "^8.11.0"
-      },
-      "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/pg": "^8.0.0",
+        "pg": "^8.11.0",
         "typescript": "^5.9.3"
-      }
+      },
+      "devDependencies": {}
     },
     "node_modules/@types/node": {
       "version": "20.19.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -30,7 +28,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -179,7 +176,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -193,7 +189,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/xtend": {

--- a/memory/plugins/turn-context/src/classifier.ts
+++ b/memory/plugins/turn-context/src/classifier.ts
@@ -1,0 +1,269 @@
+/**
+ * Message Type Classifier
+ *
+ * Classifies inbound messages into one of:
+ *   info_request | action | conversation | continuation | command
+ *
+ * Strategy:
+ *   1. Rule-based fast pass (handles 60-70% of cases)
+ *   2. Ollama LLM fallback for ambiguous cases (2000ms timeout)
+ *   3. Default to 'conversation' on failure
+ *
+ * Issues: nova-mind #150
+ */
+
+import * as http from "http";
+
+export type MessageType =
+  | "info_request"
+  | "action"
+  | "conversation"
+  | "continuation"
+  | "command";
+
+export interface ClassifierResult {
+  type: MessageType;
+  domainHints?: string[];
+  method?: "rule" | "ollama" | "default";
+}
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || "http://localhost:11434";
+const OLLAMA_CLASSIFY_MODEL =
+  process.env.OLLAMA_CLASSIFY_MODEL || "phi4-mini:latest";
+const OLLAMA_TIMEOUT_MS = 2000;
+
+// ── Rule sets ─────────────────────────────────────────────────────────────────
+
+/** Known continuation phrases (short acknowledgments / affirmations) */
+const CONTINUATION_PHRASES = new Set([
+  "ok",
+  "okay",
+  "sure",
+  "yep",
+  "yeah",
+  "yes",
+  "k",
+  "no",
+  "nope",
+  "got it",
+  "cool",
+  "great",
+  "nice",
+  "thanks",
+  "thx",
+  "ty",
+  "np",
+  "done",
+  "go",
+  "next",
+  "ack",
+  "fine",
+  "good",
+  "alright",
+  "right",
+  "noted",
+  "understood",
+  "roger",
+]);
+
+/** Starts with an imperative action verb → action */
+const ACTION_VERB_RE =
+  /^(create|search|add|delete|update|run|check|deploy|fix|build|show|get|list|find|open|close|start|stop|send|post|push|pull|fetch|make|generate|write|read|review|test|debug|install|configure|setup|set|remove|move|copy|rename|edit|save|load|export|import|download|upload|scan|analyze|monitor|report|summarize|explain|describe|enable|disable|restart|reset|clear|flush|convert|compile|format|lint|validate|seed|migrate|rollback|backup|restore|deploy|launch|kill|exec|execute|query|lookup|compare|benchmark|inspect|dump|extract|parse|transform)\b/i;
+
+/** Interrogative words indicating an info request */
+const INTERROGATIVE_RE = /\b(who|what|where|when|why|how)\b/i;
+
+/** Greeting openers → conversation */
+const GREETING_RE =
+  /^(hi\b|hey\b|hello\b|howdy\b|greetings\b|good\s+(morning|afternoon|evening|day)\b|what'?s\s+up\b|sup\b|yo\b|howzit\b|hiya\b|heya\b)/i;
+
+// ── Rule-based classification ─────────────────────────────────────────────────
+
+/**
+ * Attempt to classify the message using deterministic rules.
+ * Returns null if the message is ambiguous (needs Ollama fallback).
+ */
+function classifyByRules(content: string): ClassifierResult | null {
+  const trimmed = content.trim();
+
+  // Empty or whitespace-only → continuation
+  if (!trimmed || /^\s+$/.test(trimmed)) {
+    return { type: "continuation", method: "rule" };
+  }
+
+  // Command: starts with / or !
+  if (/^[/!]/.test(trimmed)) {
+    return { type: "command", method: "rule" };
+  }
+
+  // Continuation: single > character (workflow advance signal per GLOBAL/PROCESS_AND_COORDINATION)
+  if (trimmed === ">") {
+    return { type: "continuation", method: "rule" };
+  }
+
+  const lower = trimmed.toLowerCase();
+
+  // Continuation: known acknowledgment phrases (multi-word matches first)
+  if (CONTINUATION_PHRASES.has(lower)) {
+    return { type: "continuation", method: "rule" };
+  }
+
+  // Continuation: ≤5 chars with no spaces (single short word)
+  if (trimmed.length <= 5 && !/\s/.test(trimmed)) {
+    return { type: "continuation", method: "rule" };
+  }
+
+  // Greeting → conversation (check before action verbs, since "hello" could be a verb)
+  if (GREETING_RE.test(trimmed)) {
+    return { type: "conversation", method: "rule" };
+  }
+
+  // Info request: contains a question mark (with or without interrogative word)
+  if (trimmed.includes("?")) {
+    return { type: "info_request", method: "rule" };
+  }
+
+  // Info request: interrogative word even without ?
+  if (INTERROGATIVE_RE.test(trimmed)) {
+    return { type: "info_request", method: "rule" };
+  }
+
+  // Action: starts with an imperative verb
+  if (ACTION_VERB_RE.test(trimmed)) {
+    return { type: "action", method: "rule" };
+  }
+
+  // Ambiguous — needs Ollama fallback
+  return null;
+}
+
+// ── Ollama LLM fallback ───────────────────────────────────────────────────────
+
+/**
+ * Call Ollama for LLM-based message classification.
+ * 2000ms hard timeout — on failure, caller should default to 'conversation'.
+ */
+function callOllamaClassify(content: string): Promise<ClassifierResult> {
+  const safeContent = content.substring(0, 500).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+  const prompt = `Classify this message into EXACTLY ONE category:
+- info_request: asking for information, facts, status, or explanation
+- action: requesting an operation, task, or command to be performed
+- conversation: casual chat, social exchange, sharing context
+- continuation: brief acknowledgment like "ok", "sure", or follow-up to prior context
+- command: starts with / or ! prefix
+
+Message: "${safeContent}"
+
+Respond with ONLY valid JSON (no markdown):
+{"type": "<one of the 5 types>", "domainHints": ["<relevant domain keywords, omit if none>"]}`;
+
+  const body = JSON.stringify({
+    model: OLLAMA_CLASSIFY_MODEL,
+    prompt,
+    stream: false,
+    format: "json",
+    options: { temperature: 0, num_predict: 120 },
+  });
+
+  return new Promise((resolve, reject) => {
+    let req: http.ClientRequest;
+
+    const timeout = setTimeout(() => {
+      req?.destroy();
+      reject(new Error(`Ollama classify timeout after ${OLLAMA_TIMEOUT_MS}ms`));
+    }, OLLAMA_TIMEOUT_MS);
+
+    try {
+      const url = new URL(`${OLLAMA_BASE_URL}/api/generate`);
+      const options: http.RequestOptions = {
+        hostname: url.hostname,
+        port: parseInt(url.port || "80", 10),
+        path: url.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body),
+        },
+      };
+
+      req = http.request(options, (res) => {
+        let data = "";
+        res.on("data", (chunk: Buffer) => {
+          data += chunk.toString();
+        });
+        res.on("end", () => {
+          clearTimeout(timeout);
+          try {
+            const ollamaResp = JSON.parse(data);
+            const respText: string = ollamaResp.response || "{}";
+            const parsed = JSON.parse(respText);
+            const validTypes: MessageType[] = [
+              "info_request",
+              "action",
+              "conversation",
+              "continuation",
+              "command",
+            ];
+            const type: MessageType = validTypes.includes(parsed.type as MessageType)
+              ? (parsed.type as MessageType)
+              : "conversation";
+            const rawHints = parsed.domainHints;
+            const domainHints: string[] | undefined =
+              Array.isArray(rawHints) && rawHints.length > 0
+                ? rawHints.filter((h: unknown) => typeof h === "string")
+                : undefined;
+            resolve({ type, domainHints, method: "ollama" });
+          } catch (err) {
+            reject(new Error(`Ollama classify parse error: ${err}`));
+          }
+        });
+      });
+
+      req.on("error", (err: Error) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+
+      req.write(body);
+      req.end();
+    } catch (err) {
+      clearTimeout(timeout);
+      reject(err);
+    }
+  });
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Classify a message into one of the five message types.
+ *
+ * Rule-based classification handles 60-70% of cases without LLM overhead.
+ * Ambiguous messages fall back to Ollama (2000ms timeout).
+ * On any failure, defaults to 'conversation'.
+ *
+ * @param content The message content to classify
+ * @returns ClassifierResult with type, optional domainHints, and method used
+ */
+export async function classifyMessage(content: string): Promise<ClassifierResult> {
+  // Rule-based first pass — fast, deterministic
+  const ruleResult = classifyByRules(content);
+  if (ruleResult) {
+    return ruleResult;
+  }
+
+  // Ollama fallback for ambiguous messages
+  try {
+    const ollamaResult = await callOllamaClassify(content);
+    return ollamaResult;
+  } catch (err) {
+    console.warn(
+      "[turn-context] Classifier Ollama fallback failed:",
+      err instanceof Error ? err.message : String(err)
+    );
+    return { type: "conversation", method: "default" };
+  }
+}

--- a/memory/plugins/turn-context/src/domain-identifier.ts
+++ b/memory/plugins/turn-context/src/domain-identifier.ts
@@ -205,7 +205,8 @@ function matchKeywords(
  * Returns Map<domainId, similarity>.
  */
 async function matchVectorSimilarity(
-  embedding: number[]
+  embedding: number[],
+  domains: DomainRow[]
 ): Promise<Map<number, number>> {
   const scores = new Map<number, number>();
 
@@ -231,9 +232,11 @@ async function matchVectorSimilarity(
     );
 
     for (const row of result.rows) {
-      const domainId = parseInt(row.source_id, 10);
-      if (!isNaN(domainId)) {
-        scores.set(domainId, row.similarity);
+      // source_id is the domain_topic string (set by seed-domain-embeddings.py),
+      // not a numeric id — look up the DomainRow by topic name.
+      const domain = domains.find((d) => d.domainTopic === row.source_id);
+      if (domain) {
+        scores.set(domain.id, row.similarity);
       }
     }
   } finally {
@@ -295,7 +298,7 @@ export async function identifyDomain(
   let vectorScores = new Map<number, number>();
   try {
     const embedding = await getEmbedding(message);
-    vectorScores = await matchVectorSimilarity(embedding);
+    vectorScores = await matchVectorSimilarity(embedding, domains);
   } catch (err) {
     console.warn(
       "[turn-context] domain-identifier embedding error:",

--- a/memory/plugins/turn-context/src/domain-identifier.ts
+++ b/memory/plugins/turn-context/src/domain-identifier.ts
@@ -1,0 +1,385 @@
+/**
+ * Domain Identifier subsystem.
+ *
+ * Matches inbound messages to agent domains using two strategies:
+ *   1. Keyword matching against agent_domains.keywords (TEXT[])
+ *   2. Embedding similarity against memory_embeddings (source_type='agent_domain')
+ *
+ * Both scores are combined for final ranking.
+ * Domain table data is cached for 5 minutes (DOMAIN_CACHE_TTL_MS).
+ * Agent name is resolved via JOIN on agents table — never hardcoded.
+ *
+ * Issues: nova-mind #150
+ */
+
+import * as http from "http";
+import { getPool } from "./shared/pg-pool.ts";
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || "http://localhost:11434";
+const EMBEDDING_MODEL = "snowflake-arctic-embed2";
+const EMBEDDING_DIMS = 1024;
+const EMBEDDING_TIMEOUT_MS = 8000;
+const DOMAIN_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const SIMILARITY_THRESHOLD = parseFloat(
+  process.env.DOMAIN_SIMILARITY_THRESHOLD || "0.4"
+);
+const KEYWORD_SCORE_BOOST = 0.2; // Added to vector score when keyword also matches
+const KEYWORD_BASE_SCORE = 0.5; // Base score for keyword-only matches (no vector)
+const MAX_RESULTS = 3; // Return top N domains
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface DomainRow {
+  id: number;
+  domainTopic: string;
+  agentName: string;
+  keywords: string[];
+  notes: string;
+}
+
+export interface DomainMatch {
+  domain: string;
+  agent: string;
+  similarity: number;
+  matchedBy: "keyword" | "vector" | "both";
+}
+
+export interface DomainResult {
+  domains: DomainMatch[];
+  indicator?: "NO DOMAIN IDENTIFIED";
+}
+
+// ── Domain data cache ─────────────────────────────────────────────────────────
+
+interface DomainCacheEntry {
+  domains: DomainRow[];
+  timestamp: number;
+}
+
+let domainCache: DomainCacheEntry | null = null;
+
+async function loadDomains(): Promise<DomainRow[]> {
+  const now = Date.now();
+  if (domainCache && now - domainCache.timestamp < DOMAIN_CACHE_TTL_MS) {
+    return domainCache.domains;
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query<{
+      id: number;
+      domain_topic: string;
+      agent_name: string;
+      keywords: string[] | null;
+      notes: string | null;
+    }>(`
+      SELECT ad.id, ad.domain_topic, a.name AS agent_name, ad.keywords, ad.notes
+      FROM agent_domains ad
+      JOIN agents a ON ad.agent_id = a.id
+      ORDER BY ad.domain_topic
+    `);
+
+    const domains: DomainRow[] = result.rows.map((row) => ({
+      id: row.id,
+      domainTopic: row.domain_topic,
+      agentName: row.agent_name,
+      keywords: row.keywords ?? [],
+      notes: row.notes ?? "",
+    }));
+
+    domainCache = { domains, timestamp: now };
+    console.info(
+      `[turn-context] domain-identifier: loaded ${domains.length} domains from DB`
+    );
+    return domains;
+  } finally {
+    client.release();
+  }
+}
+
+// ── Embedding ─────────────────────────────────────────────────────────────────
+
+function getEmbedding(text: string): Promise<number[]> {
+  const body = JSON.stringify({ model: EMBEDDING_MODEL, prompt: text });
+
+  return new Promise((resolve, reject) => {
+    let req: http.ClientRequest;
+
+    const timeout = setTimeout(() => {
+      req?.destroy();
+      reject(new Error(`Embedding timeout after ${EMBEDDING_TIMEOUT_MS}ms`));
+    }, EMBEDDING_TIMEOUT_MS);
+
+    try {
+      const url = new URL(`${OLLAMA_BASE_URL}/api/embeddings`);
+      const options: http.RequestOptions = {
+        hostname: url.hostname,
+        port: parseInt(url.port || "80", 10),
+        path: url.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body),
+        },
+      };
+
+      req = http.request(options, (res) => {
+        let data = "";
+        res.on("data", (chunk: Buffer) => {
+          data += chunk.toString();
+        });
+        res.on("end", () => {
+          clearTimeout(timeout);
+          try {
+            const parsed = JSON.parse(data);
+            const embedding: number[] = parsed.embedding;
+            if (!Array.isArray(embedding) || embedding.length !== EMBEDDING_DIMS) {
+              reject(
+                new Error(
+                  `Dimension mismatch: got ${embedding?.length ?? "undefined"}, expected ${EMBEDDING_DIMS}`
+                )
+              );
+              return;
+            }
+            resolve(embedding);
+          } catch (err) {
+            reject(new Error(`Embedding parse error: ${err}`));
+          }
+        });
+      });
+
+      req.on("error", (err: Error) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+
+      req.write(body);
+      req.end();
+    } catch (err) {
+      clearTimeout(timeout);
+      reject(err);
+    }
+  });
+}
+
+// ── Keyword matching ──────────────────────────────────────────────────────────
+
+/**
+ * Check which domains have keywords present in the message.
+ * Returns a Map<domainId, keywordScore>.
+ */
+function matchKeywords(
+  message: string,
+  domains: DomainRow[]
+): Map<number, number> {
+  const lower = message.toLowerCase();
+  const scores = new Map<number, number>();
+
+  for (const domain of domains) {
+    if (!domain.keywords.length) continue;
+
+    let best = 0;
+    for (const kw of domain.keywords) {
+      if (lower.includes(kw.toLowerCase())) {
+        // Longer keywords are more specific — give them higher weight
+        const score = KEYWORD_BASE_SCORE + kw.length * 0.01;
+        if (score > best) best = score;
+      }
+    }
+
+    if (best > 0) {
+      scores.set(domain.id, best);
+    }
+  }
+
+  return scores;
+}
+
+// ── Vector similarity via PostgreSQL ─────────────────────────────────────────
+
+/**
+ * Use pgvector cosine distance to find domain embeddings similar to the query.
+ * Returns Map<domainId, similarity>.
+ */
+async function matchVectorSimilarity(
+  embedding: number[]
+): Promise<Map<number, number>> {
+  const scores = new Map<number, number>();
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    const vectorStr = `[${embedding.join(",")}]`;
+    const result = await client.query<{
+      source_id: string;
+      similarity: number;
+    }>(
+      `
+      SELECT
+        source_id,
+        1 - (embedding <=> $1::vector) AS similarity
+      FROM memory_embeddings
+      WHERE source_type = 'agent_domain'
+        AND 1 - (embedding <=> $1::vector) >= $2
+      ORDER BY similarity DESC
+      LIMIT 10
+      `,
+      [vectorStr, SIMILARITY_THRESHOLD]
+    );
+
+    for (const row of result.rows) {
+      const domainId = parseInt(row.source_id, 10);
+      if (!isNaN(domainId)) {
+        scores.set(domainId, row.similarity);
+      }
+    }
+  } finally {
+    client.release();
+  }
+
+  return scores;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Identify the domain(s) most relevant to the given message.
+ *
+ * Combines keyword matching (fast, local) with embedding similarity (pgvector).
+ * Returns the top 1-3 matches above the similarity threshold, or NO DOMAIN IDENTIFIED.
+ *
+ * The agent name is always resolved via agents JOIN — never hardcoded.
+ *
+ * @param message      The message to match against domains
+ * @param hintKeywords Optional domain hints from the classifier
+ */
+export async function identifyDomain(
+  message: string,
+  hintKeywords?: string[]
+): Promise<DomainResult> {
+  if (!message.trim()) {
+    return { domains: [], indicator: "NO DOMAIN IDENTIFIED" };
+  }
+
+  let domains: DomainRow[];
+  try {
+    domains = await loadDomains();
+  } catch (err) {
+    console.error(
+      "[turn-context] domain-identifier DB error:",
+      err instanceof Error ? err.message : String(err)
+    );
+    return { domains: [], indicator: "NO DOMAIN IDENTIFIED" };
+  }
+
+  // Step 1: Keyword matching (synchronous, fast)
+  const keywordScores = matchKeywords(message, domains);
+
+  // Apply classifier hints as additional keyword boost
+  if (hintKeywords?.length) {
+    const lower = message.toLowerCase();
+    const lowerHints = hintKeywords.map((h) => h.toLowerCase());
+    for (const domain of domains) {
+      const topic = domain.domainTopic.toLowerCase();
+      if (lowerHints.some((h) => topic.includes(h) || h.includes(topic) || lower.includes(h))) {
+        const existing = keywordScores.get(domain.id) ?? 0;
+        keywordScores.set(domain.id, Math.max(existing, SIMILARITY_THRESHOLD));
+      }
+    }
+  }
+
+  // Step 2: Embedding similarity (async, pgvector)
+  let vectorScores = new Map<number, number>();
+  try {
+    const embedding = await getEmbedding(message);
+    vectorScores = await matchVectorSimilarity(embedding);
+  } catch (err) {
+    console.warn(
+      "[turn-context] domain-identifier embedding error:",
+      err instanceof Error ? err.message : String(err)
+    );
+    // Gracefully continue with keyword-only results
+  }
+
+  // Step 3: Combine keyword and vector scores
+  const allIds = new Set([...keywordScores.keys(), ...vectorScores.keys()]);
+
+  const candidates: Array<{
+    domain: DomainRow;
+    score: number;
+    matchedBy: "keyword" | "vector" | "both";
+  }> = [];
+
+  for (const id of allIds) {
+    const domain = domains.find((d) => d.id === id);
+    if (!domain) continue;
+
+    const kwScore = keywordScores.get(id) ?? 0;
+    const vecScore = vectorScores.get(id) ?? 0;
+
+    const hasKeyword = kwScore > 0;
+    const hasVector = vecScore >= SIMILARITY_THRESHOLD;
+
+    if (!hasKeyword && !hasVector) continue;
+
+    let combinedScore: number;
+    let matchedBy: "keyword" | "vector" | "both";
+
+    if (hasKeyword && hasVector) {
+      // Both: vector similarity + keyword boost (keywords confirm the match)
+      combinedScore = vecScore + KEYWORD_SCORE_BOOST;
+      matchedBy = "both";
+    } else if (hasKeyword) {
+      combinedScore = kwScore;
+      matchedBy = "keyword";
+    } else {
+      combinedScore = vecScore;
+      matchedBy = "vector";
+    }
+
+    candidates.push({ domain, score: combinedScore, matchedBy });
+  }
+
+  // Sort descending by score, take top N
+  candidates.sort((a, b) => b.score - a.score);
+  const top = candidates.slice(0, MAX_RESULTS);
+
+  if (top.length === 0) {
+    return { domains: [], indicator: "NO DOMAIN IDENTIFIED" };
+  }
+
+  const matches: DomainMatch[] = top.map(({ domain, score, matchedBy }) => ({
+    domain: domain.domainTopic,
+    agent: domain.agentName,
+    similarity: Math.min(1.0, Math.round(score * 1000) / 1000),
+    matchedBy,
+  }));
+
+  console.info(
+    `[turn-context] domain=${matches[0].domain} similarity=${matches[0].similarity} matchedBy=${matches[0].matchedBy}`
+  );
+
+  return { domains: matches };
+}
+
+/**
+ * Format domain match results as a human-readable string for prompt injection.
+ *
+ * @param result DomainResult from identifyDomain()
+ * @returns Formatted string or null if no domain identified
+ */
+export function formatDomainContext(result: DomainResult): string | null {
+  if (!result.domains.length || result.indicator === "NO DOMAIN IDENTIFIED") {
+    return null;
+  }
+
+  const lines = result.domains.map((d) => {
+    const pct = (d.similarity * 100).toFixed(0);
+    return `🏷️ Domain: ${d.domain} → ${d.agent} (${d.matchedBy}, ${pct}%)`;
+  });
+
+  return lines.join("\n");
+}

--- a/memory/plugins/turn-context/src/entity-resolver.ts
+++ b/memory/plugins/turn-context/src/entity-resolver.ts
@@ -113,7 +113,11 @@ export interface SenderInfo {
  * Resolve the sender entity and return formatted context text, or null if
  * no entity was found or an error occurred.
  *
- * Uses the entity-resolver library's cache keyed by sessionKey.
+ * Cache key is `sessionKey:senderId` to prevent cross-user cache collisions
+ * in group channels where multiple senders share a sessionKey.
+ *
+ * Bugfix: was keyed by sessionKey alone, causing User B to receive User A's
+ * cached entity in group channels. See nova-mind #150.
  */
 export async function resolveEntityContext(
   sessionKey: string,
@@ -126,11 +130,15 @@ export async function resolveEntityContext(
 
   if (!senderId) return null;
 
+  // Cache key includes both sessionKey AND senderId to prevent cross-user collisions
+  // in group channels where sessionKey is shared across all participants.
+  const cacheKey = `${sessionKey}:${senderId}`;
+
   let entity: Entity | null = null;
 
-  // Check library cache first
+  // Check library cache first (keyed by sessionKey:senderId)
   if (getCachedEntity) {
-    entity = getCachedEntity(sessionKey) as Entity | null;
+    entity = getCachedEntity(cacheKey) as Entity | null;
   }
 
   if (!entity) {
@@ -161,7 +169,7 @@ export async function resolveEntityContext(
       }
 
       if (entity && setCachedEntity) {
-        setCachedEntity(sessionKey, entity);
+        setCachedEntity(cacheKey, entity);
       }
     } catch (err) {
       console.error(

--- a/memory/plugins/turn-context/src/entity-resolver.ts
+++ b/memory/plugins/turn-context/src/entity-resolver.ts
@@ -122,13 +122,13 @@ export interface SenderInfo {
 export async function resolveEntityContext(
   sessionKey: string,
   info: SenderInfo
-): Promise<string | null> {
+): Promise<{ text: string | null; entityId: number | null }> {
   // Lazy-load entity resolver — graceful degradation if not installed
-  if (!(await ensureEntityResolver())) return null;
+  if (!(await ensureEntityResolver())) return { text: null, entityId: null };
 
   const { senderId, senderName, provider, senderE164 } = info;
 
-  if (!senderId) return null;
+  if (!senderId) return { text: null, entityId: null };
 
   // Cache key includes both sessionKey AND senderId to prevent cross-user collisions
   // in group channels where sessionKey is shared across all participants.
@@ -146,7 +146,7 @@ export async function resolveEntityContext(
     if (Object.keys(identifiers).length === 0) {
       // Unknown provider — no way to resolve
       console.log(`[turn-context] Unknown provider '${provider}', skipping entity resolution`);
-      return null;
+      return { text: null, entityId: null };
     }
 
     try {
@@ -164,7 +164,7 @@ export async function resolveEntityContext(
             `[turn-context] Entity conflict for sender ${senderName || senderId}: ` +
             `${resolveResult.message}`
           );
-          return null;
+          return { text: null, entityId: null };
         }
       }
 
@@ -176,7 +176,7 @@ export async function resolveEntityContext(
         "[turn-context] Entity resolution error:",
         err instanceof Error ? err.message : String(err)
       );
-      return null;
+      return { text: null, entityId: null };
     }
   }
 
@@ -184,7 +184,7 @@ export async function resolveEntityContext(
     console.log(
       `[turn-context] No entity found for sender: ${senderName || senderId}`
     );
-    return null;
+    return { text: null, entityId: null };
   }
 
   // Load entity facts with a 1s timeout
@@ -205,7 +205,7 @@ export async function resolveEntityContext(
 
   const result = formatEntityContext(entity, facts);
   console.log(
-    `[turn-context] Loaded entity context for: ${entity.name} (${senderId})`
+    `[turn-context] Loaded entity context for: ${entity.name} (entityId=${entity.id}) (${senderId})`
   );
-  return result;
+  return { text: result, entityId: entity.id as number };
 }

--- a/memory/plugins/turn-context/src/index.ts
+++ b/memory/plugins/turn-context/src/index.ts
@@ -10,10 +10,15 @@
  *      context never reached the LLM prompt.
  *   2. Old semantic-recall hook used spawnSync, blocking the event loop.
  *
+ * Classifier-First Dispatch (issue #150):
+ *   Messages are classified before subsystems run. The prompt_helper_config
+ *   table gates which subsystems are enabled per message type. Turn reminders
+ *   always fire regardless of classification.
+ *
  * Prompt composition order:
  *   prependSystemContext + baseSystemPrompt + appendSystemContext
  *
- *   - prependSystemContext: entity identity + semantic recall memories
+ *   - prependSystemContext: entity identity + domain routing + semantic recall
  *     (BEFORE base system prompt, so LLM has context before reading instructions)
  *   - appendSystemContext:  per-turn reminders only
  *     (AFTER base system prompt, for proximity to user message)
@@ -22,13 +27,16 @@
  *   - `message_received`    (observation, fire-and-forget) — caches sender info
  *   - `before_prompt_build` (awaited, returns result)       — injects context
  *
- * Issue: nova-mind #182
+ * Issue: nova-mind #182, #150, #140, #168
  * Closes: nova-openclaw #40, nova-openclaw #41
  */
 
 import { getTurnReminders } from "./turn-reminders.ts";
 import { resolveEntityContext, type SenderInfo } from "./entity-resolver.ts";
 import { runSemanticRecall, type RecallInput } from "./semantic-recall.ts";
+import { classifyMessage, type ClassifierResult, type MessageType } from "./classifier.ts";
+import { identifyDomain, formatDomainContext, type DomainResult } from "./domain-identifier.ts";
+import { getPool } from "./shared/pg-pool.ts";
 
 // ── Sender info cache (message_received → before_prompt_build) ───────────────
 
@@ -48,7 +56,6 @@ const senderCache = new Map<string, SenderCache>();
 
 function evictStaleCacheEntries(): void {
   const now = Date.now();
-  // Remove stale entries
   for (const [key, entry] of senderCache.entries()) {
     if (now - entry.timestamp > CACHE_STALE_MS) {
       senderCache.delete(key);
@@ -59,7 +66,6 @@ function evictStaleCacheEntries(): void {
 function evictOldestIfFull(): void {
   if (senderCache.size < CACHE_MAX_SIZE) return;
 
-  // Find oldest entry by timestamp and evict it
   let oldestKey: string | null = null;
   let oldestTime = Infinity;
   for (const [key, entry] of senderCache.entries()) {
@@ -69,6 +75,91 @@ function evictOldestIfFull(): void {
     }
   }
   if (oldestKey) senderCache.delete(oldestKey);
+}
+
+// ── Prompt Helper Config cache ────────────────────────────────────────────────
+
+interface HelperConfig {
+  entity_resolver: boolean;
+  semantic_recall: boolean;
+  domain_identifier: boolean;
+}
+
+interface HelperConfigCacheEntry {
+  config: HelperConfig;
+  timestamp: number;
+}
+
+const HELPER_CONFIG_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const helperConfigCache = new Map<string, HelperConfigCacheEntry>();
+
+/**
+ * Query prompt_helper_config for the given agent and message type.
+ * Agent-specific rows take precedence over default (agent_name IS NULL) rows.
+ * Results are cached for 5 minutes to avoid DB round-trips per message.
+ */
+async function getHelperConfig(agentId: string, messageType: MessageType): Promise<HelperConfig> {
+  const cacheKey = `${agentId}:${messageType}`;
+  const cached = helperConfigCache.get(cacheKey);
+  if (cached && Date.now() - cached.timestamp < HELPER_CONFIG_CACHE_TTL_MS) {
+    return cached.config;
+  }
+
+  // Safe defaults — all subsystems enabled if config table is unavailable
+  const defaults: HelperConfig = {
+    entity_resolver: true,
+    semantic_recall: true,
+    domain_identifier: true,
+  };
+
+  try {
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      // DISTINCT ON ensures agent-specific config (agent_name IS NOT NULL) takes
+      // precedence over default (agent_name IS NULL) when both exist for the same helper.
+      const result = await client.query<{ helper_name: string; enabled: boolean }>(
+        `SELECT DISTINCT ON (helper_name) helper_name, enabled
+         FROM prompt_helper_config
+         WHERE message_type = $1
+           AND (agent_name = $2 OR agent_name IS NULL)
+         ORDER BY helper_name, agent_name NULLS LAST`,
+        [messageType, agentId]
+      );
+
+      const config: HelperConfig = { ...defaults };
+      for (const row of result.rows) {
+        if (row.helper_name === "entity_resolver") {
+          config.entity_resolver = row.enabled;
+        } else if (row.helper_name === "semantic_recall") {
+          config.semantic_recall = row.enabled;
+        } else if (row.helper_name === "domain_identifier") {
+          config.domain_identifier = row.enabled;
+        }
+      }
+
+      helperConfigCache.set(cacheKey, { config, timestamp: Date.now() });
+      return config;
+    } finally {
+      client.release();
+    }
+  } catch (err) {
+    // Table may not exist yet — use defaults gracefully
+    console.warn(
+      "[turn-context] prompt_helper_config query failed (using defaults):",
+      err instanceof Error ? err.message : String(err)
+    );
+    return defaults;
+  }
+}
+
+/**
+ * Determine whether a session key represents a group/channel context.
+ * Group channels share a session key across multiple senders.
+ */
+function isGroupSession(sessionKey: string | undefined): boolean {
+  if (!sessionKey) return false;
+  return sessionKey.includes(":channel:") || sessionKey.includes(":group:");
 }
 
 // ── Plugin entry ──────────────────────────────────────────────────────────────
@@ -137,9 +228,21 @@ export default function register(api: PluginApi): void {
 
   // ── Hook 2: before_prompt_build (awaited, returns context segments) ────────
   //
-  // Runs three subsystems in parallel, each with independent error handling.
-  // Returns prependSystemContext (entity + recall) and appendSystemContext
-  // (turn reminders) for injection into the system prompt.
+  // Classifier-first dispatch:
+  //   1. Classify message type (rule-based, ~0ms; Ollama fallback, <2s)
+  //   2. Load prompt_helper_config gating from DB (5-min cached)
+  //   3. Turn reminders ALWAYS fire (not gated by message type)
+  //   4. Run enabled subsystems in parallel (Promise.allSettled)
+  //   5. Assemble prependSystemContext + appendSystemContext
+  //
+  // Subsystem gating:
+  //   - entity_resolver:   gated by prompt_helper_config
+  //   - domain_identifier: gated by prompt_helper_config
+  //   - semantic_recall:   gated by prompt_helper_config
+  //   - turn_reminders:    ALWAYS fires regardless of message type
+  //
+  // Returns prependSystemContext (entity + domain + recall) and
+  // appendSystemContext (turn reminders) for injection into the system prompt.
   //
   // Composition: prependSystemContext + baseSystemPrompt + appendSystemContext
 
@@ -150,15 +253,26 @@ export default function register(api: PluginApi): void {
       const sessionKey = ctx.sessionKey;
       const agentId: string = ctx.agentId ?? "nova";
 
-      console.info(`[turn-context] before_prompt_build START agent=${agentId} session=${sessionKey ?? "none"}`);
+      console.info(
+        `[turn-context] before_prompt_build START agent=${agentId} session=${sessionKey ?? "none"}`
+      );
 
       // Retrieve cached sender info (may be undefined for first message or
       // if message_received fired from a different process).
       // Check staleness: entries older than CACHE_STALE_MS are treated as expired on read.
       const raw = sessionKey ? senderCache.get(sessionKey) : undefined;
-      const cached = raw && (Date.now() - raw.timestamp < CACHE_STALE_MS) ? raw : undefined;
+      const cached =
+        raw && Date.now() - raw.timestamp < CACHE_STALE_MS ? raw : undefined;
 
-      console.info(`[turn-context] Sender cache ${cached ? `HIT sender=${cached.senderName} content=${cached.content.length}chars` : "MISS (no cached sender info)"}`);
+      console.info(
+        `[turn-context] Sender cache ${
+          cached
+            ? `HIT sender=${cached.senderName} content=${cached.content.length}chars`
+            : "MISS (no cached sender info)"
+        }`
+      );
+
+      const isGroup = isGroupSession(sessionKey);
 
       const senderInfo: SenderInfo = {
         senderId: cached?.senderId,
@@ -167,26 +281,91 @@ export default function register(api: PluginApi): void {
         senderE164: cached?.senderE164,
       };
 
+      // ── Step 1: Classify message type ──────────────────────────────────────
+      // Rule-based classification handles ~60-70% of cases without LLM overhead.
+      // Ambiguous messages fall back to Ollama (2000ms timeout).
+      // On any failure, defaults to 'conversation'.
+
+      const classifyStart = Date.now();
+      let classification: ClassifierResult = { type: "conversation", method: "default" };
+      if (cached?.content) {
+        try {
+          classification = await classifyMessage(cached.content);
+        } catch (err) {
+          console.warn(
+            "[turn-context] Classifier error (defaulting to conversation):",
+            err instanceof Error ? err.message : String(err)
+          );
+        }
+      }
+      const classifyMs = Date.now() - classifyStart;
+      console.info(
+        `[turn-context] classifier: type=${classification.type} method=${
+          classification.method ?? "?"
+        } domainHints=${JSON.stringify(classification.domainHints ?? [])} elapsed=${classifyMs}ms`
+      );
+
+      // ── Step 2: Load prompt_helper_config ──────────────────────────────────
+      // Determines which subsystems are enabled for this message type.
+      // 5-minute cache; falls back to enabling all on query failure.
+
+      let helperConfig: HelperConfig = {
+        entity_resolver: true,
+        semantic_recall: true,
+        domain_identifier: true,
+      };
+      try {
+        helperConfig = await getHelperConfig(agentId, classification.type);
+      } catch (err) {
+        console.warn(
+          "[turn-context] prompt_helper_config load failed (using defaults):",
+          err instanceof Error ? err.message : String(err)
+        );
+      }
+      console.info(
+        `[turn-context] helper_config: type=${classification.type} ` +
+        `entity_resolver=${helperConfig.entity_resolver} ` +
+        `semantic_recall=${helperConfig.semantic_recall} ` +
+        `domain_identifier=${helperConfig.domain_identifier}`
+      );
+
+      // Build recall input: pass classifier domain hints + visibility info
       const recallInput: RecallInput = {
         content: cached?.content ?? "",
         senderId: cached?.senderId ?? "",
         senderName: cached?.senderName ?? "",
         provider: cached?.provider ?? "",
         conversationId: sessionKey ?? "",
-        isGroup: false,
+        isGroup,
         channelName: "",
         guildId: "",
         messageId: "",
+        domainHints: classification.domainHints,
       };
 
-      // ── Run all three subsystems in parallel ────────────────────────────
+      // ── Step 3: Run all subsystems in parallel ────────────────────────────
+      // Turn reminders always fire (not gated by helperConfig).
+      // Other subsystems are gated by their helperConfig flag.
+      //
+      // All run via Promise.allSettled so one failure never blocks others.
 
-      console.info("[turn-context] Starting parallel subsystems: turn-reminders, entity-resolver, semantic-recall");
+      console.info(
+        `[turn-context] Starting parallel subsystems:` +
+        ` turn-reminders=always` +
+        ` entity-resolver=${helperConfig.entity_resolver}` +
+        ` domain-identifier=${helperConfig.domain_identifier}` +
+        ` semantic-recall=${helperConfig.semantic_recall}`
+      );
       const subsystemStart = Date.now();
 
-      const [turnRemindersResult, entityContextResult, recallResult] =
-        await Promise.allSettled([
-          // 1. Turn reminders (DB-backed, 5-min cache)
+      const [turnRemindersResult, entityContextResult, domainIdentifierResult, recallResult] =
+        await Promise.allSettled<[
+          Promise<string | null>,
+          Promise<string | null>,
+          Promise<DomainResult | null>,
+          Promise<string | null>,
+        ]>([
+          // 1. Turn reminders — ALWAYS fires, never gated
           getTurnReminders(agentId).catch((err) => {
             console.error(
               "[turn-context] Turn reminders error:",
@@ -195,8 +374,8 @@ export default function register(api: PluginApi): void {
             return null;
           }),
 
-          // 2. Entity resolution (channel-aware, session-cached)
-          sessionKey
+          // 2. Entity resolution — gated by helperConfig
+          helperConfig.entity_resolver && sessionKey
             ? resolveEntityContext(sessionKey, senderInfo).catch((err) => {
                 console.error(
                   "[turn-context] Entity resolution error:",
@@ -206,8 +385,22 @@ export default function register(api: PluginApi): void {
               })
             : Promise.resolve(null),
 
-          // 3. Semantic recall (async spawn of proactive-recall.py)
-          cached?.content
+          // 3. Domain identifier — gated by helperConfig
+          helperConfig.domain_identifier && cached?.content
+            ? identifyDomain(cached.content, classification.domainHints).catch((err) => {
+                console.error(
+                  "[turn-context] Domain identification error:",
+                  err instanceof Error ? err.message : String(err)
+                );
+                return null as DomainResult | null;
+              })
+            : Promise.resolve(null as DomainResult | null),
+
+          // 4. Semantic recall — gated by helperConfig
+          // Uses classifier domain hints for domain-scoped recall (runs in parallel
+          // with domain-identifier; full domain_identifier results used for context
+          // injection only, not for scoping the recall query in this turn)
+          helperConfig.semantic_recall && cached?.content
             ? runSemanticRecall(recallInput).catch((err) => {
                 console.error(
                   "[turn-context] Semantic recall error:",
@@ -220,30 +413,55 @@ export default function register(api: PluginApi): void {
 
       const subsystemMs = Date.now() - subsystemStart;
 
-      // Log each subsystem result
-      const remindersOk = turnRemindersResult.status === "fulfilled" && turnRemindersResult.value;
-      const entityOk = entityContextResult.status === "fulfilled" && entityContextResult.value;
-      const recallOk = recallResult.status === "fulfilled" && recallResult.value;
+      // Resolve settled results
+      const remindersOk =
+        turnRemindersResult.status === "fulfilled" && turnRemindersResult.value != null;
+      const entityOk =
+        entityContextResult.status === "fulfilled" && entityContextResult.value != null;
+      const domainOk =
+        domainIdentifierResult.status === "fulfilled" && domainIdentifierResult.value != null;
+      const recallOk =
+        recallResult.status === "fulfilled" && recallResult.value != null;
 
+      // Structured observability log: per-subsystem timing + tier info
       console.info(
         `[turn-context] Subsystems completed in ${subsystemMs}ms:` +
-        ` reminders=${turnRemindersResult.status}${remindersOk ? `(${(turnRemindersResult as PromiseFulfilledResult<string | null>).value!.length}chars)` : ""}` +
-        ` entity=${entityContextResult.status}${entityOk ? `(${(entityContextResult as PromiseFulfilledResult<string | null>).value!.length}chars)` : ""}` +
-        ` recall=${recallResult.status}${recallOk ? `(${(recallResult as PromiseFulfilledResult<string | null>).value!.length}chars)` : cached?.content ? "(no results)" : "(skipped, no content)"}`
+        ` reminders=${turnRemindersResult.status}` +
+        `${remindersOk ? `(${(turnRemindersResult as PromiseFulfilledResult<string>).value!.length}chars)` : ""}` +
+        ` entity=${helperConfig.entity_resolver ? entityContextResult.status : "skipped"}` +
+        `${entityOk ? `(${(entityContextResult as PromiseFulfilledResult<string>).value!.length}chars)` : ""}` +
+        ` domain=${helperConfig.domain_identifier ? domainIdentifierResult.status : "skipped"}` +
+        `${domainOk ? `(${(domainIdentifierResult as PromiseFulfilledResult<DomainResult>).value!.domains.length}matches)` : ""}` +
+        ` recall=${helperConfig.semantic_recall ? recallResult.status : "skipped"}` +
+        `${recallOk ? `(${(recallResult as PromiseFulfilledResult<string>).value!.length}chars)` : cached?.content ? "(no results)" : "(skipped, no content)"}`
       );
 
-      // ── Build prependSystemContext: entity identity + recall memories ─────
+      // ── Build prependSystemContext: entity + domain + recall ──────────────
       // These go BEFORE the base system prompt so the LLM has full context
       // before reading instructions.
 
       const prependSegments: string[] = [];
 
+      // Entity identity (who is the sender)
       if (entityOk) {
-        prependSegments.push((entityContextResult as PromiseFulfilledResult<string>).value);
+        prependSegments.push((entityContextResult as PromiseFulfilledResult<string>).value!);
       }
 
+      // Domain routing results
+      if (domainOk) {
+        const domainResultValue = (domainIdentifierResult as PromiseFulfilledResult<DomainResult>).value!;
+        const domainContextStr = formatDomainContext(domainResultValue);
+        if (domainContextStr) {
+          prependSegments.push(domainContextStr);
+        } else {
+          // Explicitly surface "no domain identified" so agents know routing was attempted
+          prependSegments.push("🏷️ Domain: NO DOMAIN IDENTIFIED");
+        }
+      }
+
+      // Semantic recall memories
       if (recallOk) {
-        prependSegments.push((recallResult as PromiseFulfilledResult<string>).value);
+        prependSegments.push((recallResult as PromiseFulfilledResult<string>).value!);
       }
 
       // ── Build appendSystemContext: per-turn reminders ─────────────────────
@@ -252,7 +470,7 @@ export default function register(api: PluginApi): void {
       const appendSegments: string[] = [];
 
       if (remindersOk) {
-        appendSegments.push((turnRemindersResult as PromiseFulfilledResult<string>).value);
+        appendSegments.push((turnRemindersResult as PromiseFulfilledResult<string>).value!);
       }
 
       // ── Assemble result ───────────────────────────────────────────────────
@@ -269,13 +487,22 @@ export default function register(api: PluginApi): void {
 
       // If all subsystems produced nothing, return undefined (no injection)
       if (Object.keys(result).length === 0) {
-        console.info(`[turn-context] before_prompt_build DONE in ${totalMs}ms — no context to inject`);
+        console.info(
+          `[turn-context] before_prompt_build DONE in ${totalMs}ms — no context to inject` +
+          ` (classifier=${classification.type}/${classification.method})`
+        );
         return undefined;
       }
 
       const prependLen = result.prependSystemContext?.length ?? 0;
       const appendLen = result.appendSystemContext?.length ?? 0;
-      console.info(`[turn-context] before_prompt_build DONE in ${totalMs}ms — injecting prepend=${prependLen}chars append=${appendLen}chars`);
+      console.info(
+        `[turn-context] before_prompt_build DONE in ${totalMs}ms —` +
+        ` injecting prepend=${prependLen}chars append=${appendLen}chars` +
+        ` classifier=${classification.type}/${classification.method}` +
+        ` tier=${classification.domainHints?.length ? "domain" : "full_nodomain"}` +
+        ` isGroup=${isGroup}`
+      );
 
       return result;
     },

--- a/memory/plugins/turn-context/src/index.ts
+++ b/memory/plugins/turn-context/src/index.ts
@@ -448,7 +448,6 @@ export default function register(api: PluginApi): void {
         ` recall=${helperConfig.semantic_recall ? recallResult.status : "skipped"}` +
         `${recallOk ? `(${(recallResult as PromiseFulfilledResult<string>).value!.length}chars)` : cached?.content ? "(no results)" : "(skipped, no content)"}`
       );
-      );
 
       // ── Build prependSystemContext: entity + domain + recall ──────────────
       // These go BEFORE the base system prompt so the LLM has full context

--- a/memory/plugins/turn-context/src/index.ts
+++ b/memory/plugins/turn-context/src/index.ts
@@ -284,16 +284,17 @@ export default function register(api: PluginApi): void {
       // ── Step 1: Classify message type ──────────────────────────────────────
       // Rule-based classification handles ~60-70% of cases without LLM overhead.
       // Ambiguous messages fall back to Ollama (2000ms timeout).
-      // On any failure, defaults to 'conversation'.
+      // On any failure, defaults to 'info_request' so all subsystems fire —
+      // better to over-recall than silently suppress recall on classifier error.
 
       const classifyStart = Date.now();
-      let classification: ClassifierResult = { type: "conversation", method: "default" };
+      let classification: ClassifierResult = { type: "info_request", method: "default" };
       if (cached?.content) {
         try {
           classification = await classifyMessage(cached.content);
         } catch (err) {
           console.warn(
-            "[turn-context] Classifier error (defaulting to conversation):",
+            "[turn-context] Classifier error (defaulting to info_request for safe full recall):",
             err instanceof Error ? err.message : String(err)
           );
         }
@@ -329,7 +330,32 @@ export default function register(api: PluginApi): void {
         `domain_identifier=${helperConfig.domain_identifier}`
       );
 
-      // Build recall input: pass classifier domain hints + visibility info
+      // ── Step 2.5: Resolve entity first to get entityId for recall input (#075) ───
+      // Entity resolution runs sequentially before recall so the resolved entityId
+      // can be threaded into the recall input for visibility-based filtering.
+      const entityResolveStart = Date.now();
+      let entityContextText: string | null = null;
+      let resolvedEntityId: number | null = null;
+
+      if (helperConfig.entity_resolver && sessionKey) {
+        try {
+          const entityResult = await resolveEntityContext(sessionKey, senderInfo);
+          entityContextText = entityResult.text;
+          resolvedEntityId = entityResult.entityId;
+        } catch (err) {
+          console.error(
+            "[turn-context] Entity resolution error:",
+            err instanceof Error ? err.message : String(err)
+          );
+        }
+      }
+      console.info(
+        `[turn-context] entity-resolver: ` +
+        `${resolvedEntityId != null ? `entityId=${resolvedEntityId}` : "no entity"} ` +
+        `elapsed=${Date.now() - entityResolveStart}ms`
+      );
+
+      // Build recall input: pass classifier domain hints, resolved entityId, + visibility info
       const recallInput: RecallInput = {
         content: cached?.content ?? "",
         senderId: cached?.senderId ?? "",
@@ -341,9 +367,11 @@ export default function register(api: PluginApi): void {
         guildId: "",
         messageId: "",
         domainHints: classification.domainHints,
+        entityId: resolvedEntityId ?? undefined,  // Now correctly wired (#075)
       };
 
-      // ── Step 3: Run all subsystems in parallel ────────────────────────────
+      // ── Step 3: Run remaining subsystems in parallel ─────────────────────────
+      // (Entity resolution ran above to supply entityId to recallInput.)
       // Turn reminders always fire (not gated by helperConfig).
       // Other subsystems are gated by their helperConfig flag.
       //
@@ -352,15 +380,13 @@ export default function register(api: PluginApi): void {
       console.info(
         `[turn-context] Starting parallel subsystems:` +
         ` turn-reminders=always` +
-        ` entity-resolver=${helperConfig.entity_resolver}` +
         ` domain-identifier=${helperConfig.domain_identifier}` +
         ` semantic-recall=${helperConfig.semantic_recall}`
       );
       const subsystemStart = Date.now();
 
-      const [turnRemindersResult, entityContextResult, domainIdentifierResult, recallResult] =
+      const [turnRemindersResult, domainIdentifierResult, recallResult] =
         await Promise.allSettled<[
-          Promise<string | null>,
           Promise<string | null>,
           Promise<DomainResult | null>,
           Promise<string | null>,
@@ -374,18 +400,7 @@ export default function register(api: PluginApi): void {
             return null;
           }),
 
-          // 2. Entity resolution — gated by helperConfig
-          helperConfig.entity_resolver && sessionKey
-            ? resolveEntityContext(sessionKey, senderInfo).catch((err) => {
-                console.error(
-                  "[turn-context] Entity resolution error:",
-                  err instanceof Error ? err.message : String(err)
-                );
-                return null;
-              })
-            : Promise.resolve(null),
-
-          // 3. Domain identifier — gated by helperConfig
+          // 2. Domain identifier — gated by helperConfig
           helperConfig.domain_identifier && cached?.content
             ? identifyDomain(cached.content, classification.domainHints).catch((err) => {
                 console.error(
@@ -396,10 +411,9 @@ export default function register(api: PluginApi): void {
               })
             : Promise.resolve(null as DomainResult | null),
 
-          // 4. Semantic recall — gated by helperConfig
-          // Uses classifier domain hints for domain-scoped recall (runs in parallel
-          // with domain-identifier; full domain_identifier results used for context
-          // injection only, not for scoping the recall query in this turn)
+          // 3. Semantic recall — gated by helperConfig
+          // Uses classifier domain hints and resolved entityId for domain-scoped
+          // and visibility-gated recall (#150, #075)
           helperConfig.semantic_recall && cached?.content
             ? runSemanticRecall(recallInput).catch((err) => {
                 console.error(
@@ -416,8 +430,7 @@ export default function register(api: PluginApi): void {
       // Resolve settled results
       const remindersOk =
         turnRemindersResult.status === "fulfilled" && turnRemindersResult.value != null;
-      const entityOk =
-        entityContextResult.status === "fulfilled" && entityContextResult.value != null;
+      const entityOk = entityContextText != null;
       const domainOk =
         domainIdentifierResult.status === "fulfilled" && domainIdentifierResult.value != null;
       const recallOk =
@@ -428,12 +441,13 @@ export default function register(api: PluginApi): void {
         `[turn-context] Subsystems completed in ${subsystemMs}ms:` +
         ` reminders=${turnRemindersResult.status}` +
         `${remindersOk ? `(${(turnRemindersResult as PromiseFulfilledResult<string>).value!.length}chars)` : ""}` +
-        ` entity=${helperConfig.entity_resolver ? entityContextResult.status : "skipped"}` +
-        `${entityOk ? `(${(entityContextResult as PromiseFulfilledResult<string>).value!.length}chars)` : ""}` +
+        ` entity=${helperConfig.entity_resolver ? (entityOk ? "fulfilled" : "no-entity") : "skipped"}` +
+        `${entityOk ? `(${entityContextText!.length}chars entityId=${resolvedEntityId})` : ""}` +
         ` domain=${helperConfig.domain_identifier ? domainIdentifierResult.status : "skipped"}` +
         `${domainOk ? `(${(domainIdentifierResult as PromiseFulfilledResult<DomainResult>).value!.domains.length}matches)` : ""}` +
         ` recall=${helperConfig.semantic_recall ? recallResult.status : "skipped"}` +
         `${recallOk ? `(${(recallResult as PromiseFulfilledResult<string>).value!.length}chars)` : cached?.content ? "(no results)" : "(skipped, no content)"}`
+      );
       );
 
       // ── Build prependSystemContext: entity + domain + recall ──────────────
@@ -444,7 +458,7 @@ export default function register(api: PluginApi): void {
 
       // Entity identity (who is the sender)
       if (entityOk) {
-        prependSegments.push((entityContextResult as PromiseFulfilledResult<string>).value!);
+        prependSegments.push(entityContextText!);
       }
 
       // Domain routing results

--- a/memory/plugins/turn-context/src/semantic-recall.ts
+++ b/memory/plugins/turn-context/src/semantic-recall.ts
@@ -81,6 +81,10 @@ export interface RecallInput {
   channelName?: string;
   guildId?: string;
   messageId?: string;
+  /** Domain hints from classifier or domain-identifier for scoped recall (#150) */
+  domainHints?: string[];
+  /** Resolved entity ID for visibility-based filtering in group channels (#168) */
+  entityId?: number;
 }
 
 /**
@@ -98,6 +102,17 @@ export async function runSemanticRecall(
 ): Promise<string | null> {
   const messageText = input.content.substring(0, 2000);
 
+  // Determine recall tier for observability logging
+  const tier =
+    input.domainHints?.length
+      ? "domain"
+      : "full_nodomain";
+
+  console.info(
+    `[turn-context] semantic-recall: tier=${tier} isGroup=${input.isGroup ?? false}` +
+    ` domainHints=${input.domainHints?.length ?? 0} entityId=${input.entityId ?? "none"}`
+  );
+
   const stdinPayload: Record<string, unknown> = {
     content: messageText,
   };
@@ -105,10 +120,14 @@ export async function runSemanticRecall(
   if (input.senderName) stdinPayload.senderName = input.senderName;
   if (input.provider) stdinPayload.provider = input.provider;
   if (input.conversationId) stdinPayload.conversationId = input.conversationId;
-  if (input.isGroup) stdinPayload.isGroup = input.isGroup;
+  // Always pass isGroup so proactive-recall.py can apply visibility filter
+  stdinPayload.is_group = input.isGroup ?? false;
   if (input.channelName) stdinPayload.channelName = input.channelName;
   if (input.guildId) stdinPayload.guildId = input.guildId;
   if (input.messageId) stdinPayload.messageId = input.messageId;
+  // Pass domain hints and entity ID for tiered/visibility filtering
+  if (input.domainHints?.length) stdinPayload.domain_hints = input.domainHints;
+  if (input.entityId != null) stdinPayload.entity_id = input.entityId;
 
   let result: RecallResult | null = null;
   try {
@@ -137,7 +156,7 @@ export async function runSemanticRecall(
       ? ` (~${result.tokens_used}/${result.token_budget} tokens)`
       : "";
   console.log(
-    `[turn-context] Semantic recall found ${result.memories.length} memories${tokensInfo}`
+    `[turn-context] Semantic recall found ${result.memories.length} memories${tokensInfo} tier=${tier}`
   );
 
   return `🧠 **Relevant Context:**\n${memoryLines.join("\n\n")}`;

--- a/memory/plugins/turn-context/src/semantic-recall.ts
+++ b/memory/plugins/turn-context/src/semantic-recall.ts
@@ -222,8 +222,8 @@ function spawnWithTimeout(stdinPayload: string): Promise<RecallResult> {
       reject(err);
     });
 
-    // Write JSON payload to stdin and close it
-    child.stdin.write(JSON.stringify(stdinPayload), "utf-8");
+    // Write JSON payload to stdin and close it (stdinPayload is already a JSON string)
+    child.stdin.write(stdinPayload, "utf-8");
     child.stdin.end();
   });
 }

--- a/memory/schema/schema.sql
+++ b/memory/schema/schema.sql
@@ -1,0 +1,1 @@
+/home/nova/nova-mind/database/schema.sql

--- a/memory/scripts/proactive-recall.py
+++ b/memory/scripts/proactive-recall.py
@@ -145,14 +145,16 @@ def recall(config, message, token_budget=DEFAULT_TOKEN_BUDGET, threshold=DEFAULT
         query_embedding = get_embedding(config, message)
 
         cur = conn.cursor()
+        results = None  # Set by whichever recall path runs below
 
-        if is_group:
-            # Visibility filter for group channels: entity_facts must be public (#168)
+        # Tiered recall: domain-scoped search first when domain_hints provided (#150).
+        # If the domain-scoped pass returns enough results (>= 3 above threshold),
+        # use those.  Otherwise fall through to the full unscoped search.
+        if domain_hints:
             print(
-                f"[proactive-recall] applying visibility filter: is_group=True entity_id={entity_id}",
+                f"[proactive-recall] tiered recall: trying domain-scoped search hints={domain_hints}",
                 file=sys.stderr
             )
-            # Priority-weighted semantic search with entity_fact visibility gating
             cur.execute("""
                 SELECT
                     m.source_type,
@@ -162,31 +164,74 @@ def recall(config, message, token_budget=DEFAULT_TOKEN_BUDGET, threshold=DEFAULT
                     (1 - (m.embedding <=> %s::vector)) * COALESCE(p.priority, 1.0) AS weighted_score
                 FROM memory_embeddings m
                 LEFT JOIN memory_type_priorities p ON p.source_type = m.source_type
-                LEFT JOIN entity_facts ef
-                    ON m.source_type = 'entity_fact' AND m.source_id = ef.id::text
-                WHERE 1 - (m.embedding <=> %s::vector) > %s
-                  AND (m.source_type != 'entity_fact' OR ef.visibility = 'public')
+                WHERE m.source_type = 'agent_domain'
+                  AND m.source_id = ANY(%s)
+                  AND 1 - (m.embedding <=> %s::vector) > %s
                 ORDER BY weighted_score DESC
                 LIMIT %s
-            """, (query_embedding, query_embedding, query_embedding, threshold, max_results))
-        else:
-            # Standard priority-weighted semantic search (#53)
-            # Joins memory_type_priorities for configurable source_type boosting
-            cur.execute("""
-                SELECT
-                    m.source_type,
-                    m.source_id,
-                    m.content,
-                    1 - (m.embedding <=> %s::vector) AS similarity,
-                    (1 - (m.embedding <=> %s::vector)) * COALESCE(p.priority, 1.0) AS weighted_score
-                FROM memory_embeddings m
-                LEFT JOIN memory_type_priorities p ON p.source_type = m.source_type
-                WHERE 1 - (m.embedding <=> %s::vector) > %s
-                ORDER BY weighted_score DESC
-                LIMIT %s
-            """, (query_embedding, query_embedding, query_embedding, threshold, max_results))
-        
-        results = cur.fetchall()
+            """, (query_embedding, query_embedding, domain_hints, query_embedding, threshold, max_results))
+            domain_results = cur.fetchall()
+            if len(domain_results) >= 3:
+                print(
+                    f"[proactive-recall] tiered recall path: domain-scoped "
+                    f"(sufficient: {len(domain_results)} >= 3)",
+                    file=sys.stderr
+                )
+                results = domain_results
+            else:
+                print(
+                    f"[proactive-recall] tiered recall path: fallback to full search "
+                    f"(domain returned {len(domain_results)} < 3)",
+                    file=sys.stderr
+                )
+
+        if results is None:
+            # Full unscoped search (with optional group-channel visibility filter)
+            if is_group:
+                # Visibility filter for group channels: entity_facts must be public (#168)
+                print(
+                    f"[proactive-recall] applying visibility filter: is_group=True entity_id={entity_id}",
+                    file=sys.stderr
+                )
+                # Priority-weighted semantic search with entity_fact visibility gating
+                cur.execute("""
+                    SELECT
+                        m.source_type,
+                        m.source_id,
+                        m.content,
+                        1 - (m.embedding <=> %s::vector) AS similarity,
+                        (1 - (m.embedding <=> %s::vector)) * COALESCE(p.priority, 1.0) AS weighted_score
+                    FROM memory_embeddings m
+                    LEFT JOIN memory_type_priorities p ON p.source_type = m.source_type
+                    LEFT JOIN entity_facts ef
+                        ON m.source_type = 'entity_fact' AND m.source_id = ef.id::text
+                    WHERE 1 - (m.embedding <=> %s::vector) > %s
+                      AND (m.source_type != 'entity_fact' OR ef.visibility = 'public')
+                    ORDER BY weighted_score DESC
+                    LIMIT %s
+                """, (query_embedding, query_embedding, query_embedding, threshold, max_results))
+            else:
+                # Standard priority-weighted semantic search (#53)
+                # Joins memory_type_priorities for configurable source_type boosting
+                print(
+                    "[proactive-recall] tiered recall path: full unscoped search",
+                    file=sys.stderr
+                )
+                cur.execute("""
+                    SELECT
+                        m.source_type,
+                        m.source_id,
+                        m.content,
+                        1 - (m.embedding <=> %s::vector) AS similarity,
+                        (1 - (m.embedding <=> %s::vector)) * COALESCE(p.priority, 1.0) AS weighted_score
+                    FROM memory_embeddings m
+                    LEFT JOIN memory_type_priorities p ON p.source_type = m.source_type
+                    WHERE 1 - (m.embedding <=> %s::vector) > %s
+                    ORDER BY weighted_score DESC
+                    LIMIT %s
+                """, (query_embedding, query_embedding, query_embedding, threshold, max_results))
+            results = cur.fetchall()
+
         conn.close()
         
         # Apply token budget with tiered retrieval and dynamic limits

--- a/memory/scripts/proactive-recall.py
+++ b/memory/scripts/proactive-recall.py
@@ -123,11 +123,12 @@ def truncate_content(content, similarity, result_count=5, high_threshold=HIGH_CO
     return content[:max_len].rsplit(' ', 1)[0] + suffix
 
 
-def recall(config, message, token_budget=DEFAULT_TOKEN_BUDGET, threshold=DEFAULT_THRESHOLD, 
-           max_results=DEFAULT_MAX_RESULTS, high_confidence=HIGH_CONFIDENCE_THRESHOLD):
+def recall(config, message, token_budget=DEFAULT_TOKEN_BUDGET, threshold=DEFAULT_THRESHOLD,
+           max_results=DEFAULT_MAX_RESULTS, high_confidence=HIGH_CONFIDENCE_THRESHOLD,
+           is_group=False, entity_id=None, domain_hints=None):
     """
     Get relevant memories for a message with token budget control.
-    
+
     Args:
         config: Embedding configuration dict
         message: Query text
@@ -135,27 +136,55 @@ def recall(config, message, token_budget=DEFAULT_TOKEN_BUDGET, threshold=DEFAULT
         threshold: Minimum similarity score
         max_results: Maximum results to fetch from DB
         high_confidence: Threshold for full content vs summary
+        is_group: Whether this is a group channel; gates entity_fact visibility filter (#168)
+        entity_id: Resolved entity ID for fine-grained filtering (optional)
+        domain_hints: Domain keywords from classifier for domain-scoped search (optional)
     """
     try:
         conn = psycopg2.connect()
         query_embedding = get_embedding(config, message)
-        
+
         cur = conn.cursor()
-        # Priority-weighted semantic search (#53)
-        # Joins memory_type_priorities for configurable source_type boosting
-        cur.execute("""
-            SELECT 
-                m.source_type,
-                m.source_id,
-                m.content,
-                1 - (m.embedding <=> %s::vector) AS similarity,
-                (1 - (m.embedding <=> %s::vector)) * COALESCE(p.priority, 1.0) AS weighted_score
-            FROM memory_embeddings m
-            LEFT JOIN memory_type_priorities p ON p.source_type = m.source_type
-            WHERE 1 - (m.embedding <=> %s::vector) > %s
-            ORDER BY weighted_score DESC
-            LIMIT %s
-        """, (query_embedding, query_embedding, query_embedding, threshold, max_results))
+
+        if is_group:
+            # Visibility filter for group channels: entity_facts must be public (#168)
+            print(
+                f"[proactive-recall] applying visibility filter: is_group=True entity_id={entity_id}",
+                file=sys.stderr
+            )
+            # Priority-weighted semantic search with entity_fact visibility gating
+            cur.execute("""
+                SELECT
+                    m.source_type,
+                    m.source_id,
+                    m.content,
+                    1 - (m.embedding <=> %s::vector) AS similarity,
+                    (1 - (m.embedding <=> %s::vector)) * COALESCE(p.priority, 1.0) AS weighted_score
+                FROM memory_embeddings m
+                LEFT JOIN memory_type_priorities p ON p.source_type = m.source_type
+                LEFT JOIN entity_facts ef
+                    ON m.source_type = 'entity_fact' AND m.source_id = ef.id::text
+                WHERE 1 - (m.embedding <=> %s::vector) > %s
+                  AND (m.source_type != 'entity_fact' OR ef.visibility = 'public')
+                ORDER BY weighted_score DESC
+                LIMIT %s
+            """, (query_embedding, query_embedding, query_embedding, threshold, max_results))
+        else:
+            # Standard priority-weighted semantic search (#53)
+            # Joins memory_type_priorities for configurable source_type boosting
+            cur.execute("""
+                SELECT
+                    m.source_type,
+                    m.source_id,
+                    m.content,
+                    1 - (m.embedding <=> %s::vector) AS similarity,
+                    (1 - (m.embedding <=> %s::vector)) * COALESCE(p.priority, 1.0) AS weighted_score
+                FROM memory_embeddings m
+                LEFT JOIN memory_type_priorities p ON p.source_type = m.source_type
+                WHERE 1 - (m.embedding <=> %s::vector) > %s
+                ORDER BY weighted_score DESC
+                LIMIT %s
+            """, (query_embedding, query_embedding, query_embedding, threshold, max_results))
         
         results = cur.fetchall()
         conn.close()
@@ -241,24 +270,36 @@ def main():
         sys.exit(1)
     # Try to parse as JSON first (structured input from semantic-recall hook)
     # Fall back to treating stdin as plain text for backward compatibility
+    is_group = False
+    entity_id = None
+    domain_hints = None
     try:
         parsed = json.loads(raw_stdin)
         message_text = parsed.get("content", "").strip()
+        # New fields for tiered recall and visibility filtering (#150, #140, #168)
+        is_group = bool(parsed.get("is_group", False))
+        entity_id = parsed.get("entity_id")  # int or None
+        raw_hints = parsed.get("domain_hints")
+        if isinstance(raw_hints, list):
+            domain_hints = [h for h in raw_hints if isinstance(h, str)]
     except (json.JSONDecodeError, AttributeError):
         message_text = raw_stdin
-    
+
     if not message_text:
         parser.print_help()
         sys.exit(1)
     config = load_embedding_config()
     print(f"Using Ollama config: {config['provider']} / {config['model']} ({config['dimensions']} dims)", file=sys.stderr)
-    
+
     result = recall(
         config,
-        message_text, 
+        message_text,
         token_budget=args.max_tokens,
         threshold=args.threshold,
-        high_confidence=args.high_confidence
+        high_confidence=args.high_confidence,
+        is_group=is_group,
+        entity_id=entity_id,
+        domain_hints=domain_hints,
     )
     
     if args.inject:

--- a/memory/scripts/seed-domain-embeddings.py
+++ b/memory/scripts/seed-domain-embeddings.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Seed Domain Embeddings: Embed all agent_domain descriptions into memory_embeddings.
+
+Reads domain descriptions from agent_domains.notes, embeds via Ollama,
+and upserts into memory_embeddings with source_type='agent_domain'.
+
+Usage:
+    python seed-domain-embeddings.py [--dry-run]
+
+Idempotent: uses ON CONFLICT to update existing rows.
+
+Issue: nova-mind #150
+"""
+
+import os
+import sys
+import json
+import argparse
+import urllib.request
+import urllib.error
+
+import psycopg2
+
+# Load centralized PostgreSQL configuration
+sys.path.insert(0, os.path.expanduser("~/.openclaw/lib"))
+from pg_env import load_pg_env
+load_pg_env()
+
+
+def load_embedding_config():
+    """Load embedding configuration from the script's directory."""
+    config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'embedding-config.json')
+    if not os.path.exists(config_path):
+        print(f"Error: Config file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+    with open(config_path) as f:
+        return json.load(f)
+
+
+def get_embedding(config, text):
+    """Get embedding vector via Ollama API."""
+    url = f"{config['base_url']}/api/embeddings"
+    payload = json.dumps({"model": config["model"], "prompt": text}).encode()
+    req = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        result = json.loads(resp.read())
+    embedding = result["embedding"]
+    if len(embedding) != config["dimensions"]:
+        raise ValueError(f"Dimension mismatch: got {len(embedding)}, expected {config['dimensions']}")
+    return embedding
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Seed domain description embeddings into memory_embeddings")
+    parser.add_argument("--dry-run", action="store_true", help="Print domains without embedding or writing")
+    args = parser.parse_args()
+
+    config = load_embedding_config()
+    print(f"Embedding config: {config['provider']} / {config['model']} ({config['dimensions']} dims)", file=sys.stderr)
+
+    conn = psycopg2.connect()
+    cur = conn.cursor()
+
+    # Fetch all domains with descriptions
+    cur.execute("""
+        SELECT ad.domain_topic, ad.notes,
+               a.name AS agent_name
+        FROM agent_domains ad
+        JOIN agents a ON a.id = ad.agent_id
+        WHERE ad.notes IS NOT NULL AND ad.notes != ''
+        ORDER BY ad.domain_topic
+    """)
+    domains = cur.fetchall()
+
+    if not domains:
+        print("No domains with descriptions found. Run migration 081 first.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Found {len(domains)} domains with descriptions", file=sys.stderr)
+
+    if args.dry_run:
+        for topic, notes, agent in domains:
+            print(f"  {topic} ({agent}): {notes[:80]}...")
+        print(f"\nDry run: would embed {len(domains)} domains", file=sys.stderr)
+        conn.close()
+        return
+
+    embedded = 0
+    skipped = 0
+    errors = 0
+
+    for topic, notes, agent in domains:
+        # Build embedding content: domain name + description for rich context
+        embed_text = f"Subject matter domain: {topic}. {notes}"
+        try:
+            embedding = get_embedding(config, embed_text)
+        except Exception as e:
+            print(f"  ERROR embedding '{topic}': {e}", file=sys.stderr)
+            errors += 1
+            continue
+
+        try:
+            # Upsert into memory_embeddings
+            # source_type='agent_domain', source_id=domain_topic
+            cur.execute("""
+                INSERT INTO memory_embeddings (source_type, source_id, content, embedding)
+                VALUES ('agent_domain', %s, %s, %s::vector)
+                ON CONFLICT (source_type, source_id)
+                DO UPDATE SET content = EXCLUDED.content, embedding = EXCLUDED.embedding
+            """, (topic, embed_text, embedding))
+            embedded += 1
+            print(f"  ✓ {topic} ({agent})", file=sys.stderr)
+        except Exception as e:
+            print(f"  ERROR upserting '{topic}': {e}", file=sys.stderr)
+            errors += 1
+            conn.rollback()
+
+    conn.commit()
+    conn.close()
+
+    print(f"\nDone: {embedded} embedded, {skipped} skipped, {errors} errors", file=sys.stderr)
+    if errors > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/TEST-CASES-ISSUE-150-140-168.md
+++ b/tests/TEST-CASES-ISSUE-150-140-168.md
@@ -1,0 +1,1250 @@
+# Test Cases: SE Run #60 — Issues #150, #140, #168
+**Issues:**
+- #150 — Selective semantic recall + prompt preprocessing / domain routing
+- #140 — Tiered recall strategy
+- #168 — Visibility filter in semantic-recall hook
+
+**Branch:** `feature/se-run-60-selective-recall-domain-routing` (or equivalent)
+**Plugin:** `memory/plugins/turn-context/src/`
+**Recall script:** `~/.openclaw/scripts/proactive-recall.py`
+
+---
+
+## Overview
+
+This batch extends the `turn-context` plugin with five major capabilities:
+
+1. **Message Type Classifier** (`classifier.ts`) — rule-based + Ollama LLM fallback
+2. **Domain Identifier** (`domain-identifier.ts`) — embedding similarity + keyword matching against `agent_domains`
+3. **Prompt Helper Config** (`prompt_helper_config` table) — message_type → subsystem dispatch gating
+4. **Tiered Recall** (refactored `semantic-recall.ts`) — gate subsystems by message type; domain-scoped search first
+5. **Visibility Filtering** (`proactive-recall.py`) — filter `entity_facts` by `visibility` for group vs DM
+
+Plus one bug fix:
+- **Entity Resolver Cache Bugfix** (`entity-resolver.ts`) — cache key changed from `sessionKey` → `sessionKey+senderId`
+
+---
+
+## Test Area 1: Message Type Classifier
+
+### TC-001: Rule-based classification — info_request (question mark)
+**File:** `classifier.ts`
+**Preconditions:** Classifier initialised; no Ollama call expected
+**Input:** `content = "What time is it in Tokyo?"`
+**Expected:**
+- Returns `{ type: "info_request" }` without invoking Ollama
+- Ollama call count: 0
+- Rule matched: question-mark heuristic or interrogative word detection
+
+### TC-002: Rule-based classification — info_request (interrogative word)
+**Input:** `content = "Who owns this repository?"`
+**Expected:**
+- Returns `{ type: "info_request" }`
+- No Ollama call
+
+### TC-003: Rule-based classification — action (imperative verb)
+**Input:** `content = "Search GitHub for open PRs tagged bug"`
+**Expected:**
+- Returns `{ type: "action" }`
+- No Ollama call
+
+### TC-004: Rule-based classification — action (explicit verb words)
+**Input:** `content = "Create a new task for fixing the DB migration"`
+**Expected:**
+- Returns `{ type: "action" }`
+- No Ollama call
+
+### TC-005: Rule-based classification — command (slash prefix)
+**Input:** `content = "/status"`
+**Expected:**
+- Returns `{ type: "command" }`
+- No Ollama call
+
+### TC-006: Rule-based classification — command (bang prefix)
+**Input:** `content = "!help"`
+**Expected:**
+- Returns `{ type: "command" }`
+- No Ollama call
+
+### TC-007: Rule-based classification — continuation (very short message)
+**Input:** `content = "ok"` (≤ 5 chars, single word)
+**Expected:**
+- Returns `{ type: "continuation" }`
+- No Ollama call
+
+### TC-008: Rule-based classification — continuation (affirmation words)
+**Input:** `content = "got it"` or `"sure"` or `"yep"`
+**Expected:**
+- Returns `{ type: "continuation" }`
+- No Ollama call
+
+### TC-009: Rule-based classification — conversation (greeting)
+**Input:** `content = "Hey, how are you doing today?"`
+**Expected:**
+- Returns `{ type: "conversation" }`
+- No Ollama call
+
+### TC-010: Rule-based classification — 60-70% coverage threshold
+**Preconditions:** Representative sample of 100 varied messages
+**Steps:**
+1. Feed 100 messages through classifier (mix of all types)
+2. Count Ollama calls vs rule-matched results
+**Expected:**
+- At least 60 of 100 resolved by rules alone (Ollama call count ≤ 40)
+- This documents the promised 60-70% rule coverage
+
+### TC-011: Ollama fallback — ambiguous message triggers LLM
+**Preconditions:** Ollama running and accessible; mock Ollama to record calls
+**Input:** `content = "Tell me about the situation"` (ambiguous — could be info_request or conversation)
+**Expected:**
+- Rule-based pass does NOT classify with certainty
+- Ollama is called with the message text
+- Returns one of the valid types: `info_request | action | conversation | continuation | command`
+- Response includes the type from Ollama's classification
+
+### TC-012: Ollama fallback — returns domain hints when available
+**Preconditions:** Ollama configured and running
+**Input:** `content = "What's the current state of the payments integration?"` (ambiguous domain context)
+**Expected:**
+- Returns `{ type: "info_request", domainHints: ["payments", "integration"] }` (or similar)
+- domainHints is present and non-empty
+
+### TC-013: Ollama down — graceful degradation
+**Preconditions:** Ollama service stopped / connection refused
+**Input:** `content = "Tell me about that"` (would normally go to Ollama)
+**Expected:**
+- Classifier does NOT throw
+- Returns a fallback classification (e.g., `{ type: "conversation" }`) rather than crashing
+- Error is logged at warn/error level
+- No unhandled rejection propagates to caller
+
+### TC-014: Ollama timeout — graceful degradation
+**Preconditions:** Ollama mock configured to delay > classifier's timeout
+**Input:** Any ambiguous message
+**Expected:**
+- Classifier returns fallback type within the timeout window
+- Does not hang indefinitely
+- Error logged
+
+### TC-015: Empty content — classification
+**Input:** `content = ""`
+**Expected:**
+- Returns `{ type: "continuation" }` OR a well-defined default type
+- Does NOT crash or throw
+- No Ollama call for empty input
+
+### TC-016: Very long message (> 2000 chars) — rule-based still applies
+**Input:** `content` = 2500 character string that starts with a question
+**Expected:**
+- Rule-based pattern matching works on the beginning/full string
+- Classification succeeds without truncation errors
+- If Ollama is called, input is truncated or sampled safely
+
+### TC-017: Message with only whitespace
+**Input:** `content = "   \n\t  "`
+**Expected:**
+- Treated the same as empty content
+- Returns safe default type
+- No crash
+
+### TC-018: Message with special characters (emoji, unicode)
+**Input:** `content = "🔥 What's happening with the build? 🚨"`
+**Expected:**
+- Classification succeeds
+- Emoji/unicode does not break rule matching
+- Returns `info_request` (question mark present)
+
+### TC-019: Classifier returns extracted domain hints from rules
+**Input:** `content = "Check the GitHub CI status for nova-mind"`
+**Expected:**
+- type: `action` or `info_request`
+- domainHints includes something like `["github", "ci"]` or `["software_engineering"]`
+- Domain hints flow downstream to domain-identifier
+
+### TC-020: Classifier output structure validation
+**Input:** Any valid message
+**Expected:**
+- Return type has exactly: `type` (string, one of the 5 valid values) and optional `domainHints` (string array or undefined)
+- No extra undocumented fields
+- Type value is always one of: `info_request | action | conversation | continuation | command`
+
+### TC-020b: Rule-based classification — single `>` treated as continuation
+**Input:** `content = ">"` (exactly one greater-than character, no other text)
+**Preconditions:** This is I)ruid's workflow advance signal per GLOBAL/PROCESS_AND_COORDINATION
+**Expected:**
+- Returns `{ type: "continuation" }` without invoking Ollama
+- NOT misclassified as a blockquote marker, comparison operator, or command
+- Ollama call count: 0
+- Rule matched: single-character message → continuation heuristic
+**Note:** This is a documented convention: "When I)ruid responds with a single `>` character, it means proceed to the next step."
+
+---
+
+## Test Area 2: Domain Identifier
+
+### TC-021: Domain match via keyword — exact keyword hit
+**Preconditions:** `agent_domains` seeded; domain "github" has keyword `["github", "gh", "pull request", "pr"]`
+**Input:** `message = "check the github pr"`, domainHints = []
+**Expected:**
+- Returns domain match for "github" or equivalent domain
+- Matched via keyword, not vector (or both confirm the same domain)
+- Includes `agent` from JOIN on `agent_domains` (not hardcoded)
+
+### TC-022: Domain match via vector similarity — semantic match
+**Preconditions:** Domain descriptions embedded; `memory_embeddings` populated with domain descriptions
+**Input:** `message = "I need to inspect the distributed transaction trace for a slow query"`
+**Expected:**
+- Returns domain for distributed tracing / observability (e.g., "jaeger" or "tracing" domain)
+- Similarity score above threshold
+- Match via embedding similarity
+
+### TC-023: Domain match — keyword wins over low-similarity vector
+**Preconditions:** A message with a clear keyword match but ambiguous embedding
+**Input:** `message = "check slack messages"` (keyword: "slack")
+**Expected:**
+- Returns Slack domain
+- Does not return a different domain with slightly higher vector similarity
+
+### TC-024: NO DOMAIN IDENTIFIED — low similarity, no keyword match
+**Input:** `message = "hmm interesting"`
+**Expected:**
+- Returns `{ domain: "NO DOMAIN IDENTIFIED" }` or equivalent sentinel
+- No agent is returned
+- No crash
+
+### TC-025: NO DOMAIN IDENTIFIED — threshold boundary (below threshold)
+**Preconditions:** Threshold = 0.4 (or configured value); mock embedding returns similarity 0.39
+**Input:** Any message
+**Expected:**
+- Below-threshold similarity → `NO DOMAIN IDENTIFIED`
+- NOT a domain match
+
+### TC-026: Domain identified — threshold boundary (at threshold)
+**Preconditions:** Mock embedding returns similarity exactly at threshold (e.g., 0.40)
+**Input:** Any message
+**Expected:**
+- At-threshold similarity → domain IS matched (inclusive lower bound)
+- Returns the matched domain
+
+### TC-027: Domain identified — above threshold
+**Preconditions:** Mock embedding returns similarity 0.85
+**Expected:**
+- Domain matched confidently
+- Included in output
+
+### TC-028: Agent lookup — agent returned via JOIN, not hardcoded
+**Preconditions:** `agent_domains` table has domain "discord" with `agent_id` FK pointing to the "iris" row in `agents`
+**SQL the domain identifier must use:**
+```sql
+SELECT ad.domain_topic, a.name AS agent_name
+FROM agent_domains ad
+JOIN agents a ON ad.agent_id = a.id
+WHERE ...
+```
+**Input:** Message matching discord domain
+**Expected:**
+- Returned agent name is "iris" (resolved via `agent_domains.agent_id → agents.name` JOIN)
+- `agent_domains` does NOT have an `agent_name` column — the JOIN is mandatory
+- If the agents table row for iris is renamed, returned value changes without any code change
+- No hardcoded agent name strings in `domain-identifier.ts`
+- Confirm: `grep -r 'iris\|gidget\|coder\|scout' src/domain-identifier.ts` returns zero hits
+
+### TC-029: Agent_domains — keywords column populated for all 38 domains
+**Preconditions:** Migration `080_prompt_helper_config.sql` applied
+**Steps:**
+```sql
+SELECT domain_topic FROM agent_domains WHERE keywords IS NULL OR array_length(keywords, 1) = 0;
+```
+**Expected:**
+- Zero rows returned — all 38 domains have non-empty keywords arrays
+- The `keywords` column is TEXT[] and was added by this migration to the pre-existing `agent_domains` table
+
+### TC-030: Agent_domains — notes populated for all 38 domains
+**Preconditions:** Migration applied
+**Steps:**
+```sql
+SELECT domain_topic FROM agent_domains WHERE notes IS NULL OR notes = '';
+```
+**Expected:**
+- Zero rows returned — all 38 pre-existing domains have notes populated
+- The migration UPDATES existing rows; it does not INSERT new domain rows
+- `notes` column existed prior; migration fills in any gaps
+
+### TC-031: Domain descriptions embedded in memory_embeddings
+**Preconditions:** Seeding step ran
+**Steps:**
+```sql
+SELECT COUNT(*) FROM memory_embeddings WHERE source_type = 'agent_domain';
+```
+**Expected:**
+- COUNT = 38 (one embedding per domain)
+- Each row has non-null embedding vector
+- Dimension matches configured embedding model
+
+### TC-032: 5-minute cache TTL — domain data cached
+**Preconditions:** Domain identifier initialised; first call triggers DB query
+**Steps:**
+1. Call domain identifier → note DB query count = 1
+2. Call again immediately → DB query count still 1 (cache hit)
+3. Wait 5 minutes + 1 second (or mock time) → call again → DB query count = 2 (cache miss)
+**Expected:**
+- Cache hit for calls within 5-minute window
+- Cache miss after TTL expires
+- Refreshed data after TTL
+
+### TC-033: Cache TTL — multiple domains resolved, all cached together
+**Preconditions:** Cache loaded with domain data
+**Input:** Two sequential messages matching different domains
+**Expected:**
+- Second message lookup uses cached domain data (no second DB round-trip for domain table)
+
+### TC-034: Domain identifier — empty message
+**Input:** `message = ""`
+**Expected:**
+- Returns `NO DOMAIN IDENTIFIED`
+- Does NOT embed empty string
+- No crash
+
+### TC-035: Domain identifier — DB unavailable
+**Preconditions:** PostgreSQL stopped or connection refused
+**Expected:**
+- Returns `NO DOMAIN IDENTIFIED` (graceful degradation)
+- Logged error at appropriate level
+- Does not throw unhandled error
+
+### TC-036: Domain identifier — Ollama embedding service unavailable
+**Preconditions:** Ollama embedding endpoint returns 500 or connection refused
+**Expected:**
+- Returns `NO DOMAIN IDENTIFIED`
+- Error logged
+- No crash
+
+### TC-037: Domain identifier — multiple keywords match single domain
+**Preconditions:** Domain "github" has keywords `["github", "pr", "pull request", "gh"]`
+**Input:** `message = "open a PR on github"`
+**Expected:**
+- Matches "github" domain exactly once (no duplicate matches)
+- Single domain returned
+
+### TC-038: Domain identifier — ambiguous multi-domain message
+**Input:** `message = "create a github issue and post about it on slack"`
+**Expected:**
+- Returns the highest-confidence domain match (one result)
+- Does not error on ambiguity
+- Optionally: returns top-N domains if spec supports it
+
+### TC-038b: Domain identifier — top-ranked multi-domain results returned
+**Input:** `message = "create a GitHub issue for the database migration"` (legitimately spans Git Operations, Software Engineering, AND Database domains)
+**Expected:**
+- Domain identifier returns ranked list of 1-3 matches ordered by descending similarity/confidence
+- All returned domains have similarity above threshold
+- Caller (tiered recall) uses the top match for domain-scoped search
+- Remaining matches may be used as domain context hints in the output
+- No crash from multiple matches
+- Verify: at minimum, whichever of Git Operations / Software Engineering / Database scores highest is returned first
+
+### TC-039: Domain identifier output structure
+**Input:** Any message with a match
+**Expected:**
+- Output has: `domain` (string), `agent` (string from DB via agents JOIN), `similarity` (float), `matchedBy` (`"keyword" | "vector" | "both"`)
+- When NO DOMAIN IDENTIFIED: `domain = "NO DOMAIN IDENTIFIED"`, `agent = null`
+
+### TC-039b: Domain identifier — injected context format in prompt
+**Preconditions:** Domain identifier returns a match; result is assembled into prependSystemContext
+**Input:** Message matching "Git Operations" domain → agent = "gidget"
+**Expected:**
+- The string injected into the agent's context includes all of: domain name, assigned agent name
+- Example format: `🏷️ Domain: Git Operations → gidget (Version Control)` or equivalent
+- The parent domain / category label is included if available (e.g., "Version Control" as parent of "Git Operations")
+- Agent name is the resolved string from the agents JOIN, NOT an ID number
+- Format is human-readable (agent can act on the domain routing hint)
+**Note:** Exact format TBD by implementation; this TC establishes minimum required fields.
+
+### TC-040: Domain seeding — 38 domains confirmed in pre-existing table
+**Note:** The `agent_domains` table already contains 38 rows. Migration 080 enriches them (adds keywords, fills notes). It does NOT insert new domain rows.
+**Steps:**
+```sql
+SELECT COUNT(*) FROM agent_domains;
+```
+**Expected:**
+- COUNT = 38 (exact — same as before migration; no rows added or removed)
+- Verify: row count is 38 both before AND after applying migration 080
+
+---
+
+## Test Area 3: Prompt Helper Config
+
+### TC-041: Migration creates prompt_helper_config table
+**Preconditions:** Migration `080_prompt_helper_config.sql` applied fresh
+**Steps:**
+```sql
+SELECT column_name, data_type
+FROM information_schema.columns
+WHERE table_name = 'prompt_helper_config'
+ORDER BY ordinal_position;
+```
+**Expected columns (minimum):**
+- `id` (integer or serial, PK)
+- `message_type` (text or enum)
+- `helper_name` (text)
+- `agent_name` (text, nullable — for overrides, NOT routing)
+- `enabled` (boolean)
+
+### TC-042: Default rows — all message types covered
+**Steps:**
+```sql
+SELECT message_type, helper_name, agent_name FROM prompt_helper_config WHERE agent_name IS NULL ORDER BY message_type;
+```
+**Expected:**
+- Rows present for: `info_request`, `action`, `conversation`, `continuation`, `command`
+- Default (agent_name=NULL) rows define baseline dispatch for each type
+
+### TC-043: info_request — full recall pipeline enabled
+**Steps:**
+```sql
+SELECT helper_name, enabled FROM prompt_helper_config
+WHERE message_type = 'info_request' AND agent_name IS NULL;
+```
+**Expected:**
+- Rows for `semantic_recall`, `domain_identifier`, `entity_resolver` all have `enabled = true`
+
+### TC-044: action — full recall pipeline enabled
+**Steps:**
+```sql
+SELECT helper_name, enabled FROM prompt_helper_config
+WHERE message_type = 'action' AND agent_name IS NULL;
+```
+**Expected:**
+- Same helpers enabled as info_request
+
+### TC-045: conversation — entity context only, recall disabled
+**Steps:**
+```sql
+SELECT helper_name, enabled FROM prompt_helper_config
+WHERE message_type = 'conversation' AND agent_name IS NULL;
+```
+**Expected:**
+- `entity_resolver`: enabled = true
+- `semantic_recall`: enabled = false
+- `domain_identifier`: enabled = false (or absent)
+
+### TC-046: continuation — all recall subsystems disabled
+**Steps:**
+```sql
+SELECT helper_name, enabled FROM prompt_helper_config
+WHERE message_type = 'continuation' AND agent_name IS NULL;
+```
+**Expected:**
+- `semantic_recall`: enabled = false
+- `domain_identifier`: enabled = false
+- `entity_resolver`: enabled = false (or present but skipped)
+
+### TC-047: command — all recall subsystems disabled
+**Steps:**
+```sql
+SELECT helper_name, enabled FROM prompt_helper_config
+WHERE message_type = 'command' AND agent_name IS NULL;
+```
+**Expected:**
+- Same as continuation: all recall disabled
+
+### TC-047b: Turn reminders fire for ALL message types including continuation and command
+**Preconditions:** `getTurnReminders()` configured; DB returns reminders for the agent
+**Input:** Messages classified as each of: `continuation`, `command`, `conversation`, `info_request`, `action`
+**Expected:**
+- `getTurnReminders(agentId)` is called for ALL five message types
+- The gating logic (prompt_helper_config / message type checks) applies ONLY to recall/domain/entity subsystems
+- Turn reminders are NEVER gated by message type — they always run
+- `appendSystemContext` contains `📌 Per-Turn Reminders:` content regardless of message type
+- Verify: even a bare `content = ">"` (continuation) still yields appendSystemContext with reminders
+**Rationale:** Turn reminders are operational rules the agent must always see. Skipping them for "simple" messages would cause the agent to miss critical per-turn instructions.
+
+### TC-048: Agent-specific override — custom config respected
+**Preconditions:** Insert override row:
+```sql
+INSERT INTO prompt_helper_config (message_type, helper_name, agent_name, enabled)
+VALUES ('conversation', 'semantic_recall', 'nova', true);
+```
+**Input:** Message type = `conversation`, agentId = `nova`
+**Expected:**
+- Nova's pipeline enables `semantic_recall` for conversation (override wins)
+- Other agents still use the default (disabled) for conversation
+
+### TC-049: Agent-specific override — agent_name is NOT routing target
+**Preconditions:** Table has agent_name = 'nova' override
+**Steps:** Review config loading logic
+**Expected:**
+- `agent_name` column determines WHOSE dispatch config to use
+- Does NOT route the message to that agent
+- The field is purely a config-scoping key
+
+### TC-050: prompt_helper_config — invalid message_type rejected by CHECK constraint
+**Steps:**
+```sql
+INSERT INTO prompt_helper_config (message_type, helper_name, enabled)
+VALUES ('unknown_type', 'semantic_recall', true);
+```
+**Expected:**
+- Rejected by a CHECK constraint (NOT a PostgreSQL enum type)
+- Constraint form:
+  ```sql
+  CHECK (message_type IN ('info_request', 'action', 'conversation', 'continuation', 'command'))
+  ```
+- Error message references the constraint name
+- Row not inserted
+**Note:** Implementation uses CHECK, not `CREATE TYPE ... AS ENUM`. This allows adding new message types via ALTER TABLE without enum migration complexity.
+
+---
+
+## Test Area 4: Tiered Recall — Gating and Tier Selection
+
+### TC-051: continuation → skip recall entirely
+**Preconditions:** Classifier output = `{ type: "continuation" }`; prompt_helper_config defaults loaded
+**Input:** `content = "ok"` (classified as continuation)
+**Expected:**
+- `runSemanticRecall()` is NOT called
+- `runDomainIdentifier()` is NOT called
+- `proactive-recall.py` is NOT spawned
+- Log confirms recall skipped: `[turn-context] Skipping recall: message type=continuation`
+
+### TC-052: command → skip recall entirely
+**Preconditions:** Classifier output = `{ type: "command" }`
+**Input:** `content = "/status"`
+**Expected:**
+- Same as TC-051: recall and domain identifier not invoked
+
+### TC-053: conversation → entity context only, recall skipped
+**Preconditions:** Classifier output = `{ type: "conversation" }`
+**Input:** `content = "Hey, how's your day going?"`
+**Expected:**
+- Entity resolver IS called
+- `runSemanticRecall()` is NOT called
+- Domain identifier is NOT called
+- Log confirms: `[turn-context] recall=skipped(conversation) entity=invoked`
+
+### TC-054: info_request → full recall pipeline runs
+**Preconditions:** Classifier output = `{ type: "info_request" }`; domain identified
+**Input:** `content = "What does the entity resolver do?"`
+**Expected:**
+- Entity resolver is called
+- Domain identifier is called
+- Domain-scoped recall runs first
+- Full vector search runs as fallback (or domain results return, fallback skipped)
+
+### TC-055: action → full recall pipeline runs
+**Preconditions:** Classifier output = `{ type: "action" }`
+**Input:** `content = "Create a GitHub issue for the cache bug"`
+**Expected:**
+- Full pipeline: entity + domain identifier + recall
+- Same as info_request behavior
+
+### TC-056: Domain-scoped search first, results returned — fallback not triggered
+**Preconditions:** Domain identified = "github"; domain-scoped DB query returns ≥ 1 result above threshold
+**Expected:**
+- Domain-scoped SQL executes first (filtered to github domain embeddings)
+- Full vector search does NOT run (domain results sufficient)
+- Observability log: `tier=domain`
+
+### TC-057: Domain-scoped search returns zero results — full vector search fallback triggers
+**Preconditions:** Domain identified = "github"; mock DB returns 0 results for domain-scoped query
+**Expected:**
+- Domain-scoped query runs first, returns nothing
+- Full vector search runs as fallback
+- Observability log: `tier=full_fallback`
+
+### TC-058: NO DOMAIN IDENTIFIED — full vector search runs directly (no domain-scoped phase)
+**Preconditions:** Domain identifier returns `NO DOMAIN IDENTIFIED`
+**Expected:**
+- Domain-scoped search is skipped entirely
+- Full vector search runs immediately
+- Observability log: `tier=full_nodomain`
+
+### TC-059: Tier observability — tier logged in structured format
+**Preconditions:** Any recall run
+**Expected:**
+- Log line includes: `tier=<domain|full_fallback|full_nodomain|skipped>`
+- Format is consistent (parseable by log aggregation)
+- Tier is emitted even when no memories found
+
+### TC-060: Tiered recall — token budget respected across both tiers
+**Preconditions:** info_request message; domain-scoped returns 3 results; full search would return 10 more
+**Expected:**
+- Total tokens across all tiers ≤ TOKEN_BUDGET (default 1000)
+- Domain-scoped results are NOT double-counted if they overlap with full search
+
+### TC-061: Tiered recall — domain-scoped results deduped against full search
+**Preconditions:** Domain-scoped search + full search both return same memory ID
+**Expected:**
+- Memory appears in output exactly once
+- No duplicate entries in `memories[]` output
+
+### TC-062: Tiered recall — empty content bypasses all recall
+**Preconditions:** `cached?.content` is empty string
+**Input:** Before-prompt-build fires with no cached content (cache miss)
+**Expected:**
+- Recall is skipped (as in current implementation)
+- Log: `recall=skipped(no content)` or equivalent
+
+### TC-063: Tiered recall — classifier error falls back to full pipeline
+**Preconditions:** Classifier throws an unexpected error
+**Expected:**
+- Classifier error is caught
+- Pipeline defaults to full recall (safe fallback — do not skip recall on classifier failure)
+- Error logged; no unhandled rejection
+
+### TC-064: Tiered recall — domain identifier error falls back to full vector search
+**Preconditions:** Domain identifier throws (DB down, embedding timeout, etc.)
+**Expected:**
+- Error caught in domain identifier
+- Full vector search runs as fallback
+- Tier logged as `full_fallback`
+
+---
+
+## Test Area 5: Visibility Filtering
+
+**Architecture note:** `memory_embeddings` does NOT have a `visibility` column. When `source_type = 'entity_fact'`, the recall script must JOIN back to `entity_facts` to apply the visibility filter. The WHERE clause lives on the JOIN result, not directly on `memory_embeddings`.
+
+The SQL pattern for group-chat filtering must be:
+```sql
+SELECT m.source_type, m.source_id, m.content, ...
+FROM memory_embeddings m
+LEFT JOIN entity_facts ef
+  ON m.source_type = 'entity_fact' AND m.source_id = ef.id::text
+WHERE ...
+  AND (
+    m.source_type != 'entity_fact'           -- non-entity memories unaffected
+    OR ef.visibility = 'public'              -- entity facts: public only (group)
+  )
+```
+For DM (`is_group = false`), the JOIN is still performed but the visibility WHERE clause is omitted.
+
+### TC-065: Group chat — only public entity_facts returned
+**Preconditions:** `proactive-recall.py` receives `is_group = true`, `entity_id = 42`
+**Setup:**
+```sql
+-- Insert mixed-visibility facts
+INSERT INTO entity_facts (entity_id, key, value, visibility) VALUES
+  (42, 'location', 'Austin TX', 'public'),
+  (42, 'salary', '150000', 'private'),
+  (42, 'nickname', 'Druid', 'public');
+```
+**Steps:**
+```bash
+echo '{"content": "who is this person", "entity_id": 42, "is_group": true}' | python proactive-recall.py
+```
+**Expected:**
+- `location` and `nickname` facts included in output
+- `salary` (private) NOT included
+- Filter applied via JOIN from `memory_embeddings` → `entity_facts` on `source_type = 'entity_fact'`
+- No error
+
+### TC-066: DM/private chat — all entity_facts returned (no visibility filter)
+**Preconditions:** `is_group = false` (or absent); same entity as TC-065
+**Steps:**
+```bash
+echo '{"content": "who is this person", "entity_id": 42, "is_group": false}' | python proactive-recall.py
+```
+**Expected:**
+- All three facts included: `location`, `salary`, `nickname`
+- Visibility JOIN clause omitted from SQL query (or present but unconstrained)
+- No `visibility = 'public'` filter in WHERE
+
+### TC-067: is_group absent from payload — treated as DM (no filter)
+**Preconditions:** stdin JSON has no `is_group` field
+**Steps:**
+```bash
+echo '{"content": "message text", "entity_id": 42}' | python proactive-recall.py
+```
+**Expected:**
+- Treated as `is_group = false`
+- No visibility filtering applied
+- All entity_facts for entity 42 eligible for recall
+
+### TC-068: entity_id absent from payload — visibility filter not applied
+**Preconditions:** stdin JSON has no `entity_id` field (e.g., unknown sender)
+**Steps:**
+```bash
+echo '{"content": "message text", "is_group": true}' | python proactive-recall.py
+```
+**Expected:**
+- No entity-specific fact filtering (no entity_id to filter on)
+- General memory recall (non-entity_fact rows) still functions unaffected
+- No crash or SQL error
+
+### TC-069: Group chat — entity with zero public facts
+**Preconditions:** entity_id = 99; all facts are `visibility = 'private'`
+**Steps:**
+```bash
+echo '{"content": "test", "entity_id": 99, "is_group": true}' | python proactive-recall.py
+```
+**Expected:**
+- Zero entity_fact memories in output (all private, filtered by JOIN)
+- Non-entity_fact source types (e.g., `session`, `lesson`) NOT affected by visibility filter
+- No error
+
+### TC-070: Group chat — entity with zero facts at all
+**Preconditions:** entity_id = 999 (no rows in entity_facts)
+**Expected:**
+- JOIN produces no rows for entity_fact source_type
+- No SQL error (empty JOIN result is valid)
+- Non-entity_fact memories unaffected and returned normally
+
+### TC-071: Visibility JOIN — non-entity_fact sources are never filtered
+**Preconditions:** memory_embeddings contains rows with `source_type = 'session'`, `source_type = 'lesson'`, etc.
+**Input:** Group chat (`is_group = true`)
+**Expected:**
+- Only `source_type = 'entity_fact'` rows are subject to the visibility JOIN filter
+- All other source types pass through unfiltered regardless of group/DM status
+- Confirm via EXPLAIN or SQL review: the visibility WHERE condition is inside an OR/CASE that excludes non-entity_fact rows
+
+### TC-072: Visibility — null visibility value in entity_facts
+**Preconditions:** entity_id = 55 has a fact with `visibility = NULL` (stored in entity_facts)
+**Input:** Group chat (`is_group = true`)
+**Expected:**
+- NULL visibility fact NOT included after JOIN filter (NULL ≠ 'public' in SQL)
+- Consistent with strict equality: `ef.visibility = 'public'` excludes NULLs
+
+### TC-073: Visibility — 'public' value exactly (case-sensitive)
+**Preconditions:** One entity_fact has `visibility = 'Public'` (capital P); one has `visibility = 'public'`
+**Input:** Group chat
+**Expected:**
+- Only the lowercase `'public'` fact passes the JOIN filter (SQL equality is case-sensitive by default)
+- `'Public'` is treated as non-public and excluded
+- Document this behavior in test notes
+
+### TC-074: domain_hints passed via stdin — accepted without error
+**Preconditions:** proactive-recall.py receives domain_hints in payload
+**Steps:**
+```bash
+echo '{"content": "check the pipeline", "domain_hints": ["software_engineering"], "is_group": false}' | python proactive-recall.py
+```
+**Expected:**
+- Script accepts domain_hints without crashing
+- domain_hints are used if tiered recall uses them (or gracefully ignored if not yet wired)
+
+### TC-075: entity_id and is_group flow from semantic-recall.ts to proactive-recall.py
+**Preconditions:** `semantic-recall.ts` receives `isGroup: true` and `senderId` resolves to `entity_id = 42`
+**Steps:** Trace the stdin JSON payload logged by proactive-recall.py
+**Expected:**
+- stdin JSON contains `"entity_id": 42`
+- stdin JSON contains `"is_group": true`
+- Values match the resolved entity and channel type
+- Confirm: entity_id is the integer PK from the `entities` table (not senderId string)
+
+---
+
+## Test Area 6: Entity Resolver Cache Bugfix
+
+### TC-076: Bug baseline — old behavior (keyed by sessionKey alone)
+**Preconditions:** Unfixed code (or documented as baseline for regression)
+**Scenario:** Group channel where sessionKey is constant; two users message in sequence
+1. User A (senderId=111) messages first → entity for User A cached under sessionKey
+2. User B (senderId=222) messages second → cache returns User A's entity (wrong!)
+**Expected (buggy behavior to confirm fix prevents):**
+- WITHOUT fix: User B gets User A's cached entity context — WRONG
+- WITH fix: User B gets their own entity context — CORRECT
+
+### TC-077: Fix — cache keyed by sessionKey+senderId (group channel)
+**Preconditions:** Fixed `entity-resolver.ts` with cache key = `sessionKey + ":" + senderId`
+**Scenario:** Same group channel; User A then User B messages
+**Steps:**
+1. Message from User A (senderId=111) in session "group-channel-xyz"
+   - Cache lookup: `group-channel-xyz:111` → miss → resolve → cache write
+2. Message from User B (senderId=222) in same session
+   - Cache lookup: `group-channel-xyz:222` → miss → resolve → cache write
+3. Second message from User A
+   - Cache lookup: `group-channel-xyz:111` → HIT → returns User A's entity
+**Expected:**
+- Cache key format: `{sessionKey}:{senderId}`
+- Each user gets their own cached entity
+- Cache hits work for the same user in subsequent messages
+
+### TC-078: Fix — DM channel (single user, one cache entry)
+**Preconditions:** Fixed code; DM channel where only one user ever sends
+**Scenario:** User A sends 5 messages in DM session "dm-session-abc"
+**Expected:**
+- Cache hit from message 2 onward
+- Cache key: `dm-session-abc:{senderId-A}` (consistent)
+- Entity resolved once, cached thereafter
+
+### TC-079: Cache key collision — different channels, same senderId
+**Scenario:** User A (senderId=111) is in two different group channels
+- Channel 1: sessionKey = "group-abc"; entity = EntityA1
+- Channel 2: sessionKey = "group-def"; entity = EntityA2 (same user, different channel context)
+**Expected:**
+- Cache keys: `group-abc:111` and `group-def:111` are distinct
+- No cross-channel cache bleed
+
+### TC-080: Cache key — senderId undefined (anonymous or missing)
+**Preconditions:** senderId is not provided (cache miss scenario)
+**Expected:**
+- Cache lookup skipped OR key constructed defensively (e.g., `sessionKey:undefined`)
+- No entity resolved (returns null gracefully)
+- No crash
+
+### TC-081: Cache eviction — stale entry (30-minute TTL from index.ts)
+**Preconditions:** Entity cached; 30 minutes + 1 second pass (or mock time)
+**Expected:**
+- Cache entry is considered stale on read
+- Fresh resolution attempted
+- Old stale entry not served
+
+### TC-082: Cache max size — 1000 entries; oldest evicted on overflow
+**Preconditions:** 999 distinct sessionKey:senderId pairs already cached
+**Steps:**
+1. Add entry #1000 → cache size = 1000 (OK, no eviction yet)
+2. Add entry #1001 → eviction fires; oldest by timestamp removed
+**Expected:**
+- Cache never exceeds 1000 entries
+- Oldest entry removed (not random, not newest)
+- Evicted entry is re-resolved on next access (cold miss)
+
+### TC-083: Concurrent messages from same user — no double-resolution race
+**Preconditions:** Two simultaneous before_prompt_build hooks fire for same sessionKey+senderId
+**Expected:**
+- Entity resolved once (or at most twice with race, but result is consistent)
+- No cache corruption from concurrent writes
+- No Promise rejection
+
+---
+
+## Test Area 7: Integration Scenarios
+
+### TC-084: Full happy path — info_request, domain found, memories recalled
+**Scenario:** I)ruid sends "What's the status of the GitHub CI for nova-mind?"
+**Steps:**
+1. `message_received` fires → sender info cached
+2. `before_prompt_build` fires
+3. Classifier → `info_request`
+4. Domain identifier → matches "github" domain
+5. Entity resolver → resolves I)ruid's entity, loads facts
+6. Tiered recall → domain-scoped search first, returns 3 relevant memories
+7. Result assembled and returned
+**Expected:**
+- `prependSystemContext` contains:
+  - `👤 Talking with: I)ruid` (entity context)
+  - `🧠 Relevant Context:` with 3 memories (recall)
+- `appendSystemContext` contains `📌 Per-Turn Reminders:` (if reminders exist)
+- All memories are from github/CI-related content
+- No errors in any subsystem
+
+### TC-085: Full happy path — action, no domain match, full vector search fallback
+**Scenario:** "Do a thing with that stuff" (action type, ambiguous domain)
+**Expected:**
+- Classifier → `action`
+- Domain identifier → `NO DOMAIN IDENTIFIED`
+- Full vector search runs
+- Results returned based on full search
+- Tier logged as `full_nodomain`
+
+### TC-086: Full happy path — conversation, entity only (no recall)
+**Scenario:** "Hey Nova, how's it going?"
+**Expected:**
+- Classifier → `conversation`
+- Entity resolver runs → entity context in prepend
+- Recall NOT run
+- Domain identifier NOT run
+- `prependSystemContext` = entity context only
+- `appendSystemContext` = turn reminders only
+
+### TC-087: Full happy path — continuation, nothing runs
+**Scenario:** "ok" (single-word acknowledgment)
+**Expected:**
+- Classifier → `continuation`
+- Entity resolver NOT run
+- Recall NOT run
+- Domain identifier NOT run
+- Return: `undefined` OR only turn reminders (appendSystemContext) if those are not gated
+
+### TC-088: Classifier + domain identifier + tiered recall — domain-scoped then fallback
+**Scenario:** "What's happening with the Discord bot?" (info_request, discord domain)
+**Setup:** Domain-scoped search returns 0 results (no embeddings for discord in DB)
+**Expected:**
+- domain-scoped phase: 0 results
+- fallback phase: full vector search runs → returns general memories
+- Final output includes relevant memories from full search
+- Tier log shows `full_fallback`
+
+### TC-089: Group channel — entity resolver + visibility filter + recall
+**Scenario:** Unknown user in group channel sends "What's the plan for today?"
+- `is_group = true`
+- entity resolved to entity_id = 77 with mixed-visibility facts
+**Expected:**
+- Entity resolver returns entity context (public facts only)
+- `proactive-recall.py` called with `is_group: true, entity_id: 77`
+- Private facts NOT in output
+- Recall memories from full vector search (group has no domain context)
+
+### TC-090: Cache miss → resolution → cache hit on next message — all subsystems
+**Scenario:** Same user sends two messages in quick succession
+**Expected:**
+- Message 1: entity resolver cache miss → resolved → cached
+- Message 2: entity resolver cache hit (no DB call)
+- Domain cache hit (within 5-minute TTL)
+- Sender cache hit (from message_received)
+- Second message processed faster than first
+
+### TC-091: All subsystems fail — graceful total degradation
+**Preconditions:** DB down, Ollama down
+**Input:** Any message
+**Expected:**
+- Classifier → fails → fallback type returned
+- Domain identifier → fails → NO DOMAIN IDENTIFIED
+- Entity resolver → fails → null
+- Recall → fails → null
+- Return: `undefined` (no context to inject) OR only turn reminders if they were cached
+- No crash; no unhandled rejection
+- All errors logged
+
+### TC-092: Classifier + domain hint feeds domain identifier
+**Preconditions:** Classifier returns `domainHints = ["slack"]`
+**Expected:**
+- Domain identifier receives these hints
+- Keyword matching cross-references against hints
+- If "slack" matches a domain keyword, confidence boosted or domain matched faster
+
+### TC-093: message_received race condition — before_prompt_build fires before cache write
+**Preconditions:** Node.js event ordering; cache write is synchronous (per code)
+**Expected:**
+- Cache write in `message_received` occurs BEFORE any `await`
+- If `before_prompt_build` fires concurrently, it either gets the cached value or gracefully handles miss
+- The implementation's existing "cache write MUST happen before any await" comment is enforced
+
+---
+
+## Test Area 8: Boundary Values and Thresholds
+
+### TC-094: Similarity threshold — at 0.4 (default)
+**Preconditions:** `DEFAULT_THRESHOLD = 0.4`; mock result with similarity 0.40
+**Expected:**
+- Result included in output (inclusive)
+
+### TC-095: Similarity threshold — below 0.4
+**Input:** Mock result with similarity 0.39
+**Expected:**
+- Result excluded from output
+
+### TC-096: High confidence threshold — at 0.7 (default)
+**Input:** Memory with similarity 0.70
+**Expected:**
+- Full content returned (not summary)
+- Indicator: `🎯`
+
+### TC-097: High confidence threshold — just below 0.7
+**Input:** Memory with similarity 0.69
+**Expected:**
+- Summary returned (truncated)
+- Indicator: `📝`
+
+### TC-098: Token budget — exactly at limit
+**Preconditions:** `TOKEN_BUDGET = 1000`; mock results that sum to exactly 1000 tokens
+**Expected:**
+- All results included
+- No results dropped
+
+### TC-099: Token budget — first result alone exceeds budget
+**Preconditions:** One result with estimated tokens > 1000
+**Expected:**
+- High-confidence: shorter version tried → if fits, included
+- If still exceeds: skipped
+- Output may be empty (`memories: []`) — no crash
+
+### TC-100: Token budget — 95% threshold triggers early stop
+**Preconditions:** Results accumulate; 10th result would push total to 96% of budget
+**Expected:**
+- Loop stops after reaching 95% threshold (per `if tokens_used >= token_budget * 0.95: break`)
+- 10th result is NOT included
+
+### TC-101: CACHE_MAX_SIZE boundary — exactly 1000 entries
+**Preconditions:** senderCache has 1000 entries
+**Steps:** Add entry #1000
+**Expected:**
+- No eviction (size = max, not over max)
+- Entry #1000 stored
+
+### TC-102: CACHE_MAX_SIZE boundary — 1001st entry triggers eviction
+**Steps:** Add entry #1001 to a 1000-entry cache
+**Expected:**
+- `evictOldestIfFull()` fires
+- Oldest entry removed before new entry written
+- Post-insertion size = 1000 (not 1001)
+
+### TC-103: CACHE_STALE_MS boundary — exactly 30 minutes
+**Preconditions:** Entry timestamped exactly 30 minutes ago (1,800,000ms)
+**Expected:**
+- `now - timestamp = CACHE_STALE_MS` exactly
+- Entry treated as stale (eviction fires) OR not stale (off-by-one check)
+- Document behavior clearly: < or <=
+
+### TC-104: Domain cache TTL — 5 minutes (300,000ms)
+**Preconditions:** Domain data cached at T=0
+**At T+299s:** cache still valid (hit)
+**At T+301s:** cache expired (miss, DB re-queried)
+**Expected:**
+- Boundary honored within 1-second tolerance
+
+### TC-105: Recall content truncation — max_summary boundary
+**Preconditions:** Low-confidence result (< 0.7); content exactly at max_summary length
+**Expected:**
+- Content returned as-is (no truncation)
+- No `[summary]` suffix
+
+### TC-106: Recall content truncation — one char over max_summary
+**Preconditions:** Low-confidence result; content length = max_summary + 1
+**Expected:**
+- Content truncated at word boundary
+- `[summary]` suffix appended
+
+### TC-107: Dynamic content limits — single result vs 10 results
+**Preconditions:** 1 result → max_full limit applies; 10 results → min_full limit applies
+**Expected:**
+- Single result gets longer content truncation limit than result #10 in a 10-result set
+- Ratio consistent with `calculate_dynamic_limits()` implementation
+
+### TC-108: Spawn timeout — 5 seconds (SPAWN_TIMEOUT_MS)
+**Preconditions:** proactive-recall.py mocked to sleep 6 seconds
+**Expected:**
+- Process killed via SIGTERM at 5000ms
+- `reject(new Error("proactive-recall.py timed out..."))` thrown
+- Caller receives null (graceful)
+- No zombie process left running
+
+### TC-109: Entity resolution timeout — 2000ms
+**Preconditions:** `resolveEntityByIdentifiers` mocked to delay 2500ms
+**Expected:**
+- `Promise.race` timeout wins at 2000ms
+- Returns null entity (graceful degradation)
+- No wait for 2500ms resolution
+
+### TC-110: Entity facts timeout — 1000ms
+**Preconditions:** `getEntityProfile` mocked to delay 1500ms
+**Expected:**
+- `Promise.race` timeout wins at 1000ms
+- Returns empty facts `{}`
+- Entity name still displayed (partial entity context)
+
+---
+
+## Test Area 9: Error Conditions
+
+### TC-111: proactive-recall.py — non-zero exit code
+**Preconditions:** Mocked script exits with code 1
+**Expected:**
+- `spawnWithTimeout` rejects with error including exit code and stderr
+- Caller logs error and returns null
+- No crash in parent plugin
+
+### TC-112: proactive-recall.py — invalid JSON output
+**Preconditions:** Script exits 0 but stdout is not valid JSON
+**Expected:**
+- `JSON.parse` throws
+- Rejection: `"Failed to parse recall output: ..."`
+- Caller returns null
+
+### TC-113: proactive-recall.py — empty stdout on exit 0
+**Preconditions:** Script exits 0 with no stdout
+**Expected:**
+- `spawnWithTimeout` rejects OR resolves to empty (depending on implementation)
+- Either way: caller returns null
+- No crash
+
+### TC-114: proactive-recall.py — Python binary not found
+**Preconditions:** Both STANDARD_VENV and WORKSPACE_VENV paths don't exist
+**Expected:**
+- `child.on("error")` fires with ENOENT
+- Rejection caught
+- Caller returns null
+
+### TC-115: DB connection failure — PostgreSQL entirely down
+**Preconditions:** `psycopg2.connect()` raises exception
+**Expected:**
+- `recall()` returns `{"error": "<message>", "memories": []}`
+- proactive-recall.py exits 0 with that JSON output
+- `runSemanticRecall()` returns null (no memories)
+
+### TC-116: Ollama embedding failure — HTTP 500
+**Preconditions:** Ollama returns 500 on embedding request
+**Expected:**
+- `get_embedding()` raises `urllib.error.HTTPError`
+- `recall()` catches → returns error JSON
+- No crash in proactive-recall.py
+
+### TC-117: turn-reminders DB failure — pool connection error
+**Preconditions:** `pool.connect()` throws
+**Expected:**
+- `queryTurnContext()` throws
+- `getTurnReminders()` propagates error
+- Caught in `before_prompt_build` `Promise.allSettled`
+- `turnRemindersResult.status === "rejected"`
+- Other subsystems still run
+
+### TC-118: Entity resolver library not installed
+**Preconditions:** `~/.openclaw/lib/entity-resolver/index.ts` does not exist
+**Expected:**
+- `ensureEntityResolver()` returns false
+- `resolveEntityContext()` returns null
+- Logged as warn (not error)
+- Plugin continues functioning without entity context
+
+### TC-119: Classifier Ollama returns malformed JSON
+**Preconditions:** Ollama mock returns `"not json at all"` as classification
+**Expected:**
+- Classifier catches parse error
+- Falls back to default type
+- Error logged
+- No crash
+
+### TC-120: Domain identifier embedding returns wrong dimensions
+**Preconditions:** Embedding API returns vector of wrong length (e.g., 512 vs 1024)
+**Expected:**
+- `ValueError: Dimension mismatch` raised
+- Domain identifier catches error → returns NO DOMAIN IDENTIFIED
+- Error logged
+
+---
+
+## Test Area 10: Observability and Logging
+
+### TC-121: Classifier logs selected type and method (rule vs Ollama)
+**Expected log pattern:** `[turn-context] classifier type=info_request method=rule` or similar
+- `method` field present: values `"rule"` or `"ollama"`
+
+### TC-122: Domain identifier logs matched domain and similarity score
+**Expected log pattern:** `[turn-context] domain=github similarity=0.82 matchedBy=keyword`
+- When NO DOMAIN IDENTIFIED: `domain=none`
+
+### TC-123: Tiered recall logs tier used
+**Expected log pattern:** `[turn-context] recall tier=domain results=3` or `tier=full_fallback results=7` or `tier=skipped reason=continuation`
+
+### TC-124: before_prompt_build logs total duration and subsystem breakdown
+**Expected:** Existing log structure preserved and extended:
+```
+[turn-context] before_prompt_build DONE in Xms — injecting prepend=Nchars append=Mchars
+```
+New additions:
+```
+[turn-context] classifier=Xms domain=Xms recall=Xms entity=Xms
+```
+Or equivalent per-subsystem timing.
+
+### TC-125: Recall tier logged when recall skipped (continuation/command)
+**Expected:** Log line confirms skip reason:
+`[turn-context] recall=skipped reason=message_type:continuation`
+
+### TC-126: Visibility filter applied — logged in proactive-recall.py stderr
+**Expected:** When `is_group = true`:
+```
+[proactive-recall] applying visibility filter: is_group=true entity_id=42
+```
+When `is_group = false`: no filter log (or explicit "no filter applied")
+
+### TC-127: No double-logging on cache hits
+**Preconditions:** Second message hits all caches (sender, domain, entity, turn reminders)
+**Expected:**
+- Single log line per subsystem indicating cache hit
+- No duplicate "resolving..." log entries
+
+---
+
+## Test Area 11: Migration Validation
+
+### TC-128: Migration 080 — applies cleanly to fresh DB
+**Steps:**
+```bash
+psql -U gem -d nova_memory < migrations/080_prompt_helper_config.sql
+```
+**Expected:**
+- Applies without errors
+- `prompt_helper_config` table created
+- `agent_domains.keywords` column added
+- `agent_domains.notes` column updated for all 38 rows
+
+### TC-129: Migration 080 — idempotent (IF NOT EXISTS guards)
+**Steps:** Apply migration twice
+**Expected:**
+- Second application does not error
+- No duplicate rows in prompt_helper_config
+
+### TC-130: Migration 080 — rollback/down migration
+**Preconditions:** If down migration is provided
+**Expected:**
+- Down migration removes prompt_helper_config table
+- Removes keywords column from agent_domains
+- DB returns to pre-080 state
+
+### TC-131: agent_domains — keywords column is TEXT[] type
+**Steps:**
+```sql
+SELECT data_type, udt_name FROM information_schema.columns
+WHERE table_name = 'agent_domains' AND column_name = 'keywords';
+```
+**Expected:**
+- `data_type = 'ARRAY'`
+- `udt_name = '_text'`
+
+### TC-132: prompt_helper_config — PK constraint on id
+**Steps:**
+```sql
+INSERT INTO prompt_helper_config (id, message_type, helper_name, enabled)
+VALUES (1, 'action', 'semantic_recall', true);
+-- (if id=1 already exists)
+```
+**Expected:**
+- Duplicate PK error raised
+- Constraint enforced
+
+---
+
+## Test Coverage Summary
+
+| Area | TCs | Coverage Focus |
+|---|---|---|
+| 1. Message Type Classifier | TC-001 – TC-020, TC-020b | Rule-based + `>` continuation convention (21 TCs) |
+| 2. Domain Identifier | TC-021 – TC-040, TC-038b, TC-039b | Embedding + keywords + multi-match + format (22 TCs) |
+| 3. Prompt Helper Config | TC-041 – TC-050, TC-047b | Table schema + dispatch config + reminders always-on (12 TCs) |
+| 4. Tiered Recall | TC-051 – TC-064 | Gating + tier selection (14 TCs) |
+| 5. Visibility Filtering | TC-065 – TC-075 | Group vs DM, JOIN-based public/private filter (11 TCs) |
+| 6. Entity Resolver Cache Bugfix | TC-076 – TC-083 | sessionKey+senderId key fix (8 TCs) |
+| 7. Integration Scenarios | TC-084 – TC-093 | End-to-end flows (10 TCs) |
+| 8. Boundary Values | TC-094 – TC-110 | Thresholds, limits, timeouts (17 TCs) |
+| 9. Error Conditions | TC-111 – TC-120 | Failure modes + degradation (10 TCs) |
+| 10. Observability | TC-121 – TC-127 | Logging + structured output (7 TCs) |
+| 11. Migration Validation | TC-128 – TC-132 | Schema integrity (5 TCs) |
+| **TOTAL** | **137 test cases** | |
+
+---
+
+## Entry / Exit Criteria
+
+### Entry Criteria (before execution begins)
+- Migration `080_prompt_helper_config.sql` applied to staging DB
+- `classifier.ts` and `domain-identifier.ts` implemented and compiled
+- `agent_domains` seeded with 38 domains (keywords + notes + embeddings)
+- `proactive-recall.py` updated with `entity_id`/`is_group`/`domain_hints` support
+- `entity-resolver.ts` cache key fix merged
+- `semantic-recall.ts` tiered recall refactor implemented
+- Plugin builds without TypeScript errors (`npm run build` clean)
+- Staging environment available
+
+### Exit Criteria (before QA sign-off)
+- All TC-001 through TC-132 executed
+- Zero S1/S2 defects open
+- TC-010 (60-70% rule coverage) verified with representative sample
+- TC-076/TC-077 entity resolver cache bugfix confirmed via group channel scenario
+- TC-128 migration applies cleanly on staging
+- Observability logs (TC-121 to TC-127) parseable by log aggregation tools
+- No unhandled Promise rejections observed across any test scenario
+
+---
+
+## Risk Register
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Ollama latency causes classifier timeout | S2 | TC-014 verifies graceful fallback; tune timeout |
+| Domain embedding similarity tuning needed | S2 | TC-025/TC-026 establish threshold boundaries; adjust empirically |
+| Group channel cache bug regression | S1 | TC-076/TC-077 must pass; add to regression suite |
+| Visibility SQL NULL edge case | S2 | TC-072 covers NULL visibility; verify SQL behavior |
+| Migration not idempotent causes staging breakage | S2 | TC-129 validates idempotency |
+| Token budget not respected across domain+full tiers | S3 | TC-060 validates cross-tier budget tracking |

--- a/tests/test-cases-ghost-entity-prevention.md
+++ b/tests/test-cases-ghost-entity-prevention.md
@@ -1,0 +1,527 @@
+# Test Cases: Ghost Entity Prevention & Entity Dedup (Issues #230, #267)
+
+**Issues:** [#230 - Ghost entity filtering via structural heuristics + smarter resolver matching](https://github.com/NOVA-Openclaw/nova-memory/issues/230) | [#267 - Add alternate_spellings column to entities table](https://github.com/NOVA-Openclaw/nova-memory/issues/267)
+**Date:** 2026-06-02
+**Author:** Gem (QA Lead)
+
+---
+
+## Context
+
+The `extract_memories.py` pipeline suffers from four root causes producing ghost entities and duplicates:
+
+1. **Eager entity creation** — LLM-extracted names inserted into `entities` without checking if they already exist
+2. **Weak matching** — resolver uses exact-match only, missing alternate spellings, case variations, nicknames
+3. **Hardcoded `person` type** — `_store_fact()` defaults all unknown entities to `type='person'`
+4. **No structural heuristics** — no validation that an extracted "entity" is actually a real entity vs. a phrase fragment, technical identifier, or role label
+
+As of 2026-05-16, the database contains **48+ ghost entities** (e.g., `sender`, `recipient`, `nova_staging_memory`, `Unknown user: 330189773371080716`) with **130+ junk facts**.
+
+**Issue #267** adds an `alternate_spellings text[]` column to `entities` for entity-resolution hints (misspellings, transcription errors), distinct from `nicknames` (intentional alternate names).
+
+---
+
+## Test Environment
+
+- **Host:** `nova-staging@localhost`
+- **Database:** `nova_memory` (staging instance)
+- **Script under test:** `memory/scripts/extract_memories.py`
+- **DB helper under test:** `memory/scripts/dedup_helper.py`
+- **Relevant functions:** `find_entity_id()`, `ensure_entity()`, `normalize_entity_type()`, `_resolve_by_sender_id()`, `resolve_source_entity_id()`
+
+---
+
+## Section 1: Ghost Entity Prevention — Structural Heuristics
+
+Tests that the blocklist/heuristic filter rejects strings that are role labels, technical identifiers, or structural artifacts rather than real entities.
+
+### 1.1 Generic Role Word Blocklist
+
+| TC | Category | Input Name | Expected: Entity Created? | Expected: Facts Stored? |
+|:---|:---|:---|:---|:---|
+| **TC-1.1.1** | Ghost Blocklist | `sender` | NO | NO — skipped before DB write |
+| **TC-1.1.2** | Ghost Blocklist | `recipient` | NO | NO |
+| **TC-1.1.3** | Ghost Blocklist | `system` | NO | NO |
+| **TC-1.1.4** | Ghost Blocklist | `user` | NO | NO |
+| **TC-1.1.5** | Ghost Blocklist | `the recipient` | NO | NO |
+| **TC-1.1.6** | Ghost Blocklist | `the sender` | NO | NO |
+| **TC-1.1.7** | Ghost Blocklist | `group` | NO | NO |
+| **TC-1.1.8** | Ghost Blocklist | `Sender (I)ruid)` | NO | NO — parenthetical compound |
+
+**Verification:** After extraction, run:
+```sql
+SELECT id, name FROM entities
+WHERE LOWER(name) = ANY(ARRAY['sender', 'recipient', 'system', 'user',
+  'the recipient', 'the sender', 'group']);
+```
+Expected: 0 rows returned.
+
+### 1.2 Technical / Database Identifier Patterns
+
+| TC | Category | Input Name | Rejection Reason | Expected: Entity Created? |
+|:---|:---|:---|:---|:---|
+| **TC-1.2.1** | Ghost Blocklist | `nova_staging_memory` | snake_case DB identifier | NO |
+| **TC-1.2.2** | Ghost Blocklist | `agent_bootstrap_context` | snake_case technical identifier | NO |
+| **TC-1.2.3** | Ghost Blocklist | `agent_domains table` | Contains word "table" | NO |
+| **TC-1.2.4** | Ghost Blocklist | `agent_chat table` | Contains word "table" | NO |
+| **TC-1.2.5** | Ghost Blocklist | `nova-staging DB role` | Contains "DB role" | NO |
+| **TC-1.2.6** | Ghost Blocklist | `staging ownership` | Contains "staging" + "ownership" | NO |
+| **TC-1.2.7** | Ghost Blocklist | `workflows table ownership` | Contains "table" | NO |
+| **TC-1.2.8** | Ghost Blocklist | `database_system` | snake_case with "system" | NO |
+| **TC-1.2.9** | Ghost Blocklist | `tasks table` | Contains "table" | NO |
+| **TC-1.2.10** | Ghost Blocklist | `portfolio_extra_tables` | snake_case with "tables" | NO |
+
+### 1.3 Platform Metadata Artifacts (Discord / Platform IDs)
+
+| TC | Category | Input Name | Rejection Reason | Expected: Entity Created? |
+|:---|:---|:---|:---|:---|
+| **TC-1.3.1** | Ghost Blocklist | `Unknown user: 330189773371080716` | Matches `Unknown user: <id>` pattern | NO |
+| **TC-1.3.2** | Ghost Blocklist | `Unknown user: graybeard` | Matches `Unknown user: *` pattern | NO |
+| **TC-1.3.3** | Ghost Blocklist | `Unknown user: 1492403330922844250` | Matches `Unknown user: *` pattern | NO |
+| **TC-1.3.4** | Ghost Blocklist | `Unknown user: 660345224089960478` | Matches `Unknown user: *` pattern | NO |
+
+**Note:** These appear when Discord mentions reference users not in the guild member cache. The pipeline receives the raw Discord embed text and must not treat this as a person name.
+
+### 1.4 Compound Description Strings with Special Characters
+
+| TC | Category | Input Name | Rejection Reason | Expected: Entity Created? |
+|:---|:---|:---|:---|:---|
+| **TC-1.4.1** | Ghost Blocklist | `Google Drive — Edmund's Edification` | Contains em dash `—` (structural compound) | NO |
+| **TC-1.4.2** | Ghost Blocklist | `NOVA Multiuser System (project #28)` | Parenthetical project reference | NO |
+| **TC-1.4.3** | Ghost Blocklist | `Cognition System (id=9)` | Parenthetical `(id=N)` pattern | NO |
+| **TC-1.4.4** | Ghost Blocklist | `Full System (id=10)` | Parenthetical `(id=N)` pattern | NO |
+| **TC-1.4.5** | Ghost Blocklist | `the group (including sender)` | Generic phrase with parenthetical | NO |
+| **TC-1.4.6** | Ghost Blocklist | `sender's team` | Possessive of blocklisted word | NO |
+
+### 1.5 Parenthetical ID / Reference Patterns
+
+| TC | Category | Input Name | Regex Pattern Matched | Expected: Entity Created? |
+|:---|:---|:---|:---|:---|
+| **TC-1.5.1** | Ghost Blocklist | `Widget X (id=42)` | `\(id=\d+\)` | NO |
+| **TC-1.5.2** | Ghost Blocklist | `Project Alpha (project #7)` | `\(project #\d+\)` | NO |
+| **TC-1.5.3** | Ghost Blocklist | `System (id=9)` | `\(id=\d+\)` | NO |
+
+### 1.6 Valid Entities Must NOT Be Rejected
+
+The blocklist/heuristics must have zero false positives on real person/org names.
+
+| TC | Category | Input Name | Entity Type | Expected: Entity Created? |
+|:---|:---|:---|:---|:---|
+| **TC-1.6.1** | Regression (no false positive) | `Alice Johnson` | person | YES — two-word real name |
+| **TC-1.6.2** | Regression (no false positive) | `OpenAI` | organization | YES |
+| **TC-1.6.3** | Regression (no false positive) | `Edmund` | person | YES — single-word real name |
+| **TC-1.6.4** | Regression (no false positive) | `I)ruid` | person | YES — known user handle with special chars |
+| **TC-1.6.5** | Regression (no false positive) | `O'Brien` | person | YES — apostrophe in surname |
+| **TC-1.6.6** | Regression (no false positive) | `Smith-Jones` | person | YES — hyphenated surname |
+| **TC-1.6.7** | Regression (no false positive) | `Rayven` | person | YES — existing entity |
+
+---
+
+## Section 2: Entity Deduplication and Matching Improvements
+
+Tests that the improved entity resolver prevents creating duplicates via case-insensitive matching, alternate spelling lookups, and nickname resolution.
+
+### 2.1 Case-Insensitive Name Matching
+
+**Setup:** Entity `Dustin Trammell` (id=2, type=person) and entity `NOVA` (id=1, type=ai) exist in DB.
+
+| TC | Input Name | Expected: New Entity? | Expected: Resolved to |
+|:---|:---|:---|:---|
+| **TC-2.1.1** | `dustin trammell` | NO | Entity id=2 (Dustin Trammell) |
+| **TC-2.1.2** | `DUSTIN TRAMMELL` | NO | Entity id=2 |
+| **TC-2.1.3** | `Dustin Trammell` | NO | Entity id=2 |
+| **TC-2.1.4** | `nova` (lowercase) | NO | Entity id=1 (NOVA) |
+| **TC-2.1.5** | `Nova` (title case) | NO | Entity id=1 (NOVA) |
+
+**Verification:**
+```sql
+SELECT COUNT(*) FROM entities WHERE LOWER(name) = 'dustin trammell';
+-- Expected: 1 (no duplicate)
+```
+
+### 2.2 Alternate Spellings Resolution (Issue #267)
+
+**Setup:** Entity `Rayven` (id=6, type=person) has `alternate_spellings = ARRAY['Raven', 'raven', 'ravens', 'Ravens']`.
+
+| TC | Input Name | Expected: New Entity? | Expected: Resolved to |
+|:---|:---|:---|:---|
+| **TC-2.2.1** | `Raven` | NO | Entity id=6 (Rayven) |
+| **TC-2.2.2** | `raven` (lowercase) | NO | Entity id=6 (Rayven) |
+| **TC-2.2.3** | `Ravens` | NO | Entity id=6 (Rayven) |
+| **TC-2.2.4** | `RAVEN` (uppercase) | NO | Entity id=6 (Rayven) |
+
+**Verification:**
+```sql
+SELECT id, name FROM entities WHERE LOWER(name) = 'raven';
+-- Expected: 0 rows (no ghost entity created)
+
+SELECT id FROM entities WHERE 6 = id AND 'raven' = ANY(SELECT LOWER(unnest(alternate_spellings)));
+-- Expected: 1 row (Rayven entity has it)
+```
+
+### 2.3 Nickname Array Resolution
+
+**Setup:** Entity `NOVA` (id=1) has `nicknames = ARRAY['@NOVA', 'NOVA ✨', 'nova', 'Nova']`.
+
+| TC | Input Name | Expected: New Entity? | Expected: Resolved to |
+|:---|:---|:---|:---|
+| **TC-2.3.1** | `@NOVA` | NO | Entity id=1 (NOVA) |
+| **TC-2.3.2** | `NOVA ✨` | NO | Entity id=1 (NOVA) |
+
+**Note:** The `find_entity_id()` query already checks `nicknames` via `unnest`. Verify this path is exercised and not bypassed by early return.
+
+### 2.4 Preventing ON CONFLICT Silent Failures
+
+The current `ensure_entity()` uses `ON CONFLICT DO NOTHING`. Verify the correct entity ID is still returned on conflict.
+
+| TC | Category | Description | Expected |
+|:---|:---|:---|:---|
+| **TC-2.4.1** | Dedup | Insert entity with name=`Alice`, type=`person` when entity already exists. | `ON CONFLICT DO NOTHING` fires. `find_entity_id("Alice", ...)` returns existing ID. No duplicate row. |
+| **TC-2.4.2** | Dedup | Insert entity with same name but different case: `ALICE` when `Alice` exists. | Case-insensitive lookup returns existing entity. New row NOT inserted. |
+| **TC-2.4.3** | Dedup | Same `(name, type)` combo sent twice in rapid succession (race condition). | DB unique constraint `entities_name_type_key` prevents duplicate. Application receives correct entity ID both times. |
+
+### 2.5 Full-Name / Partial-Name Resolution
+
+**Setup:** Entity `Dustin Trammell` (full_name=`Dustin D. Trammell`) exists.
+
+| TC | Input Name | Expected: New Entity? | Expected: Resolved to |
+|:---|:---|:---|:---|
+| **TC-2.5.1** | `Dustin` (first name only) | Decision required — see note | If resolver extends to first-name-only, resolves to Dustin Trammell |
+| **TC-2.5.2** | `Trammell` (last name only) | Decision required — see note | Ambiguous — should NOT resolve without additional context |
+
+> **QA Note:** Partial-name matching is a scope decision for implementation. TC-2.5.1 and TC-2.5.2 are **discussion items** — the fix should document the intended behavior. If partial matching is out of scope, these become negative tests (no resolution attempted, name treated as new entity or skipped by ghost filter).
+
+---
+
+## Section 3: alternate_spellings Column — Schema and Behavior
+
+Tests for the new `alternate_spellings text[]` column added to `entities` per Issue #267.
+
+### 3.1 Schema Migration
+
+| TC | Category | Description | Expected |
+|:---|:---|:---|:---|
+| **TC-3.1.1** | Schema | After migration, `entities` table has column `alternate_spellings`. | `\d entities` shows `alternate_spellings text[]`. Column is nullable (no NOT NULL constraint). |
+| **TC-3.1.2** | Schema | Column accepts array values. | `UPDATE entities SET alternate_spellings = ARRAY['Raven', 'raven'] WHERE id = 6;` succeeds. |
+| **TC-3.1.3** | Schema | Column defaults to NULL on new entity insert (no value specified). | `INSERT INTO entities (name, type) VALUES ('TestEntity', 'person'); SELECT alternate_spellings FROM entities WHERE name = 'TestEntity';` → NULL. |
+| **TC-3.1.4** | Schema | Column allows empty array. | `UPDATE entities SET alternate_spellings = '{}' WHERE id = 6;` succeeds without error. |
+| **TC-3.1.5** | Schema | Idempotent migration — running migration twice does not error. | Second run of migration: column already exists → `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` succeeds silently. |
+
+### 3.2 Entity Resolution via alternate_spellings
+
+**Setup:** Entity `Rayven` (id=6) with `alternate_spellings = ARRAY['Raven', 'Ravens', 'raven']`.
+
+| TC | Test Name | Description | Expected |
+|:---|:---|:---|:---|
+| **TC-3.2.1** | `find_entity_id_via_alternate_spellings` | Call `find_entity_id("Raven", conn)`. | Returns entity id=6. |
+| **TC-3.2.2** | `find_entity_id_case_insensitive_spelling` | Call `find_entity_id("RAVEN", conn)`. | Returns entity id=6 (case-insensitive match in array). |
+| **TC-3.2.3** | `find_entity_id_no_match` | Call `find_entity_id("Raving", conn)` (not in alternate_spellings). | Returns `None`. New entity may be created (subject to ghost filter). |
+| **TC-3.2.4** | `alternate_spellings_checked_before_create` | Pipeline receives entity name `Raven` in LLM output. | `find_entity_id("Raven", ...)` returns Rayven's id. `ensure_entity("Raven", ...)` NOT called. No new entity row. |
+
+**SQL for resolver lookup (expected implementation):**
+```sql
+SELECT id FROM entities
+WHERE LOWER(name) = LOWER(%s)
+   OR LOWER(full_name) = LOWER(%s)
+   OR LOWER(%s) = ANY(SELECT LOWER(unnest(nicknames)))
+   OR LOWER(%s) = ANY(SELECT LOWER(unnest(alternate_spellings)))
+LIMIT 1
+```
+
+### 3.3 Separation from nicknames Column
+
+| TC | Category | Description | Expected |
+|:---|:---|:---|:---|
+| **TC-3.3.1** | Semantic separation | Nickname `Dustin` for entity `I)ruid` is in `nicknames`. It should NOT be migrated to `alternate_spellings`. | After migration: `nicknames` still contains `Dustin`. `alternate_spellings` is NULL or empty for this entity. |
+| **TC-3.3.2** | Semantic separation | Misspelling `Raven` for entity `Rayven` should be in `alternate_spellings`, NOT in `nicknames`. | After migration: `alternate_spellings` contains `Raven`. If `Raven` was in `nicknames`, it is removed from there. |
+| **TC-3.3.3** | Independence | A name in `nicknames` that is NOT a misspelling remains in `nicknames` only. | Query: nicknames and alternate_spellings are independent arrays with no unintended overlap for legitimate entities. |
+
+### 3.4 Existing Ghost Entity Cleanup
+
+| TC | Category | Description | Expected |
+|:---|:---|:---|:---|
+| **TC-3.4.1** | Cleanup migration | After cleanup migration runs, query for known ghost entities returns 0 rows. | `SELECT id FROM entities WHERE name IN ('sender', 'recipient', 'nova_staging_memory', 'agent_bootstrap_context') AND type = 'person';` → 0 rows. |
+| **TC-3.4.2** | Cleanup migration | Ghost entity facts are deleted before ghost entity record deletion. | No FK violation during cleanup. `entity_facts` for ghost entity ids are deleted first (or cascade). |
+| **TC-3.4.3** | Cleanup migration | Real entities sharing name prefix with ghost patterns are NOT deleted. | Entity named `System Administrator` (if it exists) is preserved. Cleanup filter is pattern-specific, not prefix-based. |
+
+---
+
+## Section 4: Entity Type Inference
+
+Tests that entity type is inferred correctly from context rather than always defaulting to `person`.
+
+### 4.1 normalize_entity_type() Function
+
+Unit tests for the `normalize_entity_type()` function in `extract_memories.py`.
+
+| TC | Input | Expected Output |
+|:---|:---|:---|
+| **TC-4.1.1** | `"person"` | `"person"` |
+| **TC-4.1.2** | `"PERSON"` | `"person"` (lowercased) |
+| **TC-4.1.3** | `"ai"` | `"ai"` |
+| **TC-4.1.4** | `"organization"` | `"organization"` |
+| **TC-4.1.5** | `"place"` | `"other"` (mapped — not in valid set) |
+| **TC-4.1.6** | `"restaurant"` | `"other"` |
+| **TC-4.1.7** | `"cafe"` | `"other"` |
+| **TC-4.1.8** | `"venue"` | `"other"` |
+| **TC-4.1.9** | `"unknown_type_xyz"` | `"other"` (fallback) |
+| **TC-4.1.10** | `""` (empty string) | `"other"` (fallback) |
+| **TC-4.1.11** | `"  person  "` (whitespace-padded) | `"person"` (stripped before compare) |
+
+### 4.2 Non-Hardcoded Person Default in _store_fact()
+
+The `_store_fact()` inner function currently calls `ensure_entity(subject_name, "person", ...)` unconditionally. After the fix, it should use the type inferred from the LLM's `entities` array (if available) or a smarter default.
+
+| TC | Category | Description | Expected |
+|:---|:---|:---|:---|
+| **TC-4.2.1** | Type Inference | LLM returns entity `{"name": "OpenAI", "type": "organization"}` in `entities` array. Pipeline stores it. | `SELECT type FROM entities WHERE name = 'OpenAI';` → `organization`, not `person`. |
+| **TC-4.2.2** | Type Inference | LLM returns fact with `subject: "Claude"` and entities array contains `{"name": "Claude", "type": "ai"}`. | Entity `Claude` inserted with `type='ai'`. |
+| **TC-4.2.3** | Type Inference | Fact subject name matches an entity in the `entities` array extracted from same message. | `_store_fact()` uses the type from the `entities` array when calling `ensure_entity()`, not hardcoded `person`. |
+| **TC-4.2.4** | Type Inference | LLM fact references `subject: "Discord"` (no entities array entry). | Entity `Discord` gets `type='other'` or `type='organization'` — NOT `person`. Fallback type should be configurable or context-aware. |
+| **TC-4.2.5** | Regression | Person entity with no type hint in LLM output still defaults to `person`. | `ensure_entity("Bob Smith", "person", ...)` — type defaults to `person` when no type in entities array. |
+
+### 4.3 LLM Prompt Type Awareness
+
+Verify the extraction prompt explicitly enumerates valid entity types.
+
+| TC | Category | Description | Expected |
+|:---|:---|:---|:---|
+| **TC-4.3.1** | Prompt correctness | `build_extraction_prompt()` output contains valid type list. | Prompt text includes `"person|ai|organization"` in entities template. Does NOT show `"place"` as a standalone type (only as mapped). |
+| **TC-4.3.2** | Prompt correctness | Valid entity types in prompt match DB constraint `entities_type_check`. | Prompt allows exactly: `person`, `ai`, `organization`, `pet`, `stuffed_animal`, `character`, `other`. |
+
+---
+
+## Section 5: Edge Cases
+
+### 5.1 Unicode and International Names
+
+| TC | Input Name | Type | Expected |
+|:---|:---|:---|:---|
+| **TC-5.1.1** | `François` | person | Entity created, name stored as-is with UTF-8 encoding |
+| **TC-5.1.2** | `Müller` | person | Entity created with umlaut preserved |
+| **TC-5.1.3** | `李小明` | person | Entity created, CJK characters stored correctly |
+| **TC-5.1.4** | `Αλέξανδρος` | person | Entity created, Greek characters stored correctly |
+| **TC-5.1.5** | `José María` | person | Entity created, two accented words |
+
+**Verification:** `SELECT name FROM entities WHERE name = 'François';` → 1 row with correct UTF-8 value.
+
+**Ghost filter note:** Unicode names must not be caught by heuristics targeting ASCII-only technical patterns. A regex matching `[a-z_]+` for snake_case should not block valid Unicode names.
+
+### 5.2 Single-Word Entities
+
+Single-word submissions require careful handling: valid names (Edmund, Bob) should pass; generic nouns (lunch, meeting) should not.
+
+| TC | Input Name | Context | Expected |
+|:---|:---|:---|:---|
+| **TC-5.2.1** | `Edmund` | Person reference in conversation | Entity created (known valid name) |
+| **TC-5.2.2** | `lunch` | "I'm going to lunch" | NOT an entity — generic noun, rejected |
+| **TC-5.2.3** | `meeting` | "The meeting is at 3pm" | NOT an entity — generic noun, rejected |
+| **TC-5.2.4** | `Alice` | New person introduced in message | Entity created (single-word person name) |
+
+> **QA Note:** Single-word generic noun rejection requires either a stopword list or context-aware LLM instruction. The implementation must define how the ghost filter distinguishes `Edmund` from `meeting`. If the LLM is instructed not to extract generic nouns as entities, verify the prompt reflects this. If a stopword list is used, document it in the implementation.
+
+### 5.3 Entity Names with Punctuation
+
+| TC | Input Name | Expected |
+|:---|:---|:---|
+| **TC-5.3.1** | `I)ruid` | Entity created — this is a real user handle (existing entity id=7549) |
+| **TC-5.3.2** | `O'Brien` | Entity created — apostrophe is valid in surnames |
+| **TC-5.3.3** | `Smith-Jones` | Entity created — hyphen is valid in compound surnames |
+| **TC-5.3.4** | `user@example.com` | NOT an entity — looks like an email address; should be rejected as entity name (but may be stored as a fact with key=`email`) |
+| **TC-5.3.5** | `https://example.com` | NOT an entity — URL, not a name |
+| **TC-5.3.6** | `@druid` | NOT an entity — platform handle, should be stored as fact not entity if relevant |
+
+### 5.4 Very Long Names (Boundary Value Analysis on varchar(255))
+
+| TC | Input Length | Input Name | Expected |
+|:---|:---|:---|:---|
+| **TC-5.4.1** | 254 chars | `A` × 254 | Entity created (within limit) |
+| **TC-5.4.2** | 255 chars | `A` × 255 | Entity created (at limit, max valid) |
+| **TC-5.4.3** | 256 chars | `A` × 256 | Error handled gracefully — truncated to 255 OR rejected with warning, NOT an unhandled DB exception crashing the pipeline |
+| **TC-5.4.4** | 300 chars | `A` × 300 | Same as TC-5.4.3 — no unhandled exception |
+
+**Verification for TC-5.4.3/4.4:** `extract_memories.py` exits with code 0 (partial data) or writes a WARNING to stderr. It must NOT exit with code 1 due to an unhandled psycopg2 DataError.
+
+### 5.5 Empty, Null, and Sentinel Values
+
+These are already partially handled (`ensure_entity()` checks for `"null"` and `"unknown"`), but must be verified completely:
+
+| TC | Input Name | Expected |
+|:---|:---|:---|
+| **TC-5.5.1** | `""` (empty string) | Skipped — no entity created, no error |
+| **TC-5.5.2** | `"   "` (whitespace only) | Stripped to empty, skipped |
+| **TC-5.5.3** | `"null"` (string) | Skipped — sentinel handled in `ensure_entity()` |
+| **TC-5.5.4** | `"unknown"` (string) | Skipped — sentinel handled |
+| **TC-5.5.5** | `None` (Python None) | Skipped — None check in `find_entity_id()` |
+| **TC-5.5.6** | `"N/A"` | Should be treated as noise — no entity created |
+
+### 5.6 Numeric-Only and Snowflake-Looking Names
+
+| TC | Input Name | Expected |
+|:---|:---|:---|
+| **TC-5.6.1** | `"12345"` | NOT an entity — numeric-only string, rejected by ghost filter |
+| **TC-5.6.2** | `"330189773371080716"` | NOT an entity — Discord snowflake numeric string |
+| **TC-5.6.3** | `"2025"` | NOT an entity — year number |
+| **TC-5.6.4** | `"42"` | NOT an entity — short numeric string |
+
+**Ghost filter rule:** Strings consisting solely of digits (after stripping whitespace) must not produce entity rows.
+
+---
+
+## Section 6: Integration Tests
+
+End-to-end tests exercising the full pipeline from message input through DB state.
+
+### 6.1 Ghost Entity NOT Created End-to-End
+
+**Setup:** Staging DB with no entity named `sender` or `recipient`.
+**Method:** Set env vars (`SENDER_NAME=TestUser`, `SENDER_ID=+15125550199`, `SENDER_PROVIDER=signal`), pipe a message through `extract_memories.py`.
+
+| TC | Input Message | Expected DB State | Expected Exit Code |
+|:---|:---|:---|:---|
+| **TC-6.1.1** | `"The sender wants to know what the recipient thinks."` | No entity `sender` or `recipient` created. | 0 |
+| **TC-6.1.2** | `"System is down. The agent_bootstrap_context table needs attention."` | No entities `system`, `agent_bootstrap_context`, `table` created. | 0 |
+| **TC-6.1.3** | `"Unknown user: 660345224089960478 mentioned this."` | No entity matching `Unknown user:` pattern created. | 0 |
+
+**Verification:**
+```bash
+# After each test case, confirm no ghost entity:
+psql -U gem -d nova_memory -c "
+  SELECT name FROM entities
+  WHERE name IN ('sender', 'recipient', 'system', 'agent_bootstrap_context')
+    AND created_at > NOW() - INTERVAL '1 minute';"
+# Expected: 0 rows
+```
+
+### 6.2 Entity Dedup via alternate_spellings End-to-End
+
+**Setup:** Entity `Rayven` (id=6) with `alternate_spellings = ARRAY['Raven', 'raven']`. Staging DB has no entity named `Raven`.
+
+| TC | Input Message | Expected DB State |
+|:---|:---|:---|
+| **TC-6.2.1** | `"Raven went to the store today."` | No new entity `Raven` created. Fact `{subject: Rayven, key: activity, value: went to the store}` stored with entity_id=6. |
+| **TC-6.2.2** | `"I talked to raven about the project."` | Same — resolves to Rayven (id=6). |
+
+**Verification:**
+```bash
+psql -U gem -d nova_memory -c "SELECT COUNT(*) FROM entities WHERE name = 'Raven';"
+# Expected: 0
+
+psql -U gem -d nova_memory -c "
+  SELECT ef.key, ef.value FROM entity_facts ef
+  WHERE ef.entity_id = 6
+  ORDER BY ef.learned_at DESC LIMIT 3;"
+# Expected: fact for Rayven from the test message
+```
+
+### 6.3 Case-Insensitive Entity Matching End-to-End
+
+**Setup:** Entity `Alice Johnson` (type=person) exists in DB.
+
+| TC | Input Message | Expected |
+|:---|:---|:---|
+| **TC-6.3.1** | `"alice johnson is coming to the party."` | `find_entity_id("alice johnson")` returns Alice's id. No duplicate created. |
+| **TC-6.3.2** | `"ALICE JOHNSON mentioned she likes tea."` | Same entity resolved. Fact `preference_tea` stored on Alice's existing entity. |
+
+### 6.4 Vocabulary Table Interaction
+
+Vocabulary entries must NOT generate entity rows.
+
+| TC | Category | Description | Expected |
+|:---|:---|:---|:---|
+| **TC-6.4.1** | Isolation | LLM output contains `vocabulary: [{"word": "NOVA", "category": "name"}]`. | `vocabulary` table updated/created for `NOVA`. No duplicate in `entities` table. Entity `NOVA` (if pre-existing) NOT re-created. |
+| **TC-6.4.2** | Isolation | Vocabulary word `trigeminal` (technical term, not a person). | Stored in `vocabulary` only. No entity row created. |
+
+### 6.5 Source Attribution Integrity
+
+| TC | Category | Description | Expected |
+|:---|:---|:---|:---|
+| **TC-6.5.1** | Source Attribution | Message from sender `I)ruid` (entity_id=2) about `Rayven`. | Fact stored: `entity_id=Rayven's id`, `entity_fact_sources.source_entity_id=2`. Source ≠ Subject. |
+| **TC-6.5.2** | Source Attribution | Self-reported fact: sender says "I prefer dark mode." | Fact stored: `entity_id=sender's entity_id`, source entity also = sender. Source = Subject. |
+| **TC-6.5.3** | Source Attribution | Ghost entity trigger: message body references `recipient` in facts. | No `entity_fact_sources` row with `entity_id` pointing to a ghost entity. Ghost entities produce no facts at all. |
+
+### 6.6 Multiple Entity References in Single Message
+
+**Setup:** Entities `Alice` and `Bob` both exist.
+
+| TC | Description | Expected |
+|:---|:---|:---|
+| **TC-6.6.1** | Message mentions same entity twice: `"Alice said she loves coffee, and Alice also likes hiking."` | One entity `Alice`. Two facts (`coffee_preference`, `hiking_preference`). No duplicate entity. |
+| **TC-6.6.2** | Message mentions two different entities: `"Alice and Bob are working on the project."` | Both entities resolved to existing records. Two separate fact attributions. No ghost entities. |
+
+### 6.7 Exit Code and Error Handling
+
+| TC | Scenario | Expected Exit Code | Expected Stderr |
+|:---|:---|:---|:---|
+| **TC-6.7.1** | Valid message, all operations succeed | 0 | `Extraction complete` |
+| **TC-6.7.2** | Message shorter than `MIN_MESSAGE_LENGTH` (10 chars) | 0 | `Skipping short or empty message` |
+| **TC-6.7.3** | `OPENROUTER_API_KEY` not set | 1 | `ERROR: OPENROUTER_API_KEY not set` |
+| **TC-6.7.4** | DB connection fails | 1 | `ERROR: DB connection failed` |
+| **TC-6.7.5** | LLM returns invalid JSON | 1 | `Failed to parse LLM response as JSON` |
+| **TC-6.7.6** | Ghost entity filtered — no other extractable data in message | 0 | WARNING logged, pipeline completes successfully |
+| **TC-6.7.7** | Very long entity name (256 chars) in LLM output | 0 | WARNING for entity skip, pipeline continues for other facts |
+
+---
+
+## Defect Cross-Reference: Known Ghost Entities in Production
+
+The following real ghost entities from production (as of 2026-05-16) serve as regression anchors. Each must NOT be re-created after the fix is applied:
+
+| Ghost Entity Name | entity_id | Fact Count | Rejection Reason |
+|:---|:---|:---|:---|
+| `sender` | 1782 | 18 | Generic role word |
+| `recipient` | 2213 | 16 | Generic role word |
+| `system` | 1465 | 15 | Generic role word |
+| `Unknown user: 330189773371080716` | 1672 | 9 | Platform metadata pattern |
+| `nova_staging_memory` | 1266 | 9 | snake_case DB identifier |
+| `agent_bootstrap_context` | 874 | 8 | snake_case technical identifier |
+| `the recipient` | 2596 | 7 | Generic role word (with article) |
+| `Google Drive — Edmund's Edification` | 1511 | 5 | Compound description with em dash |
+| `Unknown user: graybeard` | 2887 | 4 | Platform metadata pattern |
+| `tasks table` | 2300 | ~3 | Contains "table" |
+| `database_system` | 6102 | ~3 | snake_case + "system" |
+| `nova-staging database` | 2719 | ~3 | Technical environment reference |
+| `workflows table ownership` | 1407 | ~2 | Contains "table" |
+
+**Regression query (run after fix deployment):**
+```sql
+SELECT e.id, e.name, COUNT(ef.id) as new_facts
+FROM entities e
+LEFT JOIN entity_facts ef ON ef.entity_id = e.id AND ef.learned_at > NOW() - INTERVAL '7 days'
+WHERE e.id IN (1782, 2213, 1465, 1672, 1266, 874, 2596, 1511, 2887, 2300, 6102, 2719, 1407)
+GROUP BY e.id, e.name
+ORDER BY new_facts DESC;
+-- Expected: All new_facts = 0 (no new facts attributed to ghost entities after fix)
+```
+
+---
+
+## Quality Gates
+
+The implementation must meet these gates before QA sign-off:
+
+- [ ] All **TC-1.x** blocklist cases: 0 new ghost entities created for any test input
+- [ ] All **TC-2.x** dedup cases: 0 duplicate entities from case-insensitive inputs
+- [ ] All **TC-2.2.x** alternate_spellings cases: Raven → Rayven resolution works
+- [ ] All **TC-3.1.x** schema cases: `alternate_spellings text[]` column exists post-migration
+- [ ] All **TC-4.1.x** normalize_entity_type cases: correct type mapping
+- [ ] **TC-4.2.x**: No entity with valid type hint receives hardcoded `person` type
+- [ ] All **TC-5.5.x** null/empty cases: no crash, clean skip with 0 entities created
+- [ ] **TC-5.4.3/5.4.4**: No unhandled exception from oversized names
+- [ ] All **TC-6.1.x** integration cases: known ghost trigger messages produce 0 ghost entities
+- [ ] **TC-1.6.x** false positive regression: all valid entities still created correctly
+- [ ] Defect cross-reference query: 0 new facts added to any known ghost entity after fix
+
+---
+
+## Test Case Count Summary
+
+| Section | Area | Count |
+|:---|:---|:---|
+| 1.1–1.6 | Ghost Entity Prevention (Structural Heuristics) | 29 |
+| 2.1–2.5 | Dedup / Matching Improvements | 16 |
+| 3.1–3.4 | alternate_spellings Schema & Behavior | 13 |
+| 4.1–4.3 | Entity Type Inference | 18 |
+| 5.1–5.6 | Edge Cases | 23 |
+| 6.1–6.7 | Integration Tests | 20 |
+| **Total** | | **119** |


### PR DESCRIPTION
## Summary

Adds classifier-first dispatch to the turn-context plugin:

- **Message Type Classifier** — rule-based + Ollama LLM fallback for classifying messages into info_request/action/conversation/continuation/command
- **Domain Identifier** — embedding similarity + keyword matching against agent_domains table, returns top 1-3 domains with assigned agents
- **Prompt Helper Config** — new table gating which subsystems fire per message type, configurable per agent
- **Tiered Recall** — domain-scoped search first, full vector search fallback
- **Visibility Filtering** — group channels filter entity_facts to public only via JOIN
- **Entity Resolver Bugfix** — cache key changed to sessionKey:senderId for group channel support

### Migration Note
Migration 081 must be run split: agent_domains changes as newhart (table owner), prompt_helper_config as nova. After migration, run seed-domain-embeddings.py.

### Issues
Closes #150, closes #140, closes #168

### Test Cases
137 test cases in tests/TEST-CASES-ISSUE-150-140-168.md

### SE Run #60