### PR TITLE
fix(pg-env): return PgConnectionConfig object, stop setting process.env (#330)

### DIFF
--- a/cognition/focus/agent_chat/lib/pg-env.ts
+++ b/cognition/focus/agent_chat/lib/pg-env.ts
@@ -2,7 +2,7 @@
  * pg-env.ts — Centralized PostgreSQL config loader for TypeScript/Node.js.
  *
  * Resolution order: ENV vars → ~/.openclaw/postgres.json → defaults
- * Issue: nova-memory #94
+ * Issue: nova-memory #94, nova-mind #330
  */
 
 import { readFileSync } from "fs";
@@ -32,16 +32,30 @@ const DEFAULTS: Record<string, string | (() => string)> = {
 };
 
 /**
- * Load PostgreSQL env vars with resolution: ENV → config file → defaults.
+ * PostgreSQL connection options interface that matches
+ * the pg.Client constructor options.
+ */
+export interface PgConnectionConfig {
+  host?: string;
+  port?: number;
+  database?: string;
+  user?: string;
+  password?: string;
+}
+
+/**
+ * Load PostgreSQL config with resolution: ENV → config file → defaults.
  *
- * Sets process.env for each PG* var and returns the resulting record.
+ * Returns connection config object suitable for pg.Client / pg.Pool constructor,
+ * without modifying process.env to avoid pollution of the environment
+ * for child processes and subagents.
  * Empty ENV strings are treated as unset.
  * Null values in JSON are treated as absent.
  * Malformed JSON is caught and warned about (falls through to defaults).
  */
 export function loadPgEnv(
   configPath?: string
-): Record<string, string> {
+): PgConnectionConfig {
   const cfgPath =
     configPath ?? join(homedir(), ".openclaw", "postgres.json");
 
@@ -67,13 +81,18 @@ export function loadPgEnv(
     }
   }
 
-  const result: Record<string, string> = {};
+  const result: PgConnectionConfig = {};
 
   for (const [jsonKey, envVar] of FIELD_MAP) {
     // 1. Check ENV (empty string = unset)
     const envVal = process.env[envVar];
     if (envVal) {
-      result[envVar] = envVal;
+      if (jsonKey === "port") {
+        const portNum = Number(envVal);
+        if (!isNaN(portNum)) result[jsonKey] = portNum;
+      } else {
+        result[jsonKey] = envVal;
+      }
       continue;
     }
 
@@ -82,8 +101,12 @@ export function loadPgEnv(
     if (cfgVal != null) {
       const strVal = String(cfgVal);
       if (strVal) {
-        result[envVar] = strVal;
-        process.env[envVar] = strVal;
+        if (jsonKey === "port") {
+          const portNum = Number(strVal);
+          if (!isNaN(portNum)) result[jsonKey] = portNum;
+        } else {
+          result[jsonKey] = strVal;
+        }
         continue;
       }
     }
@@ -92,8 +115,12 @@ export function loadPgEnv(
     const def = DEFAULTS[envVar];
     if (def !== undefined) {
       const defaultVal = typeof def === "function" ? def() : def;
-      result[envVar] = defaultVal;
-      process.env[envVar] = defaultVal;
+      if (jsonKey === "port") {
+        const portNum = Number(defaultVal);
+        if (!isNaN(portNum)) result[jsonKey] = portNum;
+      } else {
+        result[jsonKey] = defaultVal;
+      }
     }
   }
 

--- a/cognition/focus/agent_chat/src/channel.ts
+++ b/cognition/focus/agent_chat/src/channel.ts
@@ -9,10 +9,8 @@ import { loadPgEnv } from "../lib/pg-env.js";
 import { getAgentChatRuntime } from "./runtime.js";
 import { AgentChatConfigSchema, type ResolvedAgentChatAccount } from "./config.js";
 
-// Load PG* env vars from ~/.openclaw/postgres.json at extension startup.
-// The pg library reads these env vars natively when new Client() is called
-// with no arguments (PGHOST, PGUSER, PGPASSWORD, PGDATABASE, PGPORT).
-loadPgEnv();
+// Get PostgreSQL config without polluting process.env for child processes
+const pgConfig = loadPgEnv();
 
 const { Client } = pg;
 
@@ -38,12 +36,11 @@ const meta: Omit<ChannelMeta, "id"> = {
 };
 
 /**
- * Create PostgreSQL client.
- * Credentials are read from PG* env vars set by loadPgEnv() at startup.
- * The pg library natively reads PGHOST, PGUSER, PGPASSWORD, PGDATABASE, PGPORT.
+ * Create PostgreSQL client with direct config pass-through
+ * avoiding environment variable pollution for child processes.
  */
 function createPgClient(): pg.Client {
-  return new Client();
+  return new Client(pgConfig);
 }
 
 /**
@@ -529,8 +526,8 @@ export const agentChatPlugin: ChannelPlugin<ResolvedAgentChatAccount> = {
         enabled: account.enabled,
         configured: Boolean(resolveAgentName(cfg)),
         agentName: resolveAgentName(cfg),
-        database: process.env.PGDATABASE ?? null,
-        host: process.env.PGHOST ?? "localhost",
+        database: pgConfig.database ?? null,
+        host: pgConfig.host ?? "localhost",
       };
     },
   },
@@ -615,7 +612,7 @@ export const agentChatPlugin: ChannelPlugin<ResolvedAgentChatAccount> = {
         // Store custom info in probe
         probe: {
           agentName: resolveAgentName(cfg),
-          database: process.env.PGDATABASE ?? null,
+          database: pgConfig.database ?? null,
         },
       };
     },

--- a/cognition/focus/bootstrap-context/hook/handler.ts
+++ b/cognition/focus/bootstrap-context/hook/handler.ts
@@ -10,14 +10,20 @@
 import { readFile } from 'fs/promises';
 import pg from 'pg';
 import { join } from 'path';
-import { homedir } from 'os';
+import { homedir, userInfo } from 'os';
 
-// Load PG env vars from postgres.json before creating Pool
-// See: https://github.com/NOVA-Openclaw/nova-memory/issues/136
+// Load PG config from postgres.json without polluting process.env
+// See: https://github.com/NOVA-Openclaw/nova-mind/issues/330
 const pgEnvPath = join(homedir(), '.openclaw', 'lib', 'pg-env.ts');
+let pgConfig: { host?: string; port?: number; database?: string; user?: string; password?: string } = {
+  host: 'localhost',
+  port: 5432,
+  database: 'nova_memory',
+  user: userInfo().username,
+};
 try {
   const { loadPgEnv } = await import(pgEnvPath);
-  loadPgEnv();
+  pgConfig = loadPgEnv();
 } catch (e) {
   console.warn('[bootstrap-context] Could not load pg-env.ts:', (e as Error).message);
 }
@@ -26,11 +32,7 @@ const { Pool } = pg;
 
 // Create connection pool (reused across invocations)
 const pool = new Pool({
-  host: process.env.PGHOST || 'localhost',
-  port: parseInt(process.env.PGPORT || '5432'),
-  database: process.env.PGDATABASE || 'nova_memory',
-  user: process.env.PGUSER || 'nova',
-  password: process.env.PGPASSWORD,
+  ...pgConfig,
   max: 5,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 5000,

--- a/lib/pg-env.ts
+++ b/lib/pg-env.ts
@@ -2,7 +2,7 @@
  * pg-env.ts — Centralized PostgreSQL config loader for TypeScript/Node.js.
  *
  * Resolution order: ENV vars → ~/.openclaw/postgres.json → defaults
- * Issue: nova-memory #94
+ * Issue: nova-memory #94, nova-mind #330
  */
 
 import { readFileSync } from "fs";
@@ -32,16 +32,30 @@ const DEFAULTS: Record<string, string | (() => string)> = {
 };
 
 /**
- * Load PostgreSQL env vars with resolution: ENV → config file → defaults.
+ * PostgreSQL connection options interface that matches
+ * the pg.Client constructor options.
+ */
+export interface PgConnectionConfig {
+  host?: string;
+  port?: number;
+  database?: string;
+  user?: string;
+  password?: string;
+}
+
+/**
+ * Load PostgreSQL config with resolution: ENV → config file → defaults.
  *
- * Sets process.env for each PG* var and returns the resulting record.
+ * Returns connection config object suitable for pg.Client / pg.Pool constructor,
+ * without modifying process.env to avoid pollution of the environment
+ * for child processes and subagents.
  * Empty ENV strings are treated as unset.
  * Null values in JSON are treated as absent.
  * Malformed JSON is caught and warned about (falls through to defaults).
  */
 export function loadPgEnv(
   configPath?: string
-): Record<string, string> {
+): PgConnectionConfig {
   const cfgPath =
     configPath ?? join(homedir(), ".openclaw", "postgres.json");
 
@@ -67,13 +81,18 @@ export function loadPgEnv(
     }
   }
 
-  const result: Record<string, string> = {};
+  const result: PgConnectionConfig = {};
 
   for (const [jsonKey, envVar] of FIELD_MAP) {
     // 1. Check ENV (empty string = unset)
     const envVal = process.env[envVar];
     if (envVal) {
-      result[envVar] = envVal;
+      if (jsonKey === "port") {
+        const portNum = Number(envVal);
+        if (!isNaN(portNum)) result[jsonKey] = portNum;
+      } else {
+        result[jsonKey] = envVal;
+      }
       continue;
     }
 
@@ -82,8 +101,12 @@ export function loadPgEnv(
     if (cfgVal != null) {
       const strVal = String(cfgVal);
       if (strVal) {
-        result[envVar] = strVal;
-        process.env[envVar] = strVal;
+        if (jsonKey === "port") {
+          const portNum = Number(strVal);
+          if (!isNaN(portNum)) result[jsonKey] = portNum;
+        } else {
+          result[jsonKey] = strVal;
+        }
         continue;
       }
     }
@@ -92,8 +115,12 @@ export function loadPgEnv(
     const def = DEFAULTS[envVar];
     if (def !== undefined) {
       const defaultVal = typeof def === "function" ? def() : def;
-      result[envVar] = defaultVal;
-      process.env[envVar] = defaultVal;
+      if (jsonKey === "port") {
+        const portNum = Number(defaultVal);
+        if (!isNaN(portNum)) result[jsonKey] = portNum;
+      } else {
+        result[jsonKey] = defaultVal;
+      }
     }
   }
 

--- a/memory/lib/pg-env.ts
+++ b/memory/lib/pg-env.ts
@@ -2,7 +2,7 @@
  * pg-env.ts — Centralized PostgreSQL config loader for TypeScript/Node.js.
  *
  * Resolution order: ENV vars → ~/.openclaw/postgres.json → defaults
- * Issue: nova-memory #94
+ * Issue: nova-memory #94, nova-mind #330
  */
 
 import { readFileSync } from "fs";
@@ -32,16 +32,30 @@ const DEFAULTS: Record<string, string | (() => string)> = {
 };
 
 /**
- * Load PostgreSQL env vars with resolution: ENV → config file → defaults.
+ * PostgreSQL connection options interface that matches
+ * the pg.Client constructor options.
+ */
+export interface PgConnectionConfig {
+  host?: string;
+  port?: number;
+  database?: string;
+  user?: string;
+  password?: string;
+}
+
+/**
+ * Load PostgreSQL config with resolution: ENV → config file → defaults.
  *
- * Sets process.env for each PG* var and returns the resulting record.
+ * Returns connection config object suitable for pg.Client / pg.Pool constructor,
+ * without modifying process.env to avoid pollution of the environment
+ * for child processes and subagents.
  * Empty ENV strings are treated as unset.
  * Null values in JSON are treated as absent.
  * Malformed JSON is caught and warned about (falls through to defaults).
  */
 export function loadPgEnv(
   configPath?: string
-): Record<string, string> {
+): PgConnectionConfig {
   const cfgPath =
     configPath ?? join(homedir(), ".openclaw", "postgres.json");
 
@@ -67,13 +81,18 @@ export function loadPgEnv(
     }
   }
 
-  const result: Record<string, string> = {};
+  const result: PgConnectionConfig = {};
 
   for (const [jsonKey, envVar] of FIELD_MAP) {
     // 1. Check ENV (empty string = unset)
     const envVal = process.env[envVar];
     if (envVal) {
-      result[envVar] = envVal;
+      if (jsonKey === "port") {
+        const portNum = Number(envVal);
+        if (!isNaN(portNum)) result[jsonKey] = portNum;
+      } else {
+        result[jsonKey] = envVal;
+      }
       continue;
     }
 
@@ -82,8 +101,12 @@ export function loadPgEnv(
     if (cfgVal != null) {
       const strVal = String(cfgVal);
       if (strVal) {
-        result[envVar] = strVal;
-        process.env[envVar] = strVal;
+        if (jsonKey === "port") {
+          const portNum = Number(strVal);
+          if (!isNaN(portNum)) result[jsonKey] = portNum;
+        } else {
+          result[jsonKey] = strVal;
+        }
         continue;
       }
     }
@@ -92,8 +115,12 @@ export function loadPgEnv(
     const def = DEFAULTS[envVar];
     if (def !== undefined) {
       const defaultVal = typeof def === "function" ? def() : def;
-      result[envVar] = defaultVal;
-      process.env[envVar] = defaultVal;
+      if (jsonKey === "port") {
+        const portNum = Number(defaultVal);
+        if (!isNaN(portNum)) result[jsonKey] = portNum;
+      } else {
+        result[jsonKey] = defaultVal;
+      }
     }
   }
 

--- a/memory/plugins/turn-context/src/shared/pg-pool.ts
+++ b/memory/plugins/turn-context/src/shared/pg-pool.ts
@@ -1,52 +1,70 @@
 /**
  * Shared singleton pg.Pool for the turn-context plugin.
  *
- * Loads PG env vars from ~/.openclaw/postgres.json before creating the pool,
- * so PGPASSWORD and friends are set correctly for node-pg.
+ * Loads PG config from ~/.openclaw/postgres.json before creating the pool,
+ * passing credentials directly to the Pool constructor to avoid polluting
+ * process.env for child processes and subagents.
  *
- * Issue: nova-mind #182
+ * Issue: nova-mind #182, nova-mind #330
  */
 
 import pg from "pg";
 import { join } from "path";
-import { homedir } from "os";
+import { homedir, userInfo } from "os";
 import { existsSync, readFileSync } from "fs";
 
 const { Pool } = pg;
 
 let pool: pg.Pool | null = null;
-let pgEnvLoaded = false;
 
-function ensurePgEnv(): void {
-  if (pgEnvLoaded) return;
-  pgEnvLoaded = true;
+interface PgConnectionConfig {
+  host?: string;
+  port?: number;
+  database?: string;
+  user?: string;
+  password?: string;
+}
+
+/**
+ * Read PostgreSQL config from ~/.openclaw/postgres.json.
+ * Returns a config object without touching process.env.
+ */
+function loadPgConfig(): PgConnectionConfig {
+  const result: PgConnectionConfig = {
+    host: process.env.PGHOST || "localhost",
+    port: parseInt(process.env.PGPORT || "5432"),
+    database: process.env.PGDATABASE || "nova_memory",
+    user: process.env.PGUSER || userInfo().username,
+    password: process.env.PGPASSWORD,
+  };
+
   try {
     const pgConfigPath = join(homedir(), ".openclaw", "postgres.json");
     if (existsSync(pgConfigPath)) {
       const config = JSON.parse(readFileSync(pgConfigPath, "utf-8"));
-      if (config.host) process.env.PGHOST = process.env.PGHOST || config.host;
-      if (config.port) process.env.PGPORT = process.env.PGPORT || String(config.port);
-      if (config.database) process.env.PGDATABASE = process.env.PGDATABASE || config.database;
-      if (config.user) process.env.PGUSER = process.env.PGUSER || config.user;
-      if (config.password) process.env.PGPASSWORD = process.env.PGPASSWORD || config.password;
+      // Config file values only applied when ENV vars are absent (empty = unset)
+      if (!process.env.PGHOST && config.host) result.host = config.host;
+      if (!process.env.PGPORT && config.port) result.port = Number(config.port);
+      if (!process.env.PGDATABASE && config.database) result.database = config.database;
+      if (!process.env.PGUSER && config.user) result.user = config.user;
+      if (!process.env.PGPASSWORD && config.password) result.password = config.password;
     }
   } catch (err) {
     console.warn("[turn-context] pg config load failed:", (err as Error).message);
   }
+
+  return result;
 }
 
 /**
  * Return the singleton pg.Pool, creating it on first call.
+ * Passes config directly to Pool constructor — no process.env writes.
  */
 export function getPool(): pg.Pool {
   if (!pool) {
-    ensurePgEnv();
+    const pgConfig = loadPgConfig();
     pool = new Pool({
-      host: process.env.PGHOST || "localhost",
-      port: parseInt(process.env.PGPORT || "5432"),
-      database: process.env.PGDATABASE || "nova_memory",
-      user: process.env.PGUSER || "nova",
-      password: process.env.PGPASSWORD,
+      ...pgConfig,
       max: 5,
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 5000,

--- a/memory/tests/test-pg-env.ts
+++ b/memory/tests/test-pg-env.ts
@@ -1,6 +1,9 @@
 /**
  * Test suite for lib/pg-env.ts
  * Run with: npx tsx tests/test-pg-env.ts
+ *
+ * Tests the updated loadPgEnv() which returns a PgConnectionConfig object
+ * instead of Record<string, string>, and does NOT set process.env.
  */
 
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
@@ -14,12 +17,31 @@ const libPath = join(__dirname, "..", "lib", "pg-env.ts");
 let PASS = 0;
 let FAIL = 0;
 
-function assertEq(desc: string, expected: string | undefined, actual: string | undefined) {
+interface PgConnectionConfig {
+  host?: string;
+  port?: number;
+  database?: string;
+  user?: string;
+  password?: string;
+}
+
+function assertEq<T>(desc: string, expected: T, actual: T) {
   if (expected === actual) {
     console.log(`  PASS: ${desc}`);
     PASS++;
   } else {
-    console.log(`  FAIL: ${desc} (expected='${expected}', got='${actual}')`);
+    console.log(`  FAIL: ${desc} (expected='${String(expected)}', got='${String(actual)}')`);
+    FAIL++;
+  }
+}
+
+function assertEnvUnset(desc: string, envVar: string) {
+  const val = process.env[envVar];
+  if (val === undefined) {
+    console.log(`  PASS: ${desc} (${envVar} not set)`);
+    PASS++;
+  } else {
+    console.log(`  FAIL: ${desc} — ${envVar} was set to '${val}' (process.env should not be modified)`);
     FAIL++;
   }
 }
@@ -54,24 +76,30 @@ async function run() {
       host: "dbhost", port: 5433, database: "testdb",
       user: "testuser", password: "secret123"
     });
-    let r = loadPgEnv(cfg1);
-    assertEq("PGHOST", "dbhost", r.PGHOST);
-    assertEq("PGPORT", "5433", r.PGPORT);
-    assertEq("PGDATABASE", "testdb", r.PGDATABASE);
-    assertEq("PGUSER", "testuser", r.PGUSER);
-    assertEq("PGPASSWORD", "secret123", r.PGPASSWORD);
+    let r: PgConnectionConfig = loadPgEnv(cfg1);
+    assertEq("host", "dbhost", r.host);
+    assertEq("port (number)", 5433, r.port);
+    assertEq("database", "testdb", r.database);
+    assertEq("user", "testuser", r.user);
+    assertEq("password", "secret123", r.password);
+    // Verify process.env was NOT polluted
+    assertEnvUnset("process.env.PGHOST not set", "PGHOST");
+    assertEnvUnset("process.env.PGDATABASE not set", "PGDATABASE");
+    assertEnvUnset("process.env.PGPASSWORD not set", "PGPASSWORD");
 
     // TC-1.2
-    console.log("TC-1.2: All ENV set");
+    console.log("TC-1.2: All ENV set — ENV takes priority");
     clearPgVars();
     Object.assign(process.env, {
       PGHOST: "envhost", PGPORT: "9999", PGDATABASE: "envdb",
       PGUSER: "envuser", PGPASSWORD: "envpass"
     });
     r = loadPgEnv(cfg1);
-    assertEq("PGHOST", "envhost", r.PGHOST);
-    assertEq("PGPORT", "9999", r.PGPORT);
-    assertEq("PGDATABASE", "envdb", r.PGDATABASE);
+    assertEq("host from ENV", "envhost", r.host);
+    assertEq("port from ENV (number)", 9999, r.port);
+    assertEq("database from ENV", "envdb", r.database);
+    assertEq("user from ENV", "envuser", r.user);
+    assertEq("password from ENV", "envpass", r.password);
 
     // TC-1.4
     console.log("TC-1.4: Mixed ENV + config");
@@ -79,66 +107,80 @@ async function run() {
     process.env.PGHOST = "remotehost";
     process.env.PGPORT = "9999";
     r = loadPgEnv(cfg1);
-    assertEq("PGHOST", "remotehost", r.PGHOST);
-    assertEq("PGPORT", "9999", r.PGPORT);
-    assertEq("PGDATABASE", "testdb", r.PGDATABASE);
-    assertEq("PGUSER", "testuser", r.PGUSER);
+    assertEq("host from ENV", "remotehost", r.host);
+    assertEq("port from ENV (number)", 9999, r.port);
+    assertEq("database from config", "testdb", r.database);
+    assertEq("user from config", "testuser", r.user);
 
     // TC-2.1: No ENV, no config
     console.log("TC-2.1: No ENV, no config — defaults");
     clearPgVars();
     r = loadPgEnv("/nonexistent/path/postgres.json");
-    assertEq("PGHOST", "localhost", r.PGHOST);
-    assertEq("PGPORT", "5432", r.PGPORT);
-    assertEq("PGUSER", currentUser, r.PGUSER);
-    assertEq("PGDATABASE unset", undefined, r.PGDATABASE);
-    assertEq("PGPASSWORD unset", undefined, r.PGPASSWORD);
+    assertEq("host default", "localhost", r.host);
+    assertEq("port default (number)", 5432, r.port);
+    assertEq("user default", currentUser, r.user);
+    assertEq("database unset", undefined, r.database);
+    assertEq("password unset", undefined, r.password);
+    // Verify process.env still unset
+    assertEnvUnset("process.env.PGHOST not set after defaults", "PGHOST");
 
     // TC-2.3: Empty strings
     console.log("TC-2.3: Config with empty strings");
     clearPgVars();
     const cfg23 = writeConfig(join(tmp, "tc2_3"), { host: "", port: 5432, user: "" });
     r = loadPgEnv(cfg23);
-    assertEq("PGHOST defaults", "localhost", r.PGHOST);
-    assertEq("PGUSER defaults", currentUser, r.PGUSER);
+    assertEq("host empty->default", "localhost", r.host);
+    assertEq("user empty->default", currentUser, r.user);
 
     // TC-3.4: Null values
     console.log("TC-3.4: Null values in JSON");
     clearPgVars();
     const cfg34 = writeConfig(join(tmp, "tc3_4"), { host: null, port: 5432 });
     r = loadPgEnv(cfg34);
-    assertEq("PGHOST null->default", "localhost", r.PGHOST);
-    assertEq("PGPORT", "5432", r.PGPORT);
+    assertEq("host null->default", "localhost", r.host);
+    assertEq("port (number)", 5432, r.port);
 
     // TC-3.5: Empty ENV string
     console.log("TC-3.5: ENV set to empty string");
     clearPgVars();
     process.env.PGHOST = "";
     r = loadPgEnv(cfg1);
-    assertEq("PGHOST empty->config", "dbhost", r.PGHOST);
+    assertEq("host empty ENV->config", "dbhost", r.host);
 
     // TC-4.1: Malformed JSON
     console.log("TC-4.1: Malformed JSON");
     clearPgVars();
     const cfgBad = writeConfig(join(tmp, "tc4_1"), "{invalid json");
     r = loadPgEnv(cfgBad);
-    assertEq("PGHOST malformed->default", "localhost", r.PGHOST);
+    assertEq("host malformed->default", "localhost", r.host);
 
-    // TC-3.2: Port as string
-    console.log("TC-3.2: Port as string");
+    // TC-3.2: Port as string in config
+    console.log("TC-3.2: Port as string in config");
     clearPgVars();
     const cfg32 = writeConfig(join(tmp, "tc3_2"), { port: "5433" });
     r = loadPgEnv(cfg32);
-    assertEq("PGPORT string", "5433", r.PGPORT);
+    assertEq("port string->number", 5433, r.port);
 
-    // TC-3.3: Port as integer
-    console.log("TC-3.3: Port as integer");
+    // TC-3.3: Port as integer in config
+    console.log("TC-3.3: Port as integer in config");
     clearPgVars();
     const cfg33 = writeConfig(join(tmp, "tc3_3"), { port: 5433 });
     r = loadPgEnv(cfg33);
-    assertEq("PGPORT int", "5433", r.PGPORT);
+    assertEq("port int->number", 5433, r.port);
+
+    // TC-5.1: Verify no process.env mutation throughout (post-test check)
+    console.log("TC-5.1: Final check — process.env.PG* all unset after clearPgVars");
+    clearPgVars();
+    r = loadPgEnv(cfg1);
+    // After loading from config, env should still be clean
+    assertEnvUnset("PGHOST unset after config load", "PGHOST");
+    assertEnvUnset("PGPORT unset after config load", "PGPORT");
+    assertEnvUnset("PGDATABASE unset after config load", "PGDATABASE");
+    assertEnvUnset("PGUSER unset after config load", "PGUSER");
+    assertEnvUnset("PGPASSWORD unset after config load", "PGPASSWORD");
 
   } finally {
+    clearPgVars();
     rmSync(tmp, { recursive: true, force: true });
   }
 

--- a/relationships/lib/entity-resolver/resolver.ts
+++ b/relationships/lib/entity-resolver/resolver.ts
@@ -9,20 +9,27 @@ import { join } from "path";
 
 const { Pool } = pg;
 
-// Load PG* env vars from ~/.openclaw/postgres.json before any DB connections
+// Load PG config from ~/.openclaw/postgres.json without polluting process.env
+// See: https://github.com/NOVA-Openclaw/nova-mind/issues/330
 const pgEnvPath = join(process.env.HOME || os.homedir(), ".openclaw", "lib", "pg-env.ts");
-const { loadPgEnv } = await import(pgEnvPath);
-loadPgEnv();
+let pgConfig: { host?: string; port?: number; database?: string; user?: string; password?: string } = {};
+try {
+  const { loadPgEnv } = await import(pgEnvPath);
+  pgConfig = loadPgEnv();
+} catch (e) {
+  console.warn('[entity-resolver] Could not load pg-env.ts:', (e as Error).message);
+}
 
 // Database connection pool (singleton)
 let dbPool: pg.Pool | null = null;
 
 /**
- * Derive database name from username (same pattern as nova-memory)
+ * Derive database name: use config value or fall back to <user>_memory convention.
  */
 function getDatabaseName(): string {
-  const user = process.env.PGUSER || os.userInfo().username;
-  return process.env.PGDATABASE || `${user.replace(/-/g, '_')}_memory`;
+  if (pgConfig.database) return pgConfig.database;
+  const user = pgConfig.user || os.userInfo().username;
+  return `${user.replace(/-/g, '_')}_memory`;
 }
 
 /**
@@ -30,12 +37,12 @@ function getDatabaseName(): string {
  */
 function getDbPool(): pg.Pool {
   if (!dbPool) {
-    const dbUser = process.env.PGUSER || os.userInfo().username;
     dbPool = new Pool({
-      host: process.env.PGHOST || "localhost",
+      host: pgConfig.host || "localhost",
+      port: pgConfig.port,
       database: getDatabaseName(),
-      user: dbUser,
-      password: process.env.PGPASSWORD,
+      user: pgConfig.user || os.userInfo().username,
+      password: pgConfig.password,
       max: 5,
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 5000,


### PR DESCRIPTION
Refactored all 3 copies of `loadPgEnv()` plus all consumers (8 files total) to return a `PgConnectionConfig` object instead of mutating `process.env`. Tests updated — 36/36 pass.

No deployment needed after merge; Graybeard handles post-merge deployment.

Closes #330