### PR TITLE
fix(motivation): read dual heartbeat-state mirrors in gate check (fixes #336)

### DIFF
--- a/motivation/scripts/proactive-gate-check.py
+++ b/motivation/scripts/proactive-gate-check.py
@@ -47,6 +47,9 @@ SESSIONS_JSON = os.path.expanduser(
 HEARTBEAT_STATE_JSON = os.path.expanduser(
     "~/.openclaw/workspace/memory/heartbeat-state.json"
 )
+HEARTBEAT_STATE_JSON_ALT = os.path.expanduser(
+    "~/.openclaw/workspace/heartbeat-state.json"
+)
 MEMORY_MAINTENANCE_JSON = os.path.expanduser(
     "~/.openclaw/state/memory-maintenance-last-run.json"
 )
@@ -115,6 +118,29 @@ def _db_connect():
 
 def _step_error(msg: str) -> dict:
     return {"actionable": False, "error": msg}
+
+
+def _load_heartbeat_state(path: str) -> tuple[dict[str, Any] | None, datetime | None]:
+    """
+    Load heartbeat state from a single JSON file.
+
+    Returns (state_dict, timestamp_datetime) on success, or (None, None) if
+    the file is missing or cannot be parsed.
+    """
+    try:
+        with open(path, "r") as fh:
+            state = json.load(fh)
+        last_introspect = state.get("lastIntrospection", {})
+        ts_str = last_introspect.get("timestamp")
+        ts = None
+        if ts_str:
+            try:
+                ts = _parse_iso(ts_str)
+            except (ValueError, OverflowError):
+                ts = None
+        return state, ts
+    except (FileNotFoundError, json.JSONDecodeError, ValueError):
+        return None, None
 
 
 # ---------------------------------------------------------------------------
@@ -278,25 +304,35 @@ def check_step3_introspection() -> dict:
     Step 3: Introspection gate.
     Compares current daily log lines + session transcript bytes + elapsed time
     against last recorded values. Any threshold exceeded → actionable.
+
+    Reads heartbeat state from two mirrored locations and uses whichever
+    copy has the more recent timestamp (primary wins ties).
     """
-    # Load last introspection state
-    try:
-        with open(HEARTBEAT_STATE_JSON, "r") as fh:
-            state = json.load(fh)
-        last_introspect = state.get("lastIntrospection", {})
-        last_lines = last_introspect.get("dailyLogLines")
-        last_bytes = last_introspect.get("sessionTranscriptBytes")
-        last_ts_str = last_introspect.get("timestamp")
-    except FileNotFoundError:
+    # Load heartbeat state from both mirrors.
+    primary_state, primary_ts = _load_heartbeat_state(HEARTBEAT_STATE_JSON)
+    alt_state, alt_ts = _load_heartbeat_state(HEARTBEAT_STATE_JSON_ALT)
+
+    if primary_state is None and alt_state is None:
         return {
             "actionable": True,
-            "reason": "heartbeat-state.json missing — first run, trigger introspection",
+            "reason": "heartbeat-state.json missing or malformed in both locations — trigger introspection",
         }
-    except (json.JSONDecodeError, ValueError) as exc:
-        return {
-            "actionable": True,
-            "reason": f"heartbeat-state.json malformed: {exc} — trigger introspection",
-        }
+
+    # Prefer the fresher mirror; primary wins ties.
+    # Guard against None timestamps: treat None as "oldest possible".
+    if alt_state is not None and (primary_state is None or (alt_ts is not None and (primary_ts is None or alt_ts > primary_ts))):
+        state = alt_state
+        source_path = HEARTBEAT_STATE_JSON_ALT
+        stale_path = HEARTBEAT_STATE_JSON
+    else:
+        state = primary_state
+        source_path = HEARTBEAT_STATE_JSON
+        stale_path = HEARTBEAT_STATE_JSON_ALT
+
+    last_introspect = state.get("lastIntrospection", {})
+    last_lines = last_introspect.get("dailyLogLines")
+    last_bytes = last_introspect.get("sessionTranscriptBytes")
+    last_ts_str = last_introspect.get("timestamp")
 
     # Parse timestamp once; reused by the cooldown check and elapsed check below.
     last_ts = None
@@ -306,6 +342,14 @@ def check_step3_introspection() -> dict:
             last_ts = _parse_iso(last_ts_str)
         except (ValueError, OverflowError) as exc:
             last_ts_parse_error = str(exc)
+
+    # Best-effort sync: write the fresher state to the stale mirror if it exists.
+    if source_path != stale_path and os.path.exists(stale_path):
+        try:
+            with open(stale_path, "w") as fh:
+                json.dump(state, fh)
+        except (OSError, TypeError):
+            pass  # Non-fatal; sync is best-effort
 
     # Minimum interval floor — prevent over-firing (see nova-mind#326)
     if last_ts is not None:

--- a/motivation/tests/test_proactive_gate_check.py
+++ b/motivation/tests/test_proactive_gate_check.py
@@ -43,6 +43,14 @@ def m() -> ModuleType:
     return _load_module()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_heartbeat_alt(m, tmp_path):
+    """Prevent the real alt heartbeat file from leaking into tests."""
+    alt_path = str(tmp_path / "alt-heartbeat.json")
+    with patch.object(m, "HEARTBEAT_STATE_JSON_ALT", alt_path):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -527,6 +535,211 @@ class TestStep3Introspection:
         assert isinstance(result["data"]["remaining_hours"], float)
         assert 0.0 <= result["data"]["elapsed_hours"] < 2.0
         assert 0.0 < result["data"]["remaining_hours"] <= 2.0
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — introspection dual-mirror heartbeat state
+# ---------------------------------------------------------------------------
+
+class TestStep3IntrospectionDualMirror:
+    def _make_heartbeat_state(self, lines: int, bytez: int, hours_ago: float) -> str:
+        return json.dumps({
+            "lastIntrospection": {
+                "dailyLogLines": lines,
+                "sessionTranscriptBytes": bytez,
+                "timestamp": _iso(hours_ago),
+            }
+        })
+
+    def _fake_run(self, mock_wc, mock_du):
+        def fake_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[0] == "wc":
+                return mock_wc
+            return mock_du
+        return fake_run
+
+    def _no_threshold_mocks(self):
+        mock_wc = MagicMock()
+        mock_wc.returncode = 0
+        mock_wc.stdout = "102 /path"  # 2-line growth
+        mock_du = MagicMock()
+        mock_du.returncode = 0
+        mock_du.stdout = "1050000"  # 50KB growth
+        return mock_wc, mock_du
+
+    def test_both_exist_primary_newer_uses_primary(self, m, tmp_path):
+        primary_file = tmp_path / "primary.json"
+        alt_file = tmp_path / "alt.json"
+        primary_file.write_text(self._make_heartbeat_state(100, 1_000_000, 3.0))
+        alt_file.write_text(self._make_heartbeat_state(100, 1_000_000, 8.0))
+
+        mock_wc, mock_du = self._no_threshold_mocks()
+
+        with patch.object(m, "HEARTBEAT_STATE_JSON", str(primary_file)), \
+             patch.object(m, "HEARTBEAT_STATE_JSON_ALT", str(alt_file)), \
+             patch("subprocess.run", side_effect=self._fake_run(mock_wc, mock_du)):
+            result = m.check_step3_introspection()
+        assert result["actionable"] is False
+
+    def test_both_exist_alt_newer_uses_alt(self, m, tmp_path):
+        primary_file = tmp_path / "primary.json"
+        alt_file = tmp_path / "alt.json"
+        primary_file.write_text(self._make_heartbeat_state(100, 1_000_000, 9.0))
+        alt_file.write_text(self._make_heartbeat_state(100, 1_000_000, 3.0))
+
+        mock_wc, mock_du = self._no_threshold_mocks()
+
+        with patch.object(m, "HEARTBEAT_STATE_JSON", str(primary_file)), \
+             patch.object(m, "HEARTBEAT_STATE_JSON_ALT", str(alt_file)), \
+             patch("subprocess.run", side_effect=self._fake_run(mock_wc, mock_du)):
+            result = m.check_step3_introspection()
+        assert result["actionable"] is False
+
+    def test_only_primary_exists_uses_primary(self, m, tmp_path):
+        primary_file = tmp_path / "primary.json"
+        alt_file = tmp_path / "alt.json"
+        primary_file.write_text(self._make_heartbeat_state(100, 1_000_000, 3.0))
+        # alt_file intentionally does not exist
+
+        mock_wc, mock_du = self._no_threshold_mocks()
+
+        with patch.object(m, "HEARTBEAT_STATE_JSON", str(primary_file)), \
+             patch.object(m, "HEARTBEAT_STATE_JSON_ALT", str(alt_file)), \
+             patch("subprocess.run", side_effect=self._fake_run(mock_wc, mock_du)):
+            result = m.check_step3_introspection()
+        assert result["actionable"] is False
+
+    def test_only_alt_exists_uses_alt(self, m, tmp_path):
+        primary_file = tmp_path / "primary.json"
+        alt_file = tmp_path / "alt.json"
+        # primary_file intentionally does not exist
+        alt_file.write_text(self._make_heartbeat_state(100, 1_000_000, 3.0))
+
+        mock_wc, mock_du = self._no_threshold_mocks()
+
+        with patch.object(m, "HEARTBEAT_STATE_JSON", str(primary_file)), \
+             patch.object(m, "HEARTBEAT_STATE_JSON_ALT", str(alt_file)), \
+             patch("subprocess.run", side_effect=self._fake_run(mock_wc, mock_du)):
+            result = m.check_step3_introspection()
+        assert result["actionable"] is False
+
+    def test_neither_exists_triggers_introspection(self, m, tmp_path):
+        primary_file = tmp_path / "primary.json"
+        alt_file = tmp_path / "alt.json"
+        # Neither file exists
+
+        with patch.object(m, "HEARTBEAT_STATE_JSON", str(primary_file)), \
+             patch.object(m, "HEARTBEAT_STATE_JSON_ALT", str(alt_file)):
+            result = m.check_step3_introspection()
+        assert result["actionable"] is True
+        assert "missing" in result["reason"].lower()
+
+    def test_primary_malformed_alt_valid_uses_alt(self, m, tmp_path):
+        primary_file = tmp_path / "primary.json"
+        alt_file = tmp_path / "alt.json"
+        primary_file.write_text("{bad json{{")
+        alt_file.write_text(self._make_heartbeat_state(100, 1_000_000, 3.0))
+
+        mock_wc, mock_du = self._no_threshold_mocks()
+
+        with patch.object(m, "HEARTBEAT_STATE_JSON", str(primary_file)), \
+             patch.object(m, "HEARTBEAT_STATE_JSON_ALT", str(alt_file)), \
+             patch("subprocess.run", side_effect=self._fake_run(mock_wc, mock_du)):
+            result = m.check_step3_introspection()
+        assert result["actionable"] is False
+
+    def test_alt_malformed_primary_valid_uses_primary(self, m, tmp_path):
+        primary_file = tmp_path / "primary.json"
+        alt_file = tmp_path / "alt.json"
+        primary_file.write_text(self._make_heartbeat_state(100, 1_000_000, 3.0))
+        alt_file.write_text("{bad json{{")
+
+        mock_wc, mock_du = self._no_threshold_mocks()
+
+        with patch.object(m, "HEARTBEAT_STATE_JSON", str(primary_file)), \
+             patch.object(m, "HEARTBEAT_STATE_JSON_ALT", str(alt_file)), \
+             patch("subprocess.run", side_effect=self._fake_run(mock_wc, mock_du)):
+            result = m.check_step3_introspection()
+        assert result["actionable"] is False
+
+    def test_same_timestamp_uses_primary(self, m, tmp_path):
+        primary_file = tmp_path / "primary.json"
+        alt_file = tmp_path / "alt.json"
+        fixed_ts = "2026-06-21T10:00:00Z"
+        primary_file.write_text(json.dumps({
+            "lastIntrospection": {
+                "dailyLogLines": 100,
+                "sessionTranscriptBytes": 1_000_000,
+                "timestamp": fixed_ts,
+            }
+        }))
+        alt_file.write_text(json.dumps({
+            "lastIntrospection": {
+                "dailyLogLines": 999,
+                "sessionTranscriptBytes": 9_000_000,
+                "timestamp": fixed_ts,
+            }
+        }))
+
+        mock_wc, mock_du = self._no_threshold_mocks()
+
+        with patch.object(m, "HEARTBEAT_STATE_JSON", str(primary_file)), \
+             patch.object(m, "HEARTBEAT_STATE_JSON_ALT", str(alt_file)), \
+             patch("subprocess.run", side_effect=self._fake_run(mock_wc, mock_du)):
+            result = m.check_step3_introspection()
+        # Primary wins tie, so it uses baseline 100/1M → no thresholds exceeded.
+        assert result["actionable"] is False
+
+    def test_both_malformed_triggers_introspection(self, m, tmp_path):
+        primary_file = tmp_path / "primary.json"
+        alt_file = tmp_path / "alt.json"
+        primary_file.write_text("{bad json{{")
+        alt_file.write_text("{also bad{{")
+
+        with patch.object(m, "HEARTBEAT_STATE_JSON", str(primary_file)), \
+             patch.object(m, "HEARTBEAT_STATE_JSON_ALT", str(alt_file)):
+            result = m.check_step3_introspection()
+        assert result["actionable"] is True
+
+    def test_sync_writes_stale_copy(self, m, tmp_path):
+        primary_file = tmp_path / "primary.json"
+        alt_file = tmp_path / "alt.json"
+        # Primary is stale; alt is fresher and has different values.
+        primary_file.write_text(self._make_heartbeat_state(100, 1_000_000, 9.0))
+        alt_state = {
+            "lastIntrospection": {
+                "dailyLogLines": 200,
+                "sessionTranscriptBytes": 2_000_000,
+                "timestamp": _iso(3.0),
+            }
+        }
+        alt_file.write_text(json.dumps(alt_state))
+
+        mock_wc, mock_du = self._no_threshold_mocks()
+
+        with patch.object(m, "HEARTBEAT_STATE_JSON", str(primary_file)), \
+             patch.object(m, "HEARTBEAT_STATE_JSON_ALT", str(alt_file)), \
+             patch("subprocess.run", side_effect=self._fake_run(mock_wc, mock_du)):
+            result = m.check_step3_introspection()
+        assert result["actionable"] is False
+        synced = json.loads(primary_file.read_text())
+        assert synced["lastIntrospection"]["dailyLogLines"] == 200
+        assert synced["lastIntrospection"]["sessionTranscriptBytes"] == 2_000_000
+
+    def test_sync_does_not_create_nonexistent_file(self, m, tmp_path):
+        primary_file = tmp_path / "primary.json"
+        alt_file = tmp_path / "alt.json"
+        # Only alt exists; primary is missing.
+        alt_file.write_text(self._make_heartbeat_state(100, 1_000_000, 3.0))
+
+        mock_wc, mock_du = self._no_threshold_mocks()
+
+        with patch.object(m, "HEARTBEAT_STATE_JSON", str(primary_file)), \
+             patch.object(m, "HEARTBEAT_STATE_JSON_ALT", str(alt_file)), \
+             patch("subprocess.run", side_effect=self._fake_run(mock_wc, mock_du)):
+            result = m.check_step3_introspection()
+        assert result["actionable"] is False
+        assert not primary_file.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`proactive-gate-check.py` reads heartbeat-state from a single location (`~/.openclaw/workspace/memory/heartbeat-state.json`), but introspection subagents sometimes write to the alternate mirror (`~/.openclaw/workspace/heartbeat-state.json`). When these desync, the gate check uses stale baselines and triggers redundant introspection runs (~$1.50-2.00 each).

Documented 3+ times: lessons #381, #409, #454.

## Fix

- Added `_load_heartbeat_state()` helper that safely reads and parses a single heartbeat-state file
- Modified `check_step3_introspection()` to read from both mirror locations and use whichever has the more recent `lastIntrospection.timestamp` (primary wins ties)
- Best-effort sync: after selecting the fresher mirror, writes its state to the stale copy (only if the stale file already exists — won't create new files)
- Defensive None-timestamp guard to prevent TypeError when timestamps are missing

## Tests

11 new test cases in `TestStep3IntrospectionDualMirror` class covering:
- Both mirrors exist (primary newer, alt newer, same timestamp)
- Single mirror exists (primary only, alt only)
- Missing/malformed files (one malformed, both malformed, both missing)
- Sync behavior (writes stale copy, doesn't create nonexistent files)

All 84 tests pass (73 existing + 11 new).

Fixes #336
Related: NOVA-Openclaw/nova-workspace#17