### PR TITLE
feat: consolidate embedding scripts into single memory-maintenance.py template (#352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### Batch: consolidate-embedding-scripts (Issue #352)
+
+#### Changed
+- **Embedding scripts consolidated into `memory-maintenance.py` template** (#352) — Removed the four separate deprecated embedding scripts (`embed-full-database.py`, `embed-research.py`, `embed-memories.py`, `embed-library.py`) from `memory/scripts/`. The authoritative source is now `memory/templates/memory-maintenance.py`, deployed to `~/.openclaw/scripts/memory-maintenance.py` by `agent-install.sh`. The installer cleanup block also removes stale copies of these deprecated scripts from both deploy targets (`~/.openclaw/workspace/scripts/` and `~/.openclaw/scripts/`) on upgrade. No functional change — `memory-maintenance.py` already absorbed all embedding logic in the entity-facts-quality batch.
+
+#### Issues Closed
+- #352 — Consolidate deprecated embedding scripts; move `memory-maintenance.py` to `memory/templates/`
+
+---
+
 ### Batch: installer-bugs-266-315-316 (Issues #266, #315, #316)
 
 #### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ All four subsystems share a single PostgreSQL database (`{username}_memory`) and
 Memory maintenance is handled by a **unified** script `memory/templates/memory-maintenance.py` (deployed to `~/.openclaw/scripts/memory-maintenance.py` by `agent-install.sh`) that replaces the separate embedding scripts (`embed-full-database.py`, `embed-memories.py`, `embed-research.py`, `embed-library.py`) and the previous memory maintenance logic. It runs as a 9-phase pipeline:
 
 1. **Cooldown check** — 4-hour gate prevents redundant runs (`--force` to bypass, `--state-file` override)
-2. **Embed** — Absorbs embed-full-database.py, embed-memories.py, embed-research.py
+2. **Embed** — Generates semantic embeddings across all table types (entities, facts, lessons, events, research, library, tasks, blog posts, etc.)
 3. **Cross-key consolidation** — pgvector cosine similarity ≥0.92
 4. **Same-key dedup** — pg_trgm similarity, 3-tier (high/medium/low)
 5. **Confidence decay** — Exponential, durability-based rates


### PR DESCRIPTION
## Summary

Consolidates 4 deprecated individual embedding scripts into the single `memory-maintenance.py` template. Updates the installer to support template-based install-if-not-exists behavior.

### Changes
- **Removed** 4 deprecated scripts from `memory/scripts/`: embed-full-database.py, embed-research.py, embed-memories.py, embed-library.py
- **Moved** `memory-maintenance.py` to `memory/templates/` for install-if-not-exists behavior
- **Updated `agent-install.sh`**:
  - Template install block — copies from `memory/templates/` only if target doesn't already exist (preserves local customizations)
  - Cleanup block — removes stale deprecated scripts from deploy targets
  - `--force` flag overrides template protection
- **Documentation** updated: README embed phase description, CHANGELOG entry

### Testing
- 32 test cases designed (TC-352-01 through TC-352-32)
- 31 PASS / 0 FAIL / 1 UNTESTED (acceptable)
- Staging test on nova-staging: clobber protection, cleanup, idempotent re-run all verified

Closes #352
Related: nova-workspace#23
