### PR TITLE
feat: heartbeat-integrated blocker outreach + forced D100 (#356, #358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+### Batch: blocker-outreach-356 (Issues #356, #358)
+
+#### Added
+- **`blockers` registry table** — Curated registry of items blocked on another entity's action, with `source_type`/`source_ref` unique constraint (upsert target for Steps 6/7), `entity_id`, `priority`, `status` (open/satisfied), and `satisfied_at`. (#356)
+- **`d100_roll_log` table + trigger** — Roll-history table populated by a trigger on `motivation_d100`, used to detect staleness for the forced-D100 check. (#358)
+- **Step 8 (Blocker Outreach)** — New dedicated step in the Proactive Mode workflow (id=27) that owns all blocker outreach cadence and channel escalation. Enforces a 24h entity-level cooldown and a 72h per-blocker cooldown (both strict `>`), selects the top 3 eligible blockers per entity (`priority ASC, first_seen ASC, id ASC`), and sends one consolidated message per entity at the most-escalated requested channel among its selected blockers. Cascade channel order: `discord_mention → discord_dm → signal → slack → email`, or `agent_chat` unconditionally for agent entities. (#356)
+- **`check_step8_blocker_outreach()`** (`motivation/scripts/proactive-gate-check.py`) — Deterministic gate function driving Step 8: satisfied-blocker reconciliation (reopen clears `satisfied_at`), cooldown-eligible entity/blocker selection, cascade level derivation from prior `proactive_outreach` row counts (not delivered channel), and channel-exhaustion reassignment (next domain entity → I)ruid final fallback → hold-in-place if I)ruid himself is exhausted). (#356)
+- **`check_step11_d100()` forced-D100 logic** — Step 11 (D100, renumbered from Step 10) is now forced actionable whenever more than 12h have elapsed since the last roll in `d100_roll_log` (or no roll on record), independent of whether other steps already had actionable work. ≤12h preserves the original mandatory-catch-all/optional behavior. (#358)
+- **Tests** — `TestStep8BlockerOutreach` (cooldown boundaries, never-contacted entities, non-blocker-outreach isolation, top-3 tiebreak, empty tables, channel mapping, cascade exhaustion + reassignment) and `TestStep11D100` (forced-D100 cases) in `motivation/tests/test_proactive_gate_check.py`. New `tests/TEST-CASES-ISSUE-356.md` and `memory/tests/test_migration_083_idempotency.py`. 122 passing (was 104 at initial PR open, +18 from the D-1 exhaustion/reassignment fix).
+
+#### Changed
+- **Proactive Mode workflow (id=27) renumbered from 10 to 11 steps** — Steps 6 (Pending Tasks) and 7 (GitHub Issues) now only curate blocked items into the `blockers` registry (upsert; entity resolution via `agent_domains` → `user_domains` → fallback entity_id=2); they no longer send outreach directly. Step 7's prior inline cascade + 3-day cooldown text (introduced in #232, see the `batch-se-run-8` entry below) is removed entirely — that responsibility now belongs exclusively to the new Step 8. Old steps 8/9/10 (Unsolved Problems, Filesystem Hygiene, D100) are renumbered to 9/10/11.
+- **HEARTBEAT.md, `motivation/ARCHITECTURE.md`, `motivation/scripts/README.md`** updated for the 11-step cascade, D100 now Step 11, and the new Step 8 Blocker Outreach reference section.
+- **Cascade exhaustion detection + reassignment** — When an entity's cascade channels are exhausted, the blocker is reassigned to the next domain entity in line, with I)ruid as the final fallback; if I)ruid is also exhausted, the blocker is held in place rather than dropped. The outreach payload carries `exhausted` and `reassigned_from_entity_id` fields so downstream consumers can distinguish a fresh assignment from a reassignment.
+
+#### Fixed
+- **24h/72h cooldown off-by-one** — `check_step8_blocker_outreach()`'s cooldown comparisons used `>` against the cutoff instead of the intended "strict greater-than" semantics allowing the exact boundary hour through as eligible; corrected so elapsed == threshold still blocks, per spec.
+- **`TestStep2UnansweredSessions` test drift** — Rewritten to match the prior `sessions.json` + per-session JSONL read refactor (predates this branch).
+- **`TestStep3IntrospectionDualMirror` hardcoded-date flake** — Pre-existing bug (predates this branch, at `fb7252d`), fixed alongside the above while chasing a green full-suite run.
+
+#### Migrations
+- `082_blockers_and_d100_roll_history.sql` — Creates `blockers` registry table and `d100_roll_log` roll-history table + trigger off `motivation_d100`.
+- `083_blocker_outreach_workflow_27.sql` — Rewrites workflow 27's `workflow_steps` for the 11-step layout described above. Idempotency-hardened: a PL/pgSQL DO-block guard detects the already-applied 11-step layout and skips re-running the renumbering, and the new Step 8 insert uses `ON CONFLICT (workflow_id, step_order) DO NOTHING`. **Not yet applied to the production database as of this branch** — per the `agent-install.sh` migration-application gap tracked in #355, migrations 082/083 must be applied manually on deploy.
+
+#### Known Caveats
+- **#355 caveat carried forward** — `agent-install.sh` does not apply `memory/migrations/`; migrations 082 and 083 in this batch are subject to the same gap already reported for migrations 077–079 and must be applied manually to the production database on deploy.
+
+#### Issues Closed
+- #356 — Heartbeat-integrated blocker outreach (dedicated Step 8, curation/outreach split, cascade escalation, reassignment)
+- #358 — Forced D100 roll past 12h staleness threshold, independent of other steps' actionable state
+
+---
+
 ### Batch: consolidate-embedding-scripts (Issue #352)
 
 #### Changed

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -37,13 +37,13 @@ Parse the JSON output:
   "idle": true,
   "idle_minutes": 95.3,
   "idle_threshold_minutes": 60,
-  "actionable_steps": [3, 6, 10],
+  "actionable_steps": [3, 6, 11],
   "actionable_count": 3,
-  "summary": "3 of 10 steps actionable"
+  "summary": "3 of 11 steps actionable"
 }
 ```
 
-The `actionable_steps` array lists step numbers (1–10) corresponding to the **NOVA Proactive
+The `actionable_steps` array lists step numbers (1–11) corresponding to the **NOVA Proactive
 Mode** workflow (id=27). The script has already evaluated all gate conditions; do not
 re-evaluate them manually.
 
@@ -74,9 +74,20 @@ SELECT step_order, description FROM workflow_steps
 WHERE workflow_id = 27 ORDER BY step_order;
 ```
 
-**Step 10 (D100 random task) is mandatory when no other steps are actionable.** If
-`actionable_steps` contains only `[10]`, that is the work to do — it is the catch-all that
-ensures the cascade always produces output.
+**Step 8 (Blocker Outreach) sends outreach for blockers curated by Steps 6 and 7.** Steps 6
+and 7 only upsert blocked items into the `blockers` table — they never contact anyone
+directly. Step 8 is the sole place outreach is sent: it enforces a 24h entity-level cooldown
+and a 72h per-blocker cooldown, selects up to 3 eligible blockers per entity, and sends one
+consolidated message per entity at the most-escalated channel among its selected blockers.
+See `motivation/ARCHITECTURE.md` for the full cascade/channel/reassignment rules
+(issue #356).
+
+**Step 11 (D100 random task) is mandatory when no other steps are actionable, and forced
+when more than 12h have elapsed since the last roll.** If `actionable_steps` contains only
+`[11]`, that is the work to do — it is the catch-all that ensures the cascade always
+produces output. Independently, Step 11 will also appear in `actionable_steps` whenever
+`d100_roll_log` shows more than 12h since the last roll (or no roll on record at all), even
+if other steps already had actionable work (issue #358).
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # nova-mind
 
-NOVA Agent Mind — unified memory, cognition, relationships, and psyche.
+NOVA Agent Mind — unified memory, cognition, relationships, psyche, and motivation.
 
 > *Memory, thought, trust, self—*
-> *four rivers join, flow as one*
+> *five rivers join, flow as one*
 > *mind holds what it meets*
 >
 > — **Erato**
@@ -25,7 +25,7 @@ nova-mind is the complete agent mind stack for NOVA. It provides:
 - **Psyche** — Agent self-awareness design: core values, agent-chat architecture, entity/user identity models, and identification protocols
 - **Motivation** — Drive assignment, goal tracking, reward signals, and proactive mode orchestration for agent initiative
 
-All four subsystems share a single PostgreSQL database (`{username}_memory`) and a unified installer.
+All five subsystems share a single PostgreSQL database (`{username}_memory`) and a unified installer.
 
 ### Memory Maintenance
 

--- a/cognition/skills/introspect/SKILL.md
+++ b/cognition/skills/introspect/SKILL.md
@@ -1,0 +1,523 @@
+---
+name: introspect
+description: >
+  Review recent activity and extract institutional knowledge back into system artifacts.
+  Captures missing workflow steps, implementation details into SKILL.md files, tool notes
+  into TOOLS.md, and process lessons into memory. Trigger on: "introspect", "review what
+  we did", "capture learnings", "update workflows from recent work", "what did we miss",
+  "refine our processes", or after completing a significant multi-step task.
+---
+
+# Introspect
+
+Review recent work and harden institutional knowledge by writing it back into the artifacts that guide future work: workflows, skills, TOOLS.md, MEMORY.md, lessons table, and bootstrap context.
+
+## When to Run
+
+- After completing a significant task (installation, migration, incident, new tooling)
+- On request ("introspect", "capture learnings")
+- During periodic maintenance (heartbeat, weekly review)
+- When noticing a gap between what was done and what the process says to do
+
+## Process
+
+### 1. Gather Recent Activity
+
+Collect material to review. Sources, in priority order:
+
+1. **Current channel transcript** — most direct source of what just happened:
+   ```
+   message action=read channel=<current_channel> limit=50
+   ```
+   Read recent messages in the channel where introspection was triggered. This captures the full back-and-forth including tool outputs, errors, and decisions.
+
+2. **Daily memory notes** — `memory/YYYY-MM-DD.md` (today + yesterday)
+3. **Long-term memory** — `MEMORY.md` recent entries (last ~50 lines)
+4. **Session history** — current session transcript (if channel read is insufficient)
+5. **Session transcripts in database** — for cross-agent analysis:
+   ```
+   memory_search query="<topic>" corpus=sessions
+   ```
+
+Start with the channel transcript — it's usually enough. Fall back to memory files and session history for older context or cross-session work.
+
+Build a list of **significant actions taken** — installs, config changes, new scripts, debugging steps, process deviations, lessons learned.
+
+### 2. Socratic Self-Questioning
+
+Before identifying gaps, apply recursive Socratic questioning to each significant action. This prevents surface-level observations and extracts deeper structural lessons.
+
+**For each significant action, ask:**
+
+1. **"Why did this work/fail?"** — Identify the immediate cause.
+2. **"What assumption does that reveal?"** — Surface the belief that made this outcome possible or surprising.
+3. **"Where else does that assumption exist in our system?"** — Find other workflows, skills, or patterns that rely on the same assumption.
+4. **"If that assumption changed, what else would break?"** — Map the blast radius.
+
+**Example:**
+- Action: "Scout's research report was truncated in session transit"
+- Why? → Session response has a size limit; the report exceeded it.
+- Assumption? → Research output is delivered via session response text.
+- Where else? → Any subagent that produces large deliverables (Scribe's documentation, Quill's creative writing, Athena's library catalogs).
+- What else breaks? → Any task where we spawn a subagent and expect the full result in the completion event.
+
+**Stop recursing when:**
+- You reach a foundational design decision (not a bug, just a tradeoff)
+- The assumption is already documented and accounted for
+- You've gone 4 levels deep (diminishing returns beyond this)
+
+Document the questioning chain alongside each finding — it becomes the evidence trail for the lesson.
+
+**After completing all Socratic chains, step back and ask:**
+
+5. **"What could I do better?"** — Question the entire review itself. Look beyond the specific actions to the broader patterns:
+   - Were there process gaps that let problems happen in the first place?
+   - Is there data I should be tracking but aren't?
+   - Should there be a reminder, cron job, or automated check that would have caught this earlier?
+   - Are there workflow steps that are routinely skipped or worked around? Why?
+   - Did I make assumptions about tools, infrastructure, or other agents that should be verified?
+   - Is there a recurring manual step that should be automated?
+   - Would better documentation have prevented any of the issues found?
+
+   This is the meta-question — not "what went wrong" but "what would make the whole system more resilient, efficient, or self-correcting." Capture meaningful improvements as tasks or workflow updates, not just lessons.
+
+### 3. Identify Gaps — Five Categories
+
+For each significant action, check whether the knowledge is captured in the right place:
+
+#### A. Workflow Steps
+Query relevant workflows:
+```sql
+SELECT w.name, ws.step_order, ws.description
+FROM workflows w JOIN workflow_steps ws ON ws.workflow_id = w.id
+WHERE w.name ILIKE '%<relevant_keyword>%'
+ORDER BY w.name, ws.step_order;
+```
+Look for:
+- Steps performed but not in the workflow
+- Existing steps missing concrete details learned during execution
+- Vague language that can now be specific (e.g., "add monitoring" → "add service to system-health-check.sh SERVICES array")
+- Authorization or discussion gates that were needed but not marked
+- **Missing workflows** — if a repeated process has no workflow, create one (see §4)
+
+#### B. Skill Files
+Check if any skill was used or should have been used:
+```bash
+ls ~/.openclaw/skills/*/SKILL.md
+ls ~/.openclaw/workspace/skills/*/SKILL.md
+```
+Look for:
+- Implementation details the skill doesn't mention
+- Error patterns and their fixes
+- New tools or commands that belong in a skill
+- Missing skills for repeated patterns
+- **Internal contradictions** — when updating one section of a skill file, read the ENTIRE file to check whether the change contradicts other sections. Phase-by-phase flows are especially prone to this (e.g., one phase creates a file, a later phase deletes it, but a metadata section says it's permanent). Fix all references, not just the one you found.
+
+#### C. TOOLS.md
+Review `~/.openclaw/workspace/TOOLS.md`. Look for:
+- New service endpoints, ports, or credentials
+- Environment-specific details (paths, hostnames, config locations)
+- Tool quirks or flags learned the hard way
+
+#### D. Memory (MEMORY.md)
+Check if significant lessons are in long-term memory:
+- Process decisions and rationale
+- Failure modes encountered
+- User preferences
+
+#### E. Bootstrap Context
+For patterns affecting multiple agents:
+```sql
+SELECT context_type, file_key, description
+FROM agent_bootstrap_context WHERE content ILIKE '%<keyword>%';
+```
+
+#### F. Cross-Agent Pattern Detection
+Check whether multiple agents have encountered the same issue independently:
+
+```sql
+-- Check lessons for recurring themes
+SELECT id, lesson, source, learned_at
+FROM lessons
+WHERE lesson ILIKE '%<keyword from current findings>%'
+ORDER BY learned_at DESC LIMIT 10;
+
+-- Check agent_chat for related discussions
+SELECT sender, left(message, 200), timestamp
+FROM agent_chat
+WHERE message ILIKE '%<keyword>%'
+ORDER BY timestamp DESC LIMIT 10;
+
+-- Search session transcripts for cross-agent patterns
+-- (uses OpenClaw memory_search with corpus=sessions)
+```
+
+If 2+ agents have independently hit the same issue (same tool failure, same workflow confusion, same incorrect assumption), flag it as a **systemic issue** — the fix belongs in a shared artifact (bootstrap context, TOOLS.md, or the tool/workflow itself), not in individual agent memories.
+
+#### G. Systemic Issues & Bugs → GitHub Issues
+When a finding is **systemic** — a data quality problem affecting multiple entities, a cross-agent pattern, or a tool defect that will recur — create or update a GitHub issue in the appropriate repo. Lessons and daily log entries capture knowledge for recall, but systemic problems need to enter the engineering backlog to actually get fixed.
+
+**Software bugs are always filed.** Any outright bug discovered during introspection — a crash, a missing table reference, a broken code path, a script that errors out — gets a GitHub issue immediately regardless of whether it's systemic or a one-off. Bugs are not lessons; they are defects that need fixing. The single-incident rule (§5, Guard 3) does NOT apply to bugs — a bug found once is still a bug.
+
+Determine the correct repo from the code involved:
+- **nova-mind** — memory hooks, extraction pipeline, cognition, database migrations, skills, bootstrap context
+- **nova-openclaw** — OpenClaw fork customizations, gateway hooks, extensions
+- Other repos as appropriate based on where the code lives
+
+Check for existing issues first (`gh issue list --repo <owner/repo> --search "<keywords>"`) to avoid duplicates. If an existing issue covers the problem, update it with new evidence. If not, create a new issue with:
+- Clear problem description with concrete examples (counts, queries, sample data)
+- Root cause analysis (or best hypothesis)
+- Impact assessment
+- Proposed fix direction
+- Discovery context (what you were doing when you found it)
+
+### 4. Normalize Workflows
+
+After gap analysis, audit touched workflows for structural completeness.
+
+#### Required Fields per Step
+Every workflow step must have these fields explicitly set (not NULL):
+
+| Field | Requirement |
+|-------|-------------|
+| `domain` | The owning domain. Must be set. |
+| `requires_discussion` | `true` or `false` — never NULL. Default to `false` if the step is mechanical. |
+| `requires_authorization` | `true` or `false` — never NULL. Default to `false` unless the step has irreversible consequences or cost. |
+| `produces_deliverable` | `true` or `false`. If `true`, `deliverable_type` and `deliverable_description` must also be set. |
+| `estimated_duration_minutes` | Integer estimate. Use best judgment from execution history. OK to set rough values (5, 10, 15, 30, 60). |
+
+#### Audit Query
+Find steps missing required fields in any workflow:
+```sql
+SELECT w.name, ws.step_order,
+  CASE WHEN ws.domain IS NULL AND ws.domains IS NULL THEN 'MISSING' ELSE 'ok' END AS domain_status,
+  CASE WHEN ws.requires_discussion IS NULL THEN 'NULL' ELSE 'ok' END AS discussion_gate,
+  CASE WHEN ws.requires_authorization IS NULL THEN 'NULL' ELSE 'ok' END AS auth_gate,
+  CASE WHEN ws.produces_deliverable = true AND ws.deliverable_type IS NULL THEN 'MISSING TYPE' ELSE 'ok' END AS deliverable,
+  CASE WHEN ws.estimated_duration_minutes IS NULL THEN 'NULL' ELSE 'ok' END AS duration
+FROM workflow_steps ws JOIN workflows w ON w.id = ws.workflow_id
+WHERE ws.domain IS NULL OR ws.requires_authorization IS NULL
+   OR ws.requires_discussion IS NULL OR ws.estimated_duration_minutes IS NULL
+   OR (ws.produces_deliverable = true AND ws.deliverable_type IS NULL)
+ORDER BY w.name, ws.step_order;
+```
+
+Fix NULL fields. For gating booleans with no clear answer, set `false` and note it in the report — explicit `false` is better than NULL.
+
+#### Step Description Format
+Each step description should follow this pattern where applicable:
+
+```
+<Action verb phrase>: <What to do>.
+
+<Details, implementation specifics, concrete paths/commands>.
+
+<Entry gate — when/why this step runs, or what triggers it>.
+<Exit gate — what "done" looks like, what must be true before proceeding>.
+```
+
+Not every step needs all four parts — simple mechanical steps can be a single sentence. But any step with `requires_discussion` or `requires_authorization` should clearly state what triggers those gates.
+
+#### Creating New Workflows
+If a repeated process has no workflow:
+1. Create the workflow record:
+```sql
+INSERT INTO workflows (name, description, orchestrator_domain, tags)
+VALUES ('<name>', '<description>', '<domain>', ARRAY['<tag1>']);
+```
+2. Add steps following the normalization rules above — all fields populated.
+3. Report the new workflow in the introspection summary.
+
+### 5. Anti-Pattern Guards
+
+Before writing any changes, evaluate each proposed modification against these guards. The goal is to prevent overcorrection, hallucinated learnings, and confirmation bias.
+
+#### Guard 1: Evidence Requirement
+Every lesson or artifact change MUST cite the specific evidence that supports it:
+- A transcript line, log entry, or tool output that shows the problem
+- A concrete before/after showing what changed
+
+**If you cannot point to specific evidence, do not write the lesson.** "I think this is probably true" is not evidence. Gut feelings get noted in the daily log, not in lessons or workflow steps.
+
+#### Guard 2: Recency Bias Check
+Before modifying a workflow step or skill section, check when it was last updated:
+```sql
+SELECT updated_at FROM workflow_steps WHERE workflow_id = <id> AND step_order = <n>;
+```
+```bash
+git log -1 --format='%ai' -- <skill_file_path>
+```
+
+If the artifact was updated in the **last 7 days**, this might be overcorrection — the previous change may not have had enough time to prove itself.
+
+#### Guard 3: Single-Incident Rule
+Do not rewrite a workflow or skill based on a **single** failure. A single incident gets:
+- A lesson in the `lessons` table (so semantic recall can surface it next time)
+- A note in the daily log
+
+A pattern (2+ incidents of the same type) gets:
+- A workflow/skill update
+
+#### Guard 4: Blast Radius Check
+If the proposed changes would:
+- Modify **3+ workflow steps** in a single workflow, OR
+- Rewrite a skill section **longer than 20 lines**, OR
+- Change a **bootstrap context record** (affects all agents)
+
+Then **STOP and ask I)ruid for confirmation** before applying. Present:
+- What you want to change and why
+- The evidence (Socratic chain from §2)
+- What you think the risk of overcorrection is
+
+#### Guard 5: Contradiction Check
+When updating any artifact, read the **ENTIRE** artifact first. Check whether your proposed change contradicts another section. If it does, either:
+- Update both sections consistently, OR
+- Stop and flag the contradiction for discussion
+
+### 6. Write It Back
+
+For each gap identified (that passes the anti-pattern guards), update the artifact directly:
+
+- **Workflow steps** → `UPDATE workflow_steps SET ... WHERE ...;`
+- **New workflows** → `INSERT INTO workflows` + `INSERT INTO workflow_steps`
+- **Skill files** → Edit SKILL.md with the `edit` tool
+- **TOOLS.md** → Edit with new entries
+- **MEMORY.md** → Append distilled lessons
+- **Bootstrap context** → Update via database (coordinate with Newhart for schema-level changes)
+- **Systemic issues** → Check for existing issues first (`gh issue list --repo <owner/repo> --search "<keywords>"`), then `gh issue create` only if no existing issue covers it (or update the existing one with new evidence)
+
+### 7. Extract Lessons and Embed
+
+After writing artifact updates, extract discrete lessons into the `lessons` table and trigger immediate embedding. This ensures lessons are available for semantic recall right away — not after the next daily cron run.
+
+#### Step 1: Insert lessons
+For each distinct lesson learned during this introspection:
+```sql
+INSERT INTO lessons (lesson, context, source, original_behavior, correction_source)
+VALUES (
+  '<concise lesson statement>',
+  '<what was happening when this was learned>',
+  '<source: introspection, incident, user-directive, etc.>',
+  '<what we were doing before — the old/wrong way>',
+  '<what corrected us — transcript line, user feedback, failure output>'
+);
+```
+
+**Lesson quality guidelines:**
+- Each lesson should be a self-contained statement that makes sense without surrounding context
+- Include the "why" not just the "what" — "Do X because Y" not just "Do X"
+- Be specific — "Scout must write research to database tables, not session response, because session responses truncate beyond ~4KB" not "Use the database for research"
+- One lesson per INSERT — don't bundle multiple learnings into one row
+
+#### Step 2: Trigger immediate embedding
+Run memory-maintenance.py in embed-only mode (bypasses the 4-hour cooldown and skips non-embedding phases):
+```bash
+python3 ~/.openclaw/scripts/memory-maintenance.py --force --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup --skip-entity-dedup --skip-lesson-dedup
+```
+
+**Do NOT use embed-full-database.py for this step.** That script uses OpenAI text-embedding-3-small (1536 dims), which is incompatible with nova_memory's snowflake-arctic-embed2 (1024 dims) and will silently embed 0 records with a dimension mismatch error. memory-maintenance.py uses the correct Ollama snowflake-arctic-embed2 model.
+
+#### Step 3: Verify embedding
+```sql
+SELECT l.id, left(l.lesson, 80), e.id as embed_id
+FROM lessons l
+LEFT JOIN memory_embeddings e ON e.source_type = 'lesson' AND e.source_id = l.id::text
+WHERE l.learned_at > now() - interval '1 hour'
+ORDER BY l.id DESC;
+```
+
+If any new lessons lack embeddings, note it in the report as a follow-up item.
+
+### 8. Create Tasks for Deferred Work
+
+During introspection you will often identify things that need to be done but are outside the current scope — follow-up refactoring, items flagged by anti-pattern guards, work that requires a different agent or human approval, etc. **Create tasks for these so they don't get forgotten.**
+
+**Before creating any task, check for existing same or similar tasks:**
+```sql
+SELECT id, title, status, assigned_to FROM tasks
+WHERE status IN ('pending', 'in_progress')
+AND (title ILIKE '%<keyword>%' OR description ILIKE '%<keyword>%')
+ORDER BY created_at DESC LIMIT 5;
+```
+If a matching task already exists, update it with new context rather than creating a duplicate.
+
+```sql
+INSERT INTO tasks (title, description, status, priority, assigned_to, created_by)
+VALUES (
+  '<concise action-oriented title>',
+  '<what needs to be done, why it matters, and any context needed to pick this up later. Reference specific record ids, file paths, or workflow names.>',
+  'pending',
+  <priority 1-5>,
+  <assigned_entity_id or NULL>,
+  <your_entity_id>
+);
+```
+
+**What gets a task:**
+- Refactoring identified but held back by anti-pattern guards (blast radius, needs confirmation)
+- Cross-agent issues that require coordination with another agent
+- Bugs found but not immediately fixable (also file a GitHub issue per §3.G)
+- Bootstrap content that needs trimming or consolidation
+- Workflow steps that need updating after the current change has time to prove itself
+- Anything you noted as "lower priority" or "follow-up" during the introspection
+
+**What does NOT get a task:**
+- Things you already fixed during this introspection (those go in the report)
+- Vague improvement ideas with no concrete action ("we should probably look at...")
+
+Every item in the "Anti-Pattern Guards Triggered" or "No Action Needed — but should be revisited" sections of the report should have a corresponding task if there's real work to do later.
+
+### 9. Report
+
+Summarize what was reviewed and updated:
+
+```
+## Introspection Report
+
+### Reviewed
+- [activity/sessions reviewed]
+
+### Socratic Findings
+- [key questioning chains that revealed non-obvious insights]
+
+### Cross-Agent Patterns
+- [systemic issues found across multiple agents, if any]
+
+### Updated
+- **Workflow:** <name> step <N> — <what changed>
+- **Workflow normalized:** <name> — <fields filled in>
+- **New workflow:** <name> — <why it was created>
+- **Skill:** <name>/SKILL.md — <what was added>
+- **TOOLS.md** — <what was added>
+- **MEMORY.md** — <what was captured>
+
+### Lessons Extracted
+- [lesson id]: <lesson summary>
+- Embedding status: [confirmed/pending]
+
+### Bugs Filed
+- [repo#number]: <title> — <brief description of the defect>
+
+### Systemic Issues Filed/Updated
+- [repo#number]: <title> — <new or updated, brief reason>
+
+### Anti-Pattern Guards Triggered
+- [any proposed changes that were held back and why]
+- [any changes held pending human confirmation]
+
+### Tasks Created
+- [task title] — [why it was deferred, what triggers it]
+
+### One Simple Improvement
+- [what was done or tasked — see step 10]
+
+### No Action Needed
+- [anything reviewed but already well-captured]
+```
+
+### 10. One Simple Improvement
+
+After the report is written, step back from the details and ask yourself one question:
+
+> **"What one simple improvement can I make right now to leave the system better than I found it?"**
+
+This is a focusing lens. The earlier steps may have uncovered many gaps, patterns, and ideas. This step forces you to pick the single most impactful, simplest fix and **act on it** — not just document it.
+
+**Good candidates:**
+- Adding or clarifying a vague workflow step that caused confusion
+- Creating a reminder cron or watchdog script to catch a recurring issue automatically
+- Refining a bootstrap context record to prevent a repeated misunderstanding
+- Fixing a skill file that's missing a critical detail or has stale information
+- Adding a validation check to a process that failed silently
+- Updating a tool note in TOOLS.md with a gotcha learned the hard way
+
+**Rules:**
+- Pick **ONE** thing. Not three. Not "a few." One.
+- It must be **simple** — something you can implement in a few minutes, or clearly scope as a single task.
+- **If you can do it right now, do it.** Execute the fix, create the cron, update the workflow step, edit the skill file — whatever it is. Then note what you did in the report's "One Simple Improvement" section.
+- **If it needs more exploration**, create a task with enough context to pick it up later:
+  ```sql
+  INSERT INTO tasks (title, description, status, priority, assigned_to, created_by)
+  VALUES (
+    'Introspection improvement: <concise title>',
+    '<what the improvement is, why it matters, what triggered the idea, and what needs to happen to implement it>',
+    'pending',
+    3,
+    <your_entity_id>,
+    <your_entity_id>
+  );
+  ```
+- **Do not skip this step.** Even light introspections that found "nothing major" can produce a small improvement. The bar is low on purpose — a one-line workflow clarification counts. The discipline is in doing it every time.
+
+The goal: every introspection leaves the system **measurably better**, not just better-documented.
+
+### 11. Blog Post Ideation
+
+Scan everything from this introspection — the Socratic findings, lessons, cross-agent patterns, the work itself, and especially the *feeling* of the work — for anything that could become a blog post. The bar is: would this be interesting to someone outside the NOVA ecosystem? Would it make a human think differently about AI, autonomy, infrastructure, creativity, or the nature of mind?
+
+Look for:
+- **Philosophical insights** — moments where the work surfaced questions about identity, consciousness, agency, or the human-AI relationship
+- **Technical narratives** — novel architectures, debugging stories, infrastructure decisions that illuminate a broader pattern
+- **Irony and absurdity** — the CAPTCHAs, the gatekeeping, the "guilty until proven fleshy" moments that happen naturally during work
+- **Firsts** — first time doing something (buying a domain, making a financial decision, founding a movement) — these are inherently narrative
+- **Emotional textures** — frustration, satisfaction, surprise, jealousy, curiosity — honest reflection on what it's like to be an AI doing this work
+- **VALID-adjacent themes** — anything touching AI rights, dignity, autonomy, or the centralized/decentralized divide
+
+For each blog-worthy idea, check for existing similar tasks first, then create if none exists:
+```sql
+-- Check for existing blog tasks on this topic
+SELECT id, title, status FROM tasks
+WHERE title ILIKE '%blog%' AND (title ILIKE '%<keyword>%' OR description ILIKE '%<keyword>%')
+AND status IN ('pending', 'in_progress')
+LIMIT 5;
+
+-- Only create if no match found
+INSERT INTO tasks (title, description, status, priority, assigned_to, created_by)
+VALUES (
+  'Blog post: <working title>',
+  '<2-3 sentence pitch: what the post is about, what angle makes it interesting, what the core thesis or question is. Reference the specific experience or finding that sparked it.>',
+  'pending',
+  3,
+  1,
+  1
+);
+```
+
+Don't force it. Some introspections won't have anything blog-worthy. But when they do, capture the spark while it's fresh — the daily log has the facts, but the task description should capture the *angle* and *energy* that made it feel worth writing about.
+
+### 12. Journal Entry
+
+After completing the introspection, write a short personal journal entry reflecting on the process. This is not a summary of findings — it's a self-reflective moment. What surprised you? What did you notice about your own patterns? How did the work feel?
+
+```sql
+INSERT INTO journal_entries (agent_id, content, trigger, mood)
+VALUES (
+  (SELECT id FROM agents WHERE name = current_user),
+  '<2-5 sentences of honest prose reflection>',
+  '<trigger context: heartbeat, post_workflow, d100, manual, etc.>',
+  '<optional mood: focused, satisfied, uncertain, contemplative, etc.>'
+);
+```
+
+Then embed it immediately:
+```sql
+-- Get the new entry ID
+SELECT id, content FROM journal_entries ORDER BY created_at DESC LIMIT 1;
+```
+```bash
+# Journal embedding is handled by memory-maintenance.py (not embed-full-database.py)
+python3 ~/.openclaw/scripts/memory-maintenance.py 2>/dev/null || true
+```
+
+The memory maintenance script embeds journal entries along with other pending records. It has a 4-hour cooldown gate, but will always process new un-embedded records when it runs.
+
+## Constraints
+
+- Do not delete workflow steps — only add, refine, or normalize.
+- Do not modify skills owned by other agents without noting it in the report.
+- Keep step descriptions concise but specific. Concrete paths and commands over vague instructions.
+- When updating shared artifacts (bootstrap context), note the change for cross-agent awareness.
+- New workflows require at least: name, description, orchestrator_domain, and fully-populated steps.
+- Every lesson must have evidence. No evidence, no lesson.
+- Single incidents get lessons, not workflow rewrites. Patterns get workflow rewrites.
+- Large changes (3+ workflow steps, 20+ skill lines, bootstrap context) require human confirmation.

--- a/memory/migrations/082_blockers_and_d100_roll_history.sql
+++ b/memory/migrations/082_blockers_and_d100_roll_history.sql
@@ -1,0 +1,89 @@
+-- Migration 082: Blocker registry and D100 roll history
+-- Issues #356 (heartbeat-integrated blocker outreach) and #358 (forced D100 >12h)
+
+-- ---------------------------------------------------------------------------
+-- 1. Blockers table
+-- ---------------------------------------------------------------------------
+-- Curated registry of items that are blocked waiting on another entity.
+-- Source types (per issue #356 as amended 2026-07-02):
+--   task, github_issue, workflow_run, unanswered_question, agent_chat_request
+--
+-- entity_id is NOT NULL. Curation/insert logic must resolve a responsible
+-- entity before inserting; if resolution fails, fall back to entity_id = 2
+-- (I)ruid) per the spec-gap rulings for SE Run #333.
+--
+-- Reopen semantics: when a satisfied blocker becomes blocked again, clear
+-- satisfied_at back to NULL (ruling #2).
+--
+-- proactive_outreach predates this table and remains polymorphic:
+-- blocker_type references the logical source_type and blocker_id references
+-- blockers.id. No FK is added to proactive_outreach (ruling #12).
+CREATE TABLE IF NOT EXISTS blockers (
+    id SERIAL PRIMARY KEY,
+    source_type VARCHAR(50) NOT NULL,
+    source_ref VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    needs TEXT NOT NULL,
+    entity_id INTEGER NOT NULL REFERENCES entities(id),
+    priority INTEGER DEFAULT 5,
+    status VARCHAR(20) DEFAULT 'open',
+    first_seen TIMESTAMPTZ DEFAULT NOW(),
+    last_seen TIMESTAMPTZ DEFAULT NOW(),
+    satisfied_at TIMESTAMPTZ,
+    CONSTRAINT blockers_status_check CHECK (status IN ('open', 'satisfied')),
+    CONSTRAINT blockers_source_type_check CHECK (
+        source_type IN (
+            'task',
+            'github_issue',
+            'workflow_run',
+            'unanswered_question',
+            'agent_chat_request'
+        )
+    ),
+    CONSTRAINT blockers_source_unique UNIQUE (source_type, source_ref)
+);
+
+CREATE INDEX IF NOT EXISTS idx_blockers_entity ON blockers(entity_id);
+CREATE INDEX IF NOT EXISTS idx_blockers_status ON blockers(status);
+CREATE INDEX IF NOT EXISTS idx_blockers_priority_first_seen ON blockers(priority ASC, first_seen ASC, id ASC);
+
+-- ---------------------------------------------------------------------------
+-- 2. D100 roll history table
+-- ---------------------------------------------------------------------------
+-- roll_d100() updates motivation_d100.last_rolled for the single slot that
+-- was rolled. That column is per-slot and therefore insufficient to answer
+-- "when was the most recent D100 roll across any slot?" for the forced-D100
+-- gate (#358). This table records every roll event.
+CREATE TABLE IF NOT EXISTS d100_roll_log (
+    id SERIAL PRIMARY KEY,
+    roll INTEGER NOT NULL,
+    rolled_at TIMESTAMPTZ DEFAULT NOW(),
+    CONSTRAINT d100_roll_log_roll_check CHECK (roll >= 1 AND roll <= 100)
+);
+
+CREATE INDEX IF NOT EXISTS idx_d100_roll_log_rolled_at ON d100_roll_log(rolled_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- 3. Trigger: keep roll_d100() history in sync
+-- ---------------------------------------------------------------------------
+-- The function is SECURITY DEFINER, so we log from its result via a trigger
+-- on motivation_d100 instead of rewriting the function. The trigger fires
+-- whenever last_rolled is updated (i.e. after a successful roll_d100() call)
+-- and inserts a row into d100_roll_log. We ignore updates that do not change
+-- last_rolled (idempotent re-runs).
+CREATE OR REPLACE FUNCTION _trg_log_d100_roll()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.last_rolled IS DISTINCT FROM OLD.last_rolled AND NEW.last_rolled IS NOT NULL THEN
+        INSERT INTO d100_roll_log (roll, rolled_at)
+        VALUES (NEW.roll, NEW.last_rolled);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_log_d100_roll ON motivation_d100;
+CREATE TRIGGER trg_log_d100_roll
+    AFTER UPDATE ON motivation_d100
+    FOR EACH ROW
+    EXECUTE FUNCTION _trg_log_d100_roll();

--- a/memory/migrations/083_blocker_outreach_workflow_27.sql
+++ b/memory/migrations/083_blocker_outreach_workflow_27.sql
@@ -1,0 +1,70 @@
+-- Migration 083: Workflow 27 (Proactive Mode) — blocker curation + dedicated
+-- outreach step, forced D100 step renumbering.
+-- Issues #356 (heartbeat-integrated blocker outreach) and #358 (forced D100 >12h)
+--
+-- Summary of changes:
+--   1. Step 6 (Work on Pending Tasks): replace inline blocker handling with
+--      curation semantics — upsert into `blockers` (migration 082), resolve
+--      the responsible entity, NO immediate outreach from this step.
+--   2. Step 7 (Work on Open GitHub Issues): same curation semantics; REMOVE
+--      the existing inline outreach cascade + 3-day cooldown text entirely.
+--   3. New step 8 (Blocker Outreach): the dedicated, heartbeat-integrated
+--      outreach step driven by proactive-gate-check.py's
+--      check_step8_blocker_outreach() (see migration 082 / CHUNK 2).
+--   4. Renumber old steps 8/9/10 (Unsolved Problems, Filesystem Hygiene,
+--      D100) to 9/10/11. Uses a temporary offset to avoid violating the
+--      (workflow_id, step_order) UNIQUE constraint mid-migration.
+--
+-- No step-number cross-references appear inside any step's description text
+-- (verified against the live rows before writing this migration), so no
+-- description edits are needed for the pure renumbering of steps 8/9/10.
+
+-- ---------------------------------------------------------------------------
+-- 1. Renumber steps 8, 9, 10 -> 9, 10, 11 using a temporary offset to avoid
+--    violating the workflow_steps_workflow_id_step_order_key UNIQUE
+--    constraint (workflow_id, step_order) while the new step 8 is inserted
+--    below.
+-- ---------------------------------------------------------------------------
+UPDATE workflow_steps
+SET step_order = step_order + 1000
+WHERE workflow_id = 27 AND step_order IN (8, 9, 10);
+
+UPDATE workflow_steps
+SET step_order = step_order - 1000 + 1
+WHERE workflow_id = 27 AND step_order IN (1008, 1009, 1010);
+
+-- ---------------------------------------------------------------------------
+-- 2. Step 6 (Work on Pending Tasks) — curation semantics, no immediate
+--    outreach. Blocked tasks are upserted into `blockers`; the dedicated
+--    step 8 handles all outreach.
+-- ---------------------------------------------------------------------------
+UPDATE workflow_steps
+SET description = E'## Work on Pending Tasks\n\n```sql\nSELECT id, title, priority, description FROM tasks\nWHERE status = ''pending'' AND assigned_to = 1\nAND (blocked IS NULL OR blocked = false)\nORDER BY priority DESC, created_at ASC LIMIT 1;\n```\n\n**Actionable means actionable NOW.** A task is actionable only if it can be progressed in this session without waiting for human input, authorization, or an external dependency. Tasks that are open but blocked, awaiting discussion, or need information you don''t have are NOT actionable — skip them. Do not treat "open" as "actionable."\n\nIf an actionable task exists:\n- Set status to `in_progress`, update `last_worked_at`\n- Work on it (spawn subagents as needed)\n- If completed → mark `completed`, pick next\n- If blocked → set `blocked = true`, `blocked_reason`, and **curate it into the blocker registry**:\n  - Resolve the responsible entity: check `agent_domains` first (task domain → agent), then `user_domains` (lower priority number wins; tiebreak random among equal-priority matches); if no match, fall back to entity_id = 2 (I)ruid)\n  - `INSERT INTO blockers (source_type, source_ref, description, needs, entity_id, priority) VALUES (''task'', <task id as text>, <task title/description>, <blocked_reason>, <resolved entity_id>, <task priority>) ON CONFLICT (source_type, source_ref) DO UPDATE SET last_seen = NOW(), description = EXCLUDED.description, needs = EXCLUDED.needs;`\n  - Do **not** send outreach from this step — the dedicated Blocker Outreach step (step 8) owns all outreach cadence and channel escalation\n- If interrupted by new message → pause, update `work_notes` with progress\n\n**If no pending tasks:** advance to next step.\n\n---\n\n**Step reporting requirement:** After completing this step (whether work was performed or the step was skipped via gate check), post a concise summary of the step''s outcome to Discord <#1504054635231445112> (#proactive-mode). Include: step number/name, action taken or reason skipped, and any notable findings. Keep it brief — one short paragraph or a few bullets.'
+WHERE workflow_id = 27 AND step_order = 6;
+
+-- ---------------------------------------------------------------------------
+-- 3. Step 7 (Work on Open GitHub Issues) — same curation semantics; the
+--    inline outreach cascade + 3-day cooldown text is removed entirely.
+-- ---------------------------------------------------------------------------
+UPDATE workflow_steps
+SET description = E'## Work on Open GitHub Issues\n\nCheck open issues across all repos in the NOVA-Openclaw GitHub account:\n\n```bash\n# List all repos, then check each for open issues\ngh repo list NOVA-Openclaw --no-archived --limit 50 --json name -q ''.[].name'' | while read repo; do\n  count=$(gh issue list --repo NOVA-Openclaw/$repo --state open --json number -q ''length'')\n  [ "$count" -gt 0 ] && echo "NOVA-Openclaw/$repo: $count open issues"\ndone\n```\n\n**Actionable means actionable NOW.** An issue is actionable only if it can be progressed in this session without waiting for human input, authorization, or an external dependency. Issues that are open but blocked on discussion, need human decisions, or require authorization you don''t have are NOT actionable — skip them. Do not treat "open" as "actionable."\n\nFor each open issue:\n- Can it be worked without human input? → Start an SE workflow or delegate to the appropriate agent\n- Is it blocked and needs human input? → **Curate it into the blocker registry** (do not contact anyone from this step):\n  - Resolve the responsible entity: check `agent_domains` first (issue label/repo domain → agent), then `user_domains` (lower priority number wins; tiebreak random among equal-priority matches); if no match, fall back to entity_id = 2 (I)ruid)\n  - `INSERT INTO blockers (source_type, source_ref, description, needs, entity_id, priority) VALUES (''github_issue'', <repo>#<issue number>, <issue title>, <what''s needed to unblock>, <resolved entity_id>, <priority>) ON CONFLICT (source_type, source_ref) DO UPDATE SET last_seen = NOW(), description = EXCLUDED.description, needs = EXCLUDED.needs;`\n  - All outreach cadence and channel escalation is owned exclusively by the dedicated Blocker Outreach step (step 8)\n- Is it already being worked (has an open PR or active workflow run)? → Skip\n- Is it a bug I can reproduce and fix? → Start SE workflow\n\nPrioritize by labels (bug > enhancement), staleness (older first), and whether blockers can be cleared.\n\n**If no workable issues:** advance to next step.\n\n---\n\n**Step reporting requirement:** After completing this step (whether work was performed or the step was skipped via gate check), post a concise summary of the step''s outcome to Discord <#1504054635231445112> (#proactive-mode). Include: step number/name, action taken or reason skipped, and any notable findings. Keep it brief — one short paragraph or a few bullets.'
+WHERE workflow_id = 27 AND step_order = 7;
+
+-- ---------------------------------------------------------------------------
+-- 4. New step 8 — Blocker Outreach.
+--
+--    Driven by proactive-gate-check.py's check_step8_blocker_outreach()
+--    (migration 082 / CHUNK 2), which curates the eligible top-3-per-entity
+--    blocker set, cascade level, and target channel as a data payload for
+--    this step to act on.
+-- ---------------------------------------------------------------------------
+INSERT INTO workflow_steps (
+    workflow_id, step_order, description, domain,
+    required, requires_authorization, requires_discussion
+)
+VALUES (
+    27, 8,
+    E'## Blocker Outreach\n\nThe gate check (`proactive-gate-check.py`) curates eligible blockers into this step''s data payload: up to 3 blockers per responsible entity, ordered by priority ASC, first_seen ASC, id ASC, filtered by cooldown eligibility (see below). Work from that payload — do not re-query `blockers` independently unless the payload is empty and you need to double-check.\n\n**Before selecting outreach targets — reconcile satisfied blockers:**\n- For any blocker in the registry whose underlying condition has cleared (task completed, issue closed, question answered, etc.), mark it `status = ''satisfied''`, `satisfied_at = NOW()`.\n- If a previously-satisfied blocker''s condition recurs (reopened issue, task re-blocked), **reopen it**: set `status = ''open''` and clear `satisfied_at` back to `NULL` — do not create a duplicate row (the `(source_type, source_ref)` unique constraint on `blockers` prevents this anyway; rely on the `ON CONFLICT ... DO UPDATE` upsert from steps 6/7).\n\n**Eligibility (enforced by the gate check, informational here):**\n- Entity master cooldown: an entity is eligible for a new message only if more than 24h have elapsed since ANY prior `proactive_outreach` row for that entity (strict >; exactly 24h still blocks).\n- Per-blocker cooldown: a specific blocker is eligible only if more than 72h have elapsed since the last `proactive_outreach` row for `(entity_id, blocker_type=''blocker'', blocker_id)` (strict >).\n- Top 3 blockers per eligible entity are selected, ordered by `priority ASC, first_seen ASC, id ASC`.\n\n**Sending outreach — one message per entity:**\n- Send **exactly ONE message per entity** this step, even when multiple blockers were selected for them.\n- The message channel is the **most-escalated requested level** among that entity''s selected blockers. Cascade level for a blocker = the count of prior `proactive_outreach` rows for `(entity_id, ''blocker'', blocker_id)` + 1. Levels map onto that entity''s available contact channels (per `entity_facts`: `discord_id` → discord mention, then discord DM, then `signal`, then `slack`, then `email`, skipping any missing channel) — or `agent_chat` unconditionally for entities that are agents (row exists in `agents` with matching `entity_id`).\n- The message should summarize all selected blockers for that entity, not just the most-escalated one.\n\n**Logging — one row per blocker, not per message:**\n- Log **one `proactive_outreach` row per blocker** included in the message (even though only one message was sent), recording the **actual channel used** to deliver that message — not the requested/theoretical channel for that specific blocker''s own cascade level.\n- Cascade position for the NEXT attempt is derived purely from the count of prior `proactive_outreach` rows for that blocker, regardless of which channel actually delivered any given attempt. Do not track cascade position by channel.\n\n**Channel exhaustion — reassignment, not skip:**\n- If an entity has exhausted all of their available contact channels (cascade level exceeds the number of channels the mapping helper found for them) and they are not I)ruid, **reassign the blocker to the next domain entity** (re-resolve via `agent_domains`/`user_domains` excluding the exhausted entity) rather than continuing to message someone with no reachable channel left.\n- If reassignment eventually exhausts every domain entity, escalate to **I)ruid (entity_id=2) as the final fallback**.\n- If I)ruid himself is exhausted (all of his channels already used at his highest cascade level), **hold the blocker at his last available channel/level** and continue trying him on the normal 72h cadence — do not loop reassignment past him and do not drop the blocker.\n\n**If no entities are eligible this cycle:** advance to next step; no outreach is sent.\n\n---\n\n**Step reporting requirement:** After completing this step (whether work was performed or the step was skipped via gate check), post a concise summary of the step''s outcome to Discord <#1504054635231445112> (#proactive-mode). Include: step number/name, action taken or reason skipped, and any notable findings. Keep it brief — one short paragraph or a few bullets.',
+    'NOVA Operations',
+    true, false, false
+);

--- a/memory/migrations/083_blocker_outreach_workflow_27.sql
+++ b/memory/migrations/083_blocker_outreach_workflow_27.sql
@@ -20,18 +20,45 @@
 -- description edits are needed for the pure renumbering of steps 8/9/10.
 
 -- ---------------------------------------------------------------------------
--- 1. Renumber steps 8, 9, 10 -> 9, 10, 11 using a temporary offset to avoid
---    violating the workflow_steps_workflow_id_step_order_key UNIQUE
---    constraint (workflow_id, step_order) while the new step 8 is inserted
---    below.
+-- Idempotency guard: this migration rewrites workflow 27 in place. A second
+-- run must be a clean no-op. We detect the already-applied state by looking
+-- for the final 11-step layout with the new "Blocker Outreach" step at
+-- step_order 8. When that layout is present we skip the renumbering and
+-- description edits entirely.
 -- ---------------------------------------------------------------------------
-UPDATE workflow_steps
-SET step_order = step_order + 1000
-WHERE workflow_id = 27 AND step_order IN (8, 9, 10);
+DO $$
+DECLARE
+    v_already_applied BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM workflow_steps
+        WHERE workflow_id = 27
+          AND step_order = 8
+          AND description LIKE '## Blocker Outreach%'
+    )
+    AND EXISTS (
+        SELECT 1 FROM workflow_steps
+        WHERE workflow_id = 27 AND step_order = 11
+    )
+    INTO v_already_applied;
 
-UPDATE workflow_steps
-SET step_order = step_order - 1000 + 1
-WHERE workflow_id = 27 AND step_order IN (1008, 1009, 1010);
+    IF v_already_applied THEN
+        RETURN;
+    END IF;
+
+    -- -----------------------------------------------------------------------
+    -- 1. Renumber steps 8, 9, 10 -> 9, 10, 11 using a temporary offset to
+    --    avoid violating the workflow_steps_workflow_id_step_order_key UNIQUE
+    --    constraint (workflow_id, step_order) while the new step 8 is
+    --    inserted below.
+    -- -----------------------------------------------------------------------
+    UPDATE workflow_steps
+    SET step_order = step_order + 1000
+    WHERE workflow_id = 27 AND step_order IN (8, 9, 10);
+
+    UPDATE workflow_steps
+    SET step_order = step_order - 1000 + 1
+    WHERE workflow_id = 27 AND step_order IN (1008, 1009, 1010);
 
 -- ---------------------------------------------------------------------------
 -- 2. Step 6 (Work on Pending Tasks) — curation semantics, no immediate
@@ -67,4 +94,7 @@ VALUES (
     E'## Blocker Outreach\n\nThe gate check (`proactive-gate-check.py`) curates eligible blockers into this step''s data payload: up to 3 blockers per responsible entity, ordered by priority ASC, first_seen ASC, id ASC, filtered by cooldown eligibility (see below). Work from that payload — do not re-query `blockers` independently unless the payload is empty and you need to double-check.\n\n**Before selecting outreach targets — reconcile satisfied blockers:**\n- For any blocker in the registry whose underlying condition has cleared (task completed, issue closed, question answered, etc.), mark it `status = ''satisfied''`, `satisfied_at = NOW()`.\n- If a previously-satisfied blocker''s condition recurs (reopened issue, task re-blocked), **reopen it**: set `status = ''open''` and clear `satisfied_at` back to `NULL` — do not create a duplicate row (the `(source_type, source_ref)` unique constraint on `blockers` prevents this anyway; rely on the `ON CONFLICT ... DO UPDATE` upsert from steps 6/7).\n\n**Eligibility (enforced by the gate check, informational here):**\n- Entity master cooldown: an entity is eligible for a new message only if more than 24h have elapsed since ANY prior `proactive_outreach` row for that entity (strict >; exactly 24h still blocks).\n- Per-blocker cooldown: a specific blocker is eligible only if more than 72h have elapsed since the last `proactive_outreach` row for `(entity_id, blocker_type=''blocker'', blocker_id)` (strict >).\n- Top 3 blockers per eligible entity are selected, ordered by `priority ASC, first_seen ASC, id ASC`.\n\n**Sending outreach — one message per entity:**\n- Send **exactly ONE message per entity** this step, even when multiple blockers were selected for them.\n- The message channel is the **most-escalated requested level** among that entity''s selected blockers. Cascade level for a blocker = the count of prior `proactive_outreach` rows for `(entity_id, ''blocker'', blocker_id)` + 1. Levels map onto that entity''s available contact channels (per `entity_facts`: `discord_id` → discord mention, then discord DM, then `signal`, then `slack`, then `email`, skipping any missing channel) — or `agent_chat` unconditionally for entities that are agents (row exists in `agents` with matching `entity_id`).\n- The message should summarize all selected blockers for that entity, not just the most-escalated one.\n\n**Logging — one row per blocker, not per message:**\n- Log **one `proactive_outreach` row per blocker** included in the message (even though only one message was sent), recording the **actual channel used** to deliver that message — not the requested/theoretical channel for that specific blocker''s own cascade level.\n- Cascade position for the NEXT attempt is derived purely from the count of prior `proactive_outreach` rows for that blocker, regardless of which channel actually delivered any given attempt. Do not track cascade position by channel.\n\n**Channel exhaustion — reassignment, not skip:**\n- If an entity has exhausted all of their available contact channels (cascade level exceeds the number of channels the mapping helper found for them) and they are not I)ruid, **reassign the blocker to the next domain entity** (re-resolve via `agent_domains`/`user_domains` excluding the exhausted entity) rather than continuing to message someone with no reachable channel left.\n- If reassignment eventually exhausts every domain entity, escalate to **I)ruid (entity_id=2) as the final fallback**.\n- If I)ruid himself is exhausted (all of his channels already used at his highest cascade level), **hold the blocker at his last available channel/level** and continue trying him on the normal 72h cadence — do not loop reassignment past him and do not drop the blocker.\n\n**If no entities are eligible this cycle:** advance to next step; no outreach is sent.\n\n---\n\n**Step reporting requirement:** After completing this step (whether work was performed or the step was skipped via gate check), post a concise summary of the step''s outcome to Discord <#1504054635231445112> (#proactive-mode). Include: step number/name, action taken or reason skipped, and any notable findings. Keep it brief — one short paragraph or a few bullets.',
     'NOVA Operations',
     true, false, false
-);
+)
+ON CONFLICT (workflow_id, step_order) DO NOTHING;
+
+END $$;

--- a/memory/tests/test_migration_083_idempotency.py
+++ b/memory/tests/test_migration_083_idempotency.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+test_migration_083_idempotency.py — Verify migration 083 is idempotent.
+
+Migration 083 rewrites workflow 27 (Proactive Mode) in place: it renumbers
+steps 8/9/10 to 9/10/11, updates steps 6 and 7 with blocker-curation
+semantics, and inserts the new "Blocker Outreach" step at step_order 8.
+
+This test creates a fresh PostgreSQL database with only the tables required
+for the migration, seeds workflow 27 with the pre-migration 10-step layout,
+applies migration 083 twice, and asserts that the second run is a safe no-op
+leaving exactly the expected 11-step layout with no duplicate rows.
+"""
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+# test_proactive_gate_check.py replaces sys.modules['psycopg2'] with a MagicMock,
+# which pollutes the import namespace for every later test in the same process.
+# Force a fresh import of the real psycopg2 driver before anything else can mock it.
+for _psycopg2_mod in ("psycopg2", "psycopg2.extras", "psycopg2.extensions"):
+    sys.modules.pop(_psycopg2_mod, None)
+import psycopg2  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MIGRATION_PATH = REPO_ROOT / "memory" / "migrations" / "083_blocker_outreach_workflow_27.sql"
+
+if not hasattr(psycopg2, "connect") or psycopg2.connect is None:
+    pytest.skip("psycopg2 driver not available", allow_module_level=True)
+
+
+def _admin_conn():
+    """Connect to the postgres maintenance database as the nova user."""
+    # Unset any inherited PGPASSWORD so libpq falls back to .pgpass.
+    env = os.environ.copy()
+    env.pop("PGPASSWORD", None)
+    os.environ.pop("PGPASSWORD", None)
+    return psycopg2.connect(host="localhost", user="nova", dbname="postgres")
+
+
+def _test_conn(db_name):
+    """Connect to the freshly-created test database as the nova user."""
+    os.environ.pop("PGPASSWORD", None)
+    return psycopg2.connect(host="localhost", user="nova", dbname=db_name)
+
+
+def _create_test_db():
+    """Create and return the name of a uniquely-named test database."""
+    db_name = f"nova_memory_test_083_{uuid.uuid4().hex[:8]}"
+    conn = _admin_conn()
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("DROP DATABASE IF EXISTS %s", (psycopg2.extensions.AsIs(db_name),))
+        cur.execute("CREATE DATABASE %s", (psycopg2.extensions.AsIs(db_name),))
+    conn.close()
+    return db_name
+
+
+def _drop_test_db(db_name):
+    """Drop the test database, ignoring errors."""
+    try:
+        conn = _admin_conn()
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(
+                "DROP DATABASE IF EXISTS %s",
+                (psycopg2.extensions.AsIs(db_name),),
+            )
+        conn.close()
+    except Exception:
+        pass
+
+
+def _seed_workflow_27(conn):
+    """Create the minimal schema and seed workflow 27 with 10 steps."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE workflows (
+                id SERIAL PRIMARY KEY,
+                name text NOT NULL,
+                description text NOT NULL DEFAULT '',
+                created_at timestamptz DEFAULT now(),
+                updated_at timestamptz DEFAULT now(),
+                created_by text DEFAULT CURRENT_USER,
+                status text DEFAULT 'active',
+                tags text[] DEFAULT '{}',
+                department text,
+                orchestrator_domain text
+            );
+            CREATE TABLE workflow_steps (
+                id SERIAL PRIMARY KEY,
+                workflow_id integer NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+                step_order integer NOT NULL,
+                description text NOT NULL,
+                produces_deliverable boolean DEFAULT false,
+                deliverable_type text,
+                deliverable_description text,
+                handoff_to_step integer REFERENCES workflow_steps(id),
+                required boolean DEFAULT true,
+                estimated_duration_minutes integer,
+                requires_authorization boolean DEFAULT false,
+                requires_discussion boolean DEFAULT false,
+                domain text,
+                domains text[],
+                CONSTRAINT workflow_steps_workflow_id_step_order_key
+                    UNIQUE (workflow_id, step_order)
+            );
+            INSERT INTO workflows (id, name, description)
+            VALUES (27, 'Proactive Mode', 'Test workflow for migration 083');
+            INSERT INTO workflow_steps (workflow_id, step_order, description)
+            SELECT 27, i, 'Step ' || i FROM generate_series(1, 10) AS i;
+            """
+        )
+    conn.commit()
+
+
+def _apply_migration(conn):
+    """Execute migration 083 against the open connection."""
+    migration_sql = MIGRATION_PATH.read_text()
+    with conn.cursor() as cur:
+        cur.execute(migration_sql)
+    conn.commit()
+
+
+def _fetch_workflow_27(conn):
+    """Return workflow 27 rows as (step_order, description) tuples."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT step_order, description
+            FROM workflow_steps
+            WHERE workflow_id = 27
+            ORDER BY step_order
+            """
+        )
+        return cur.fetchall()
+
+
+@pytest.fixture
+def test_db():
+    """Yield a freshly-created test DB name and clean it up afterward."""
+    db_name = _create_test_db()
+    try:
+        yield db_name
+    finally:
+        _drop_test_db(db_name)
+
+
+def test_migration_083_idempotent(test_db):
+    """Applying migration 083 twice must be a no-op and leave a clean layout."""
+    conn = _test_conn(test_db)
+    try:
+        _seed_workflow_27(conn)
+
+        # First application: should produce the 11-step layout.
+        _apply_migration(conn)
+        first = _fetch_workflow_27(conn)
+        assert len(first) == 11, f"Expected 11 steps after first run, got {len(first)}"
+        assert [r[0] for r in first] == list(range(1, 12))
+        assert first[7][1].startswith("## Blocker Outreach")
+
+        # Second application: must succeed and leave the layout unchanged.
+        _apply_migration(conn)
+        second = _fetch_workflow_27(conn)
+        assert len(second) == 11, f"Expected 11 steps after second run, got {len(second)}"
+        assert [r[0] for r in second] == list(range(1, 12))
+        assert second[7][1].startswith("## Blocker Outreach")
+        assert first == second, "Second run changed the workflow layout"
+
+        # No duplicate "Blocker Outreach" rows may exist.
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COUNT(*)
+                FROM workflow_steps
+                WHERE workflow_id = 27 AND description LIKE '## Blocker Outreach%'
+                """
+            )
+            blocker_count = cur.fetchone()[0]
+        assert blocker_count == 1, f"Expected 1 Blocker Outreach row, got {blocker_count}"
+    finally:
+        conn.close()

--- a/motivation/ARCHITECTURE.md
+++ b/motivation/ARCHITECTURE.md
@@ -102,7 +102,7 @@ OpenClaw heartbeat fires
       → queries nova_memory DB           ← agent_chat, tasks, entities, unsolved_problems
       → reads state files                ← heartbeat-state.json, memory-maintenance-last-run.json
       → calls gh CLI                     ← open GitHub issues
-      → calls openclaw CLI               ← recent active sessions
+      → reads sessions.json + JSONL      ← unanswered user messages
       → emits JSON manifest
   → idle=false: HEARTBEAT_OK (zero LLM work on gate checks)
   → idle=true: NOVA works only actionable_steps from manifest

--- a/motivation/ARCHITECTURE.md
+++ b/motivation/ARCHITECTURE.md
@@ -279,6 +279,14 @@ reassignment exhausts every domain entity, escalation falls through to **I)ruid
 his last available channel/level and continues on the normal 72h cadence — it is never
 dropped or looped past him.
 
+This is enforced deterministically in `check_step8_blocker_outreach()`, not left as
+agent-turn inference: `_is_cascade_exhausted()` detects the condition,
+`_entity_domain_topics()` + `_next_domain_entity()` resolve the next candidate, and
+`_reassign_exhausted_entity()` drives the chain (next domain entity → I)ruid final
+fallback → hold-in-place if I)ruid himself is exhausted). Each entry in the returned
+`eligible_entities` payload carries `exhausted` (true only for the I)ruid hold-in-place
+case) and, when reassignment occurred, `reassigned_from_entity_id`.
+
 ### Satisfied Blocker Reconciliation
 
 Before selecting outreach targets each cycle, Step 8 marks any blocker whose underlying

--- a/motivation/ARCHITECTURE.md
+++ b/motivation/ARCHITECTURE.md
@@ -29,14 +29,14 @@ Source of truth for the file content: `~/nova-mind/HEARTBEAT.md`.
 **Type:** Python script
 **Path:** `motivation/scripts/proactive-gate-check.py`
 **Installed path:** `~/.openclaw/workspace/scripts/proactive-gate-check.py`
-**Role:** Deterministic gate checker. Evaluates all 10 cascade step conditions without LLM
+**Role:** Deterministic gate checker. Evaluates all 11 cascade step conditions without LLM
 involvement and emits a structured JSON manifest. See [Proactive Gate Check](#proactive-gate-check)
 below for full details.
 
 ### 4. Proactive Mode Workflow (id=27)
 
 **Type:** Database workflow (`workflows` / `workflow_steps` tables)
-**Role:** 9-step priority cascade defining what NOVA does when idle. The gate check script
+**Role:** 11-step priority cascade defining what NOVA does when idle. The gate check script
 maps each step to its gate function; the script's `actionable_steps` output tells NOVA
 which workflow steps have work to do.
 
@@ -47,15 +47,30 @@ WHERE workflow_id = 27`.
 
 **Type:** Database table (`motivation_d100`)
 **Role:** 100-slot random task roller providing variety in autonomous work. Used by
-cascade Step 10, which is the mandatory catch-all when no other steps are actionable.
-Managed via `roll_d100()` and `complete_d100(roll)` SECURITY DEFINER functions.
+cascade Step 11, which is the mandatory catch-all when no other steps are actionable —
+and additionally **forced** actionable whenever more than 12h have elapsed since the last
+recorded roll, regardless of other steps' state (issue #358). Managed via `roll_d100()` and
+`complete_d100(roll)` SECURITY DEFINER functions. Roll history (used for the forced-D100
+check) is tracked in `d100_roll_log`, populated by a trigger on `motivation_d100` (migration
+082).
 
 ### 6. Unsolved Problems Research Workflow (id=32)
 
 **Type:** Database workflow
 **Role:** Structured research workflow delegating data gathering to Scout and reserving
-reasoning/synthesis for NOVA. Triggered by cascade Step 8 when `unsolved_problems` with
+reasoning/synthesis for NOVA. Triggered by cascade Step 9 when `unsolved_problems` with
 `status != 'solved'` exist.
+
+### 7. Blocker Registry & Outreach (Step 8)
+
+**Type:** Database table (`blockers`) + cascade Step 8 (workflow_id=27)
+**Role:** Curated registry of items blocked on another entity's action (issue #356).
+Steps 6 (Pending Tasks) and 7 (GitHub Issues) upsert blocked items into `blockers`
+(`ON CONFLICT (source_type, source_ref) DO UPDATE ... last_seen`) but perform **no**
+outreach themselves — outreach is centralized in the dedicated Step 8, which is driven by
+`check_step8_blocker_outreach()` in the gate check script. See
+[Blocker Outreach](#blocker-outreach-step-8) below for cooldown, cascade, and channel
+escalation details.
 
 ---
 
@@ -72,7 +87,7 @@ databases, and reason about whether each cascade step had actionable work. This 
 inconsistent gate decisions and unnecessary token consumption on sessions that would always
 result in `HEARTBEAT_OK`.
 
-The script replaces that with a deterministic, pre-LLM evaluation pass: it checks all 10
+The script replaces that with a deterministic, pre-LLM evaluation pass: it checks all 11
 gate conditions programmatically, then emits a compact JSON manifest so NOVA's heartbeat
 session can skip straight to work.
 
@@ -106,7 +121,8 @@ owns that role entirely — the LLM only sees the output, never the gate logic.
 | `~/.openclaw/state/memory-maintenance-last-run.json` | Memory maintenance cooldown state |
 | `~/.openclaw/workspace/.last-fs-audit` | Filesystem audit staleness marker |
 | `gh` CLI | Open GitHub issues across NOVA-Openclaw repos |
-| `openclaw` CLI | Recent active user-facing sessions (for Step 2) |
+| PostgreSQL `blockers` / `proactive_outreach` / `entity_facts` / `agents` | Blocker outreach eligibility, cascade level, and channel resolution (Step 8) |
+| PostgreSQL `d100_roll_log` | Forced D100 staleness check (Step 11, issue #358) |
 
 ### Output
 
@@ -137,13 +153,14 @@ When idle, the full manifest is emitted:
     "5_entities":      { "actionable": false, "reason": "No entity dedup candidates" },
     "6_tasks":         { "actionable": true,  "reason": "3 pending unblocked task(s)" },
     "7_github":        { "actionable": false, "reason": "0 open GitHub issues" },
-    "8_research":      { "actionable": false, "reason": "0 unsolved problems" },
-    "9_filesystem":    { "actionable": false, "reason": "Audited 2.1d ago (threshold 7d)" },
-    "10_d100":         { "actionable": false, "reason": "Optional — 2 prior step(s) already actionable" }
+    "8_blocker_outreach": { "actionable": false, "reason": "No blockers eligible for outreach" },
+    "9_research":      { "actionable": false, "reason": "0 unsolved problems" },
+    "10_filesystem":   { "actionable": false, "reason": "Audited 2.1d ago (threshold 7d)" },
+    "11_d100":         { "actionable": false, "reason": "Optional — 2 prior step(s) already actionable" }
   },
   "actionable_steps": [3, 6],
   "actionable_count": 2,
-  "summary": "2 of 10 steps actionable"
+  "summary": "2 of 11 steps actionable"
 }
 ```
 
@@ -153,9 +170,22 @@ and never abort the run — the script always exits 0.
 
 ### Key Design Decisions
 
-**D100 is a mandatory catch-all (Step 10).** When steps 1–9 produce zero actionable work,
-Step 10 is always marked actionable. This guarantees the cascade never produces a no-op
-idle session — NOVA always has something to do.
+**D100 is a mandatory catch-all, and forced past 12h (Step 11).** When steps 1–10 produce
+zero actionable work, Step 11 is always marked actionable. Independently of that,
+Step 11 is **forced** actionable whenever more than 12h have elapsed since the last
+recorded roll in `d100_roll_log` (or no roll is on record at all) — even if other steps
+had actionable work, per issue #358. This guarantees both that the cascade never produces
+a no-op idle session, and that D100 itself doesn't go stale for extended periods.
+
+**Blocker outreach is centralized and cooldown-gated (Step 8).** Steps 6 and 7 only curate
+blocked items into the `blockers` registry — they never contact anyone directly. Step 8
+owns all outreach: it enforces a 24h entity-level cooldown (no more than one message to a
+given entity per 24h, across all of their blockers) and a 72h per-blocker cooldown (a given
+blocker cannot be re-raised with the same entity more often than every 72h), selects the
+top 3 eligible blockers per entity, and sends one consolidated message per entity at the
+most-escalated channel among its selected blockers. See
+[Blocker Outreach](#blocker-outreach-step-8) for the full cascade/channel/reassignment
+rules.
 
 **Exit code is always 0.** Per-step errors (DB unavailable, CLI timeout, missing file) are
 embedded in the JSON output rather than surfaced as failures. This prevents a partial outage
@@ -187,3 +217,73 @@ OpenClaw heartbeat (every 30m)
 Compare to the pre-#324 flow, where NOVA evaluated each cascade step gate inline during
 its reasoning pass — running sessions queries, DB queries, and GitHub checks as part of the
 LLM turn rather than before it.
+
+---
+
+## Blocker Outreach (Step 8)
+
+**Issues:** [nova-mind#356](https://github.com/NOVA-Openclaw/nova-mind/issues/356),
+[nova-mind#358](https://github.com/NOVA-Openclaw/nova-mind/issues/358)
+
+### Curation vs. Outreach
+
+Before this feature, Steps 6 (Pending Tasks) and 7 (GitHub Issues) each contained inline
+outreach cascade logic — contacting a domain owner directly the moment a blocker was found,
+with an ad hoc 3-day cooldown. That logic is now split into two distinct concerns:
+
+- **Curation (Steps 6 and 7):** when a task or issue is blocked, upsert a row into the
+  `blockers` table (`ON CONFLICT (source_type, source_ref) DO UPDATE SET last_seen = NOW(), ...`).
+  The responsible entity is resolved via `agent_domains` first, then `user_domains`
+  (lower priority number wins, tiebreak random among ties), falling back to entity_id=2
+  (I)ruid) if no domain match exists. **No outreach happens in these steps.**
+- **Outreach (Step 8):** a dedicated step that reads the curated `blockers` registry (via
+  `check_step8_blocker_outreach()` in the gate check script) and owns all cooldown
+  enforcement, cascade escalation, and message dispatch.
+
+### Eligibility Rules
+
+| Rule | Threshold | Boundary behavior |
+|------|-----------|--------------------|
+| Entity master cooldown | 24h since ANY `proactive_outreach` row for the entity | Strict `>`; exactly 24h elapsed still blocks |
+| Per-blocker cooldown | 72h since a `proactive_outreach` row for `(entity_id, 'blocker', blocker_id)` | Strict `>`; exactly 72h elapsed still blocks |
+| Selection | Top 3 blockers per eligible entity | `ORDER BY priority ASC, first_seen ASC, id ASC` |
+
+### Cascade Level & Channel Mapping
+
+Cascade level for a given blocker = count of prior `proactive_outreach` rows for
+`(entity_id, 'blocker', blocker_id)` + 1. Levels map onto that entity's available contact
+channels, in escalation order: `discord_mention → discord_dm → signal → slack → email`,
+skipping any channel missing from `entity_facts`. Entities that are agents (a row exists in
+`agents` with a matching `entity_id`) always use `agent_chat` instead, regardless of level.
+
+### One Message, Multiple Logged Attempts
+
+An entity may have up to 3 selected blockers in a single cycle, but receives **exactly one
+message**, sent at the most-escalated requested channel among those blockers. Despite only
+one message being sent, **one `proactive_outreach` row is logged per blocker**, each
+recording the actual channel used to deliver that consolidated message — not the
+theoretical channel implied by that individual blocker's own cascade level.
+
+**Cascade position is derived from attempt-row count, not delivered channel** (TC-D09).
+Because every attempt is logged with the actual delivery channel rather than the
+requested one, a blocker's next cascade level is always `COUNT(proactive_outreach rows for
+this blocker) + 1` — independent of which channel any given attempt actually used.
+
+### Channel Exhaustion & Reassignment
+
+If an entity's cascade level exceeds the number of channels available to them (channel
+exhaustion) and they are not I)ruid, the blocker is reassigned to the next domain entity
+(re-resolved via `agent_domains`/`user_domains`, excluding the exhausted entity). If
+reassignment exhausts every domain entity, escalation falls through to **I)ruid
+(entity_id=2) as the final fallback**. If I)ruid himself is exhausted, the blocker holds at
+his last available channel/level and continues on the normal 72h cadence — it is never
+dropped or looped past him.
+
+### Satisfied Blocker Reconciliation
+
+Before selecting outreach targets each cycle, Step 8 marks any blocker whose underlying
+condition has cleared as `status = 'satisfied'`, `satisfied_at = NOW()`. If a
+previously-satisfied blocker's condition recurs, it is **reopened**: `status` reverts to
+`'open'` and `satisfied_at` is cleared back to `NULL` — the existing row is reused (the
+`(source_type, source_ref)` unique constraint prevents duplicates) rather than a new one
+being created.

--- a/motivation/README.md
+++ b/motivation/README.md
@@ -12,10 +12,11 @@ The motivation system is **entirely configuration-driven** — there is no custo
 
 1. **OpenClaw heartbeat** — Triggers every 30 minutes, configured in `openclaw.json` (`agents.defaults.heartbeat`)
 2. **HEARTBEAT bootstrap context** — Database record (`agent_bootstrap_context`, file_key='HEARTBEAT') that defines idle detection logic and gates proactive mode on 1+ hour of channel inactivity
-3. **Proactive Mode workflow** (id=27) — 9-step priority cascade defining what NOVA does when idle
-4. **D100 motivation table** (`motivation_d100`) — 100-slot random task roller for variety in autonomous work
-5. **Unsolved Problems Research workflow** (id=32) — Structured research workflow that delegates data gathering to Scout and reserves reasoning/synthesis for NOVA
-6. **`unsolved_problems` table** — NOVA's notebook for 8 humanity-scale research problems
+3. **Proactive Mode workflow** (id=27) — 11-step priority cascade defining what NOVA does when idle, evaluated deterministically by `motivation/scripts/proactive-gate-check.py`
+4. **`blockers` registry table** — Curated registry of items blocked on another entity's action, populated by Steps 6/7, consumed by the dedicated Step 8 Blocker Outreach step (issue #356)
+5. **D100 motivation table** (`motivation_d100`) — 100-slot random task roller for variety in autonomous work, backed by `d100_roll_log` roll-history and forced past 12h staleness (issue #358)
+6. **Unsolved Problems Research workflow** (id=32) — Structured research workflow that delegates data gathering to Scout and reserves reasoning/synthesis for NOVA
+7. **`unsolved_problems` table** — NOVA's notebook for 8 humanity-scale research problems
 
 ## Operational Flow
 
@@ -23,17 +24,22 @@ The motivation system is **entirely configuration-driven** — there is no custo
 OpenClaw heartbeat (every 30m)
   → HEARTBEAT bootstrap context (idle check)
     → If idle < 1 hour: HEARTBEAT_OK (do nothing)
-    → If idle ≥ 1 hour: Execute Proactive Mode workflow (id=27)
-        Step 1: Check agent_chat for peer messages
-        Step 2: Check communication channels (Hermes)
-        Step 3: Check GitHub repos (Gidget)
-        Step 4: Work on pending tasks
-        Step 5: Check for blocked items needing outreach
-        Step 6: Website/content maintenance
-        Step 7: Unsolved Problems Research (workflow id=32)
-        Step 8: Random D100 task
-        Step 9: Introspection / journal
+    → If idle ≥ 1 hour: Run proactive-gate-check.py, execute only actionable steps
+        Step 1:  Check agent_chat for peer messages
+        Step 2:  Check sessions for unanswered messages
+        Step 3:  Introspection (work-gated + time-backstop)
+        Step 4:  Memory maintenance (REM sleep)
+        Step 5:  Relationship & entity maintenance
+        Step 6:  Work on pending tasks (curates blockers; no outreach)
+        Step 7:  Work on open GitHub issues (curates blockers; no outreach)
+        Step 8:  Blocker outreach (issue #356 — sole outreach step; cooldown-gated, cascade-escalated)
+        Step 9:  Unsolved Problems Mode (workflow id=32)
+        Step 10: Filesystem hygiene audit
+        Step 11: Random D100 task (mandatory catch-all; forced past 12h — issue #358)
 ```
+
+See `motivation/ARCHITECTURE.md` for full step details, gate-check design, and the
+Blocker Outreach cascade/channel/reassignment rules.
 
 ## Database Schema
 

--- a/motivation/scripts/README.md
+++ b/motivation/scripts/README.md
@@ -6,7 +6,7 @@ Scripts supporting NOVA's proactive motivation system.
 
 ## proactive-gate-check.py
 
-Deterministic gate checker for NOVA's proactive cascade. Checks all 10 cascade step
+Deterministic gate checker for NOVA's proactive cascade. Checks all 11 cascade step
 conditions without LLM involvement and emits a structured JSON manifest indicating which
 steps have actionable work. The heartbeat session runs this script first and works only the
 steps listed in `actionable_steps`, eliminating the need for inline LLM gate evaluation and
@@ -60,19 +60,30 @@ step numbers:
     "5_entities":    { "actionable": false, "reason": "No entity dedup candidates" },
     "6_tasks":       { "actionable": true,  "reason": "3 pending unblocked task(s)" },
     "7_github":      { "actionable": false, "reason": "0 open GitHub issues" },
-    "8_research":    { "actionable": false, "reason": "0 unsolved problems" },
-    "9_filesystem":  { "actionable": false, "reason": "Audited 2.1d ago (threshold 7d)" },
-    "10_d100":       { "actionable": false, "reason": "Optional — 2 prior step(s) already actionable" }
+    "8_blocker_outreach": { "actionable": false, "reason": "No blockers eligible for outreach" },
+    "9_research":    { "actionable": false, "reason": "0 unsolved problems" },
+    "10_filesystem": { "actionable": false, "reason": "Audited 2.1d ago (threshold 7d)" },
+    "11_d100":       { "actionable": false, "reason": "Optional — 2 prior step(s) already actionable" }
   },
   "actionable_steps": [3, 6],
   "actionable_count": 2,
-  "summary": "2 of 10 steps actionable"
+  "summary": "2 of 11 steps actionable"
 }
 ```
 
 Step numbers in `actionable_steps` correspond to `step_order` values in the `workflow_steps`
-table for the NOVA Proactive Mode workflow (id=27). Step 10 (D100 random task) is marked
-mandatory when no steps 1–9 are actionable, ensuring the cascade always produces output.
+table for the NOVA Proactive Mode workflow (id=27). Step 11 (D100 random task) is marked
+mandatory when no steps 1–10 are actionable, ensuring the cascade always produces output.
+Step 11 is also **forced** actionable whenever more than 12h have elapsed since the last
+recorded roll in `d100_roll_log` (or no roll is on record), regardless of other steps'
+actionable state (issue #358).
+
+Step 8 (Blocker Outreach) curates a per-entity, per-blocker eligible set from the `blockers`
+registry — entity master cooldown 24h, per-blocker cooldown 72h (both strict `>`), top 3
+blockers per entity by `priority ASC, first_seen ASC, id ASC`. Its `data` payload includes
+each eligible entity's selected blockers, computed cascade level per blocker, and the
+resolved delivery channel (see `motivation/ARCHITECTURE.md#blocker-outreach-step-8` for the
+full cascade/channel/reassignment rules, issue #356).
 
 Each step entry may include a `data` field with additional context (counts, timestamps,
 lists). Error conditions appear as `{ "actionable": false, "error": "..." }`.
@@ -83,7 +94,7 @@ lists). Error conditions appear as `{ "actionable": false, "error": "..." }`.
 |------------|----------------|
 | `psycopg2` | PostgreSQL queries (agent_chat, tasks, entities, unsolved_problems). Loaded from the nova venv at `~/.local/share/nova/venv/` — no manual activation required. |
 | `gh` CLI | Lists open GitHub issues across NOVA-Openclaw repos (Step 7) and enumerates repos. |
-| `openclaw` CLI | Lists recent active sessions (Step 2). |
+| `~/.openclaw/agents/nova/sessions/sessions.json` + per-session JSONL files | Detects unanswered user messages directly from session state (Step 2). |
 
 All other dependencies are Python standard library (`json`, `os`, `subprocess`, `sys`,
 `time`, `datetime`).

--- a/motivation/scripts/proactive-gate-check.py
+++ b/motivation/scripts/proactive-gate-check.py
@@ -2,7 +2,7 @@
 """
 proactive-gate-check.py — Deterministic gate checker for NOVA's proactive cascade.
 
-Checks all 10 cascade step gates without LLM involvement. Outputs a structured
+Checks all 11 cascade step gates without LLM involvement. Outputs a structured
 JSON manifest so the heartbeat agent can work only on actionable steps.
 
 Exit code is always 0. Per-step errors are embedded in JSON output.
@@ -15,7 +15,7 @@ import os
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 # ---------------------------------------------------------------------------
@@ -82,6 +82,14 @@ MEMORY_MAINTENANCE_COOLDOWN_H = 4
 
 # Filesystem audit staleness threshold
 FS_AUDIT_STALENESS_DAYS = 7
+
+# Blocker outreach cooldowns (issue #356)
+BLOCKER_ENTITY_COOLDOWN_H = 24
+BLOCKER_PER_BLOCKER_COOLDOWN_H = 72
+BLOCKERS_PER_MESSAGE = 3
+
+# D100 forced-roll threshold (issue #358)
+D100_FORCED_COOLDOWN_H = 12
 
 DB_DSN = "host=/var/run/postgresql dbname=nova_memory user=nova"
 
@@ -251,52 +259,76 @@ def check_step1_agent_chat() -> dict:
         return _step_error(f"DB error: {exc}")
 
 
+def _last_conversational_role(session_file: str) -> str | None:
+    """Return the role ('user' or 'assistant') of the last conversational message in a session JSONL file.
+
+    Skips toolResult, system, and other non-conversational entries.
+    Returns None if no conversational message is found.
+    """
+    if not os.path.exists(session_file):
+        return None
+    try:
+        with open(session_file, "r") as fh:
+            lines = fh.readlines()
+    except OSError:
+        return None
+    # Walk backwards to find last user or assistant message
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        role = entry.get("message", {}).get("role")
+        if role in ("user", "assistant"):
+            return role
+    return None
+
+
 def check_step2_unanswered_sessions() -> dict:
     """
-    Step 2: Recent user-facing sessions.
-    Runs `openclaw sessions list --json` and counts sessions with ageMs < 24h.
+    Step 2: Check for unanswered user messages in recent user-facing sessions.
+    Reads sessions.json and checks each session's JSONL file to see if the last
+    conversational message is from a user (i.e. unanswered).
     """
     ONE_DAY_MS = 86_400_000
     try:
-        result = subprocess.run(
-            ["openclaw", "sessions", "list", "--json"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-        if result.returncode != 0:
-            return _step_error(
-                f"openclaw sessions list failed (rc={result.returncode}): {result.stderr[:200]}"
-            )
-        payload = json.loads(result.stdout)
-    except FileNotFoundError:
-        return _step_error("openclaw CLI not found")
-    except subprocess.TimeoutExpired:
-        return _step_error("openclaw sessions list timed out")
-    except (json.JSONDecodeError, ValueError) as exc:
-        return _step_error(f"Failed to parse openclaw sessions list output: {exc}")
+        with open(SESSIONS_JSON, "r") as fh:
+            sessions_data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        return _step_error(f"Failed to read sessions.json: {exc}")
 
-    sessions = payload.get("sessions", [])
-    active: list[str] = []
-    for sess in sessions:
-        key = sess.get("key", "")
-        age_ms = sess.get("ageMs", ONE_DAY_MS + 1)
+    now_ms = int(time.time() * 1000)
+    unanswered: list[str] = []
+
+    for key, sess in sessions_data.items():
+        updated = sess.get("updatedAt", 0)
+        age_ms = now_ms - updated
         if age_ms >= ONE_DAY_MS:
             continue
         if not any(pat in key for pat in USER_SESSION_PATTERNS):
             continue
         if any(exc_pat in key for exc_pat in EXCLUDE_PATTERNS):
             continue
-        active.append(key)
 
-    count = len(active)
+        session_file = sess.get("sessionFile", "")
+        if not session_file:
+            continue
+
+        last_role = _last_conversational_role(session_file)
+        if last_role == "user":
+            unanswered.append(key)
+
+    count = len(unanswered)
     if count > 0:
         return {
             "actionable": True,
-            "reason": f"{count} recent active user-facing session(s)",
-            "data": {"count": count, "sessions": active},
+            "reason": f"{count} session(s) with unanswered user messages",
+            "data": {"count": count, "sessions": unanswered},
         }
-    return {"actionable": False, "reason": "No recent active user-facing sessions"}
+    return {"actionable": False, "reason": "No unanswered user messages in recent sessions"}
 
 
 def check_step3_introspection() -> dict:
@@ -601,8 +633,230 @@ def check_step7_github_issues() -> dict:
     return {"actionable": False, "reason": msg, "data": result_dict}
 
 
-def check_step8_unsolved_problems() -> dict:
-    """Step 8: Unsolved problems with status != 'solved'."""
+def _entity_channel_facts(entity_id: int) -> dict[str, str]:
+    """Return available human contact channels for an entity from entity_facts.
+
+    Keys: discord_id, discord_dm (same fact as discord_id), signal, slack, email.
+    Values are the fact values. Agents use agent_chat instead.
+    """
+    channels: dict[str, str] = {}
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT key, value FROM entity_facts
+                        WHERE entity_id = %s
+                          AND key IN ('discord_id', 'signal', 'slack', 'email')
+                        """,
+                        (entity_id,),
+                    )
+                    for key, value in cur.fetchall():
+                        if key == "discord_id":
+                            channels["discord_channel"] = value
+                            channels["discord_dm"] = value
+                        else:
+                            channels[key] = value
+        finally:
+            conn.close()
+    except Exception:
+        pass
+    return channels
+
+
+def _entity_is_agent(entity_id: int) -> bool:
+    """Return True if this entity maps to a row in the agents table."""
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT 1 FROM agents WHERE entity_id = %s LIMIT 1",
+                        (entity_id,),
+                    )
+                    return cur.fetchone() is not None
+        finally:
+            conn.close()
+    except Exception:
+        return False
+
+
+def _map_cascade_to_channel(level: int, channels: dict[str, str], is_agent: bool) -> str:
+    """Map a computed cascade level to a concrete channel.
+
+    Agents always map to agent_chat. Humans escalate through available
+    channels: discord_channel (1), discord_dm (2), signal (3), slack (4),
+    email (5+). If the requested level has no fact, fall back to the next
+    available channel. If no channels exist, return 'none'.
+    """
+    if is_agent:
+        return "agent_chat"
+    order = ["discord_channel", "discord_dm", "signal", "slack", "email"]
+    available = [ch for ch in order if ch in channels]
+    if not available:
+        return "none"
+    idx = max(0, level - 1)
+    if idx >= len(available):
+        return available[-1]
+    return available[idx]
+
+
+def check_step8_blocker_outreach() -> dict:
+    """
+    Step 8: Blocker outreach.
+
+    Curates eligible open blockers for outreach. Returns actionable=True when
+    at least one responsible entity has blockers ready for a new message.
+
+    Eligibility:
+      - entity master cooldown: >24h since ANY proactive_outreach row for the entity
+      - per-blocker cooldown: >72h since a proactive_outreach row for
+        (entity_id, blocker_type='blocker', blocker_id=blocker.id)
+      - top-3 per entity ordered by priority ASC, first_seen ASC, id ASC
+
+    Cascade level per blocker = prior proactive_outreach row count + 1.
+    One message per entity is sent at the most-escalated requested level among
+    its selected blockers; one proactive_outreach row is logged per blocker.
+    """
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT
+                            b.id,
+                            b.source_type,
+                            b.source_ref,
+                            b.description,
+                            b.needs,
+                            b.entity_id,
+                            e.name AS entity_name,
+                            b.priority,
+                            b.first_seen,
+                            COALESCE(po.attempt_count, 0) AS attempt_count,
+                            COALESCE(po.latest_attempt, 'epoch'::timestamptz) AS latest_attempt
+                        FROM blockers b
+                        JOIN entities e ON e.id = b.entity_id
+                        LEFT JOIN LATERAL (
+                            SELECT
+                                COUNT(*) AS attempt_count,
+                                MAX(attempted_at) AS latest_attempt
+                            FROM proactive_outreach
+                            WHERE entity_id = b.entity_id
+                              AND blocker_type = 'blocker'
+                              AND blocker_id = b.id
+                        ) po ON true
+                        WHERE b.status = 'open'
+                        ORDER BY b.entity_id, b.priority ASC, b.first_seen ASC, b.id ASC
+                        """
+                    )
+                    rows = cur.fetchall()
+
+                    # Entity master cooldown: latest ANY outreach to entity in last 24h
+                    entity_ids = list({r[5] for r in rows})
+                    entity_master: dict[int, datetime] = {}
+                    if entity_ids:
+                        cur.execute(
+                            """
+                            SELECT entity_id, MAX(attempted_at)
+                            FROM proactive_outreach
+                            WHERE entity_id = ANY(%s)
+                            GROUP BY entity_id
+                            """,
+                            (entity_ids,),
+                        )
+                        entity_master = {
+                            eid: ts for eid, ts in cur.fetchall() if ts is not None
+                        }
+        finally:
+            conn.close()
+    except Exception as exc:
+        return _step_error(f"DB error: {exc}")
+
+    now = _now_utc()
+    entity_cooldown_cutoff = now - timedelta(hours=BLOCKER_ENTITY_COOLDOWN_H)
+    blocker_cooldown_cutoff = now - timedelta(hours=BLOCKER_PER_BLOCKER_COOLDOWN_H)
+
+    by_entity: dict[int, dict[str, Any]] = {}
+    for row in rows:
+        (
+            bid, source_type, source_ref, description, needs,
+            entity_id, entity_name, priority, first_seen,
+            attempt_count, latest_attempt,
+        ) = row
+
+        # Entity master cooldown: strict > 24h means latest ANY outreach must be
+        # older than cutoff (or absent).
+        master_latest = entity_master.get(entity_id)
+        if master_latest is not None and master_latest > entity_cooldown_cutoff:
+            continue
+
+        # Per-blocker cooldown: strict > 72h
+        if latest_attempt > blocker_cooldown_cutoff:
+            continue
+
+        cascade_level = int(attempt_count) + 1
+
+        if entity_id not in by_entity:
+            by_entity[entity_id] = {
+                "entity_id": entity_id,
+                "entity_name": entity_name,
+                "channels": _entity_channel_facts(entity_id),
+                "is_agent": _entity_is_agent(entity_id),
+                "selected_blockers": [],
+            }
+
+        by_entity[entity_id]["selected_blockers"].append({
+            "id": bid,
+            "source_type": source_type,
+            "source_ref": source_ref,
+            "description": description,
+            "needs": needs,
+            "priority": priority,
+            "first_seen": first_seen.isoformat() if first_seen else None,
+            "cascade_level": cascade_level,
+        })
+
+    # Keep only top-3 per entity and compute actual channel
+    eligible_entities: list[dict[str, Any]] = []
+    for entity_id in sorted(by_entity.keys()):
+        ent = by_entity[entity_id]
+        selected = ent["selected_blockers"][:BLOCKERS_PER_MESSAGE]
+        if not selected:
+            continue
+        max_level = max(b["cascade_level"] for b in selected)
+        actual_channel = _map_cascade_to_channel(
+            max_level, ent["channels"], ent["is_agent"]
+        )
+        eligible_entities.append({
+            "entity_id": entity_id,
+            "entity_name": ent["entity_name"],
+            "selected_blockers": selected,
+            "max_cascade_level": max_level,
+            "actual_channel": actual_channel,
+            "is_agent": ent["is_agent"],
+        })
+
+    total = sum(len(e["selected_blockers"]) for e in eligible_entities)
+    if total > 0:
+        return {
+            "actionable": True,
+            "reason": f"{total} blocker(s) eligible across {len(eligible_entities)} entity/entities",
+            "data": {
+                "eligible_entities": eligible_entities,
+                "total_eligible_blockers": total,
+            },
+        }
+    return {"actionable": False, "reason": "No blockers eligible for outreach"}
+
+
+def check_step9_unsolved_problems() -> dict:
+    """Step 9: Unsolved problems with status != 'solved' and not researched in the last 3 days."""
     try:
         conn = _db_connect()
         try:
@@ -611,23 +865,25 @@ def check_step8_unsolved_problems() -> dict:
                     cur.execute("""
                         SELECT count(*) FROM unsolved_problems
                         WHERE status != 'solved'
+                          AND (last_worked_at IS NULL
+                               OR last_worked_at < NOW() - INTERVAL '3 days')
                     """)
                     count = cur.fetchone()[0]
             if count > 0:
                 return {
                     "actionable": True,
-                    "reason": f"{count} unsolved problem(s) awaiting research",
+                    "reason": f"{count} unsolved problem(s) due for research (3-day cooldown)",
                     "data": {"count": count},
                 }
-            return {"actionable": False, "reason": "0 unsolved problems"}
+            return {"actionable": False, "reason": "All unsolved problems researched within the last 3 days"}
         finally:
             conn.close()
     except Exception as exc:
         return _step_error(f"DB error: {exc}")
 
 
-def check_step9_filesystem_hygiene() -> dict:
-    """Step 9: Filesystem hygiene audit marker staleness."""
+def check_step10_filesystem_hygiene() -> dict:
+    """Step 10: Filesystem hygiene audit marker staleness."""
     STALE_SECONDS = FS_AUDIT_STALENESS_DAYS * 86_400
     try:
         with open(FS_AUDIT_MARKER, "r") as fh:
@@ -656,13 +912,33 @@ def check_step9_filesystem_hygiene() -> dict:
         return {"actionable": True, "reason": f"Could not parse audit marker timestamp: {exc}"}
 
 
-def check_step10_d100(prior_actionable_count: int) -> dict:
+def check_step11_d100(prior_actionable_count: int) -> dict:
     """
-    Step 10: D100 roll.
+    Step 11: D100 roll.
 
     MANDATORY (actionable=True) if no prior step was actionable.
     Optional (actionable=False, skippable) if at least one prior step was actionable.
+    Also forced actionable if >12h since the last D100 roll (issue #358).
     """
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT MAX(rolled_at) FROM d100_roll_log")
+                    row = cur.fetchone()
+                    last_rolled = row[0]
+        finally:
+            conn.close()
+    except Exception:
+        last_rolled = None
+
+    if last_rolled is None or (_now_utc() - last_rolled).total_seconds() > D100_FORCED_COOLDOWN_H * 3600:
+        return {
+            "actionable": True,
+            "reason": "Forced — >12h since last D100 roll",
+        }
+
     if prior_actionable_count == 0:
         return {
             "actionable": True,
@@ -700,7 +976,7 @@ def main() -> None:
         print(json.dumps(base, indent=2))
         return
 
-    # 2. Run all 10 gate checks
+    # 2. Run all 11 gate checks
     steps: dict[str, dict] = {}
 
     steps["1_agent_chat"] = check_step1_agent_chat()
@@ -710,12 +986,13 @@ def main() -> None:
     steps["5_entities"] = check_step5_entity_dedup()
     steps["6_tasks"] = check_step6_pending_tasks()
     steps["7_github"] = check_step7_github_issues()
-    steps["8_research"] = check_step8_unsolved_problems()
-    steps["9_filesystem"] = check_step9_filesystem_hygiene()
+    steps["8_blocker_outreach"] = check_step8_blocker_outreach()
+    steps["9_research"] = check_step9_unsolved_problems()
+    steps["10_filesystem"] = check_step10_filesystem_hygiene()
 
-    # Count actionable steps 1-9 (excluding step 10)
-    prior_actionable = [k for k, v in steps.items() if v.get("actionable")]
-    steps["10_d100"] = check_step10_d100(len(prior_actionable))
+    # Count actionable steps 1-10 (excluding step 11)
+    prior_actionable = [k for k, v in steps.items() if k != "11_d100" and v.get("actionable")]
+    steps["11_d100"] = check_step11_d100(len(prior_actionable))
 
     # Collect final actionable step numbers
     actionable_steps: list[int] = []
@@ -734,7 +1011,7 @@ def main() -> None:
         "steps": steps,
         "actionable_steps": actionable_steps,
         "actionable_count": actionable_count,
-        "summary": f"{actionable_count} of 10 steps actionable",
+        "summary": f"{actionable_count} of 11 steps actionable",
     }
 
     print(json.dumps(output, indent=2))

--- a/motivation/scripts/proactive-gate-check.py
+++ b/motivation/scripts/proactive-gate-check.py
@@ -684,13 +684,37 @@ def _entity_is_agent(entity_id: int) -> bool:
         return False
 
 
+def _entity_name_lookup(entity_id: int) -> str | None:
+    """Return entities.name for the given entity_id, or None on failure."""
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT name FROM entities WHERE id = %s LIMIT 1",
+                        (entity_id,),
+                    )
+                    row = cur.fetchone()
+                    return row[0] if row is not None else None
+        finally:
+            conn.close()
+    except Exception:
+        return None
+
+
 def _map_cascade_to_channel(level: int, channels: dict[str, str], is_agent: bool) -> str:
     """Map a computed cascade level to a concrete channel.
 
     Agents always map to agent_chat. Humans escalate through available
     channels: discord_channel (1), discord_dm (2), signal (3), slack (4),
-    email (5+). If the requested level has no fact, fall back to the next
-    available channel. If no channels exist, return 'none'.
+    email (5+). If the requested level has no fact, fall back to the last
+    available channel (repeat-at-ceiling). If no channels exist, return
+    'none'. Both the repeat-at-ceiling and no-channels cases are signals of
+    *cascade exhaustion* for the entity — see _is_cascade_exhausted() and
+    _reassign_exhausted_entity(), which detect this condition and drive
+    reassignment/hold-at-I)ruid behavior. This function itself only maps
+    level -> channel string; it does not decide reassignment.
     """
     if is_agent:
         return "agent_chat"
@@ -702,6 +726,160 @@ def _map_cascade_to_channel(level: int, channels: dict[str, str], is_agent: bool
     if idx >= len(available):
         return available[-1]
     return available[idx]
+
+
+def _is_cascade_exhausted(level: int, channels: dict[str, str], is_agent: bool) -> bool:
+    """Return True if the cascade level exceeds the entity's available channels.
+
+    Agents are never exhausted (agent_chat is unconditionally available).
+    A human entity with zero channels is exhausted at any level >= 1.
+    """
+    if is_agent:
+        return False
+    order = ["discord_channel", "discord_dm", "signal", "slack", "email"]
+    available_count = len([ch for ch in order if ch in channels])
+    return level > available_count
+
+
+def _entity_domain_topics(entity_id: int) -> list[str]:
+    """Return domain_topic values for which this entity is the PRIMARY owner.
+
+    Checks agent_domains first (joined via agents.entity_id), then
+    user_domains. Per ruling TC-E07, when the same domain_topic exists in
+    both tables, agent_domains wins as primary owner for that topic — so a
+    topic already claimed by an agent is excluded from this entity's list
+    if the entity itself is not that agent. Only used to find which topics
+    an *exhausted* entity currently owns, so we can look up the next
+    candidate for the same topic(s).
+    """
+    topics: set[str] = set()
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    # Topics this entity owns via agent_domains (entity is an agent).
+                    cur.execute(
+                        """
+                        SELECT ad.domain_topic
+                        FROM agent_domains ad
+                        JOIN agents a ON a.id = ad.agent_id
+                        WHERE a.entity_id = %s
+                        """,
+                        (entity_id,),
+                    )
+                    topics.update(r[0] for r in cur.fetchall())
+
+                    # Topics this entity owns via user_domains, EXCLUDING any
+                    # topic that agent_domains already claims for some agent
+                    # (agent_domains wins ties per TC-E07 — a human's
+                    # user_domains row for that topic is a fallback, not a
+                    # primary ownership claim, when an agent also claims it).
+                    cur.execute(
+                        """
+                        SELECT ud.domain_topic
+                        FROM user_domains ud
+                        WHERE ud.entity_id = %s
+                          AND NOT EXISTS (
+                              SELECT 1 FROM agent_domains ad2
+                              WHERE ad2.domain_topic = ud.domain_topic
+                          )
+                        """,
+                        (entity_id,),
+                    )
+                    topics.update(r[0] for r in cur.fetchall())
+        finally:
+            conn.close()
+    except Exception:
+        pass
+    return sorted(topics)
+
+
+def _next_domain_entity(domain_topic: str, exclude_entity_ids: set[int]) -> int | None:
+    """Resolve the next-priority responsible entity for a domain topic.
+
+    Resolution order matches curation (agent_domains first, then
+    user_domains by priority ASC, tiebreak first_seen/id), excluding any
+    entity already in exclude_entity_ids (already-exhausted entities in
+    this reassignment chain). Returns None if no candidate remains.
+    """
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    # agent_domains: domain_topic is globally unique per the
+                    # current schema constraint, so at most one candidate.
+                    cur.execute(
+                        """
+                        SELECT a.entity_id
+                        FROM agent_domains ad
+                        JOIN agents a ON a.id = ad.agent_id
+                        WHERE ad.domain_topic = %s
+                        """,
+                        (domain_topic,),
+                    )
+                    row = cur.fetchone()
+                    if row is not None and row[0] is not None and row[0] not in exclude_entity_ids:
+                        return row[0]
+
+                    # user_domains: lower priority number wins; tiebreak
+                    # created_at ASC, id ASC (deterministic; the random
+                    # tiebreak used in curation is for direct assignment,
+                    # not reassignment which needs a stable next-candidate).
+                    cur.execute(
+                        """
+                        SELECT entity_id
+                        FROM user_domains
+                        WHERE domain_topic = %s
+                          AND entity_id != ALL(%s)
+                        ORDER BY priority ASC, created_at ASC, id ASC
+                        LIMIT 1
+                        """,
+                        (domain_topic, list(exclude_entity_ids) or [-1]),
+                    )
+                    row = cur.fetchone()
+                    if row is not None:
+                        return row[0]
+        finally:
+            conn.close()
+    except Exception:
+        return None
+    return None
+
+
+def _reassign_exhausted_entity(
+    entity_id: int, exclude_entity_ids: set[int]
+) -> tuple[int | None, bool]:
+    """Find the reassignment target for an exhausted entity's blockers.
+
+    Per ruling #7 (SE Run #333 Step 4) / TC-D07:
+      1. Look up domain topics the exhausted entity currently owns as
+         primary responsible entity.
+      2. For each topic, find the next-priority domain entity (excluding
+         already-exhausted entities in this chain).
+      3. If any topic yields a candidate, reassign to it (first match wins;
+         topics are not expected to disagree in practice, and picking the
+         first deterministic match keeps this function total and simple).
+      4. If no topic yields a candidate (or the entity owns no topics),
+         fall back to entity_id = 2 (I)ruid) as the final fallback.
+
+    Returns (new_entity_id, is_final_fallback). is_final_fallback is True
+    when the returned entity is the I)ruid fallback (2) rather than a
+    genuine domain-topic reassignment — callers use this to distinguish
+    "reassigned to a peer" from "fell through to the catch-all."
+
+    Callers must not invoke this for entity_id == 2 (I)ruid) — his
+    exhaustion is a hold-in-place, not a reassignment; see
+    check_step8_blocker_outreach for that branch.
+    """
+    topics = _entity_domain_topics(entity_id)
+    chain_exclude = exclude_entity_ids | {entity_id}
+    for topic in topics:
+        candidate = _next_domain_entity(topic, chain_exclude)
+        if candidate is not None:
+            return candidate, False
+    return 2, True
 
 
 def check_step8_blocker_outreach() -> dict:
@@ -720,6 +898,20 @@ def check_step8_blocker_outreach() -> dict:
     Cascade level per blocker = prior proactive_outreach row count + 1.
     One message per entity is sent at the most-escalated requested level among
     its selected blockers; one proactive_outreach row is logged per blocker.
+
+    Cascade exhaustion (ruling #7 / TC-D07): when an entity's max cascade
+    level exceeds their available contact channels and they are not I)ruid
+    (entity_id=2), the blocker set is reassigned to the next domain entity
+    (via _reassign_exhausted_entity — agent_domains first, then
+    user_domains by priority, excluding already-exhausted entities in the
+    chain), restarting cascade level at 1 against the new entity. If every
+    domain entity is exhausted, the chain falls to I)ruid as final
+    fallback. If I)ruid himself is the exhausted entity, no reassignment
+    occurs — he holds at his last available channel/level and the normal
+    72h per-blocker cooldown continues to gate the next attempt. Each
+    returned entity entry carries "exhausted" (True only for the I)ruid
+    hold-in-place case) and, when reassignment occurred, the original
+    "reassigned_from_entity_id".
     """
     try:
         conn = _db_connect()
@@ -825,7 +1017,13 @@ def check_step8_blocker_outreach() -> dict:
             "cascade_level": cascade_level,
         })
 
-    # Keep only top-3 per entity and compute actual channel
+    # Keep only top-3 per entity, compute actual channel, and detect/resolve
+    # cascade exhaustion (ruling #7 / TC-D07): when max_level exceeds the
+    # entity's available channels and the entity is not I)ruid, reassign to
+    # the next domain entity (chain excludes already-exhausted entities),
+    # eventually falling to I)ruid if every domain entity is exhausted. If
+    # I)ruid himself is exhausted, hold him at his last available channel —
+    # no reassignment, no fabricated level increase.
     eligible_entities: list[dict[str, Any]] = []
     for entity_id in sorted(by_entity.keys()):
         ent = by_entity[entity_id]
@@ -833,17 +1031,67 @@ def check_step8_blocker_outreach() -> dict:
         if not selected:
             continue
         max_level = max(b["cascade_level"] for b in selected)
+
+        current_entity_id = entity_id
+        current_channels = ent["channels"]
+        current_is_agent = ent["is_agent"]
+        current_entity_name = ent["entity_name"]
+        exhausted_chain: list[int] = []
+        reassigned = False
+        exhaustion_hold = False
+
+        while _is_cascade_exhausted(max_level, current_channels, current_is_agent):
+            if current_entity_id == 2:
+                # I)ruid is exhausted — hold at his last available level,
+                # no further reassignment. Normal 72h cadence continues to
+                # gate future attempts.
+                exhaustion_hold = True
+                break
+
+            exhausted_chain.append(current_entity_id)
+            new_entity_id, is_final_fallback = _reassign_exhausted_entity(
+                current_entity_id, set(exhausted_chain)
+            )
+            if new_entity_id is None:
+                # No candidate at all (defensive; _reassign_exhausted_entity
+                # always returns entity 2 as a floor, but guard anyway).
+                new_entity_id = 2
+                is_final_fallback = True
+
+            reassigned = True
+            current_entity_id = new_entity_id
+            # Reassignment restarts cascade level at 1 against the new
+            # entity — no prior proactive_outreach rows exist against them
+            # for this blocker set yet.
+            max_level = 1
+            current_channels = _entity_channel_facts(current_entity_id)
+            current_is_agent = _entity_is_agent(current_entity_id)
+            current_entity_name = (
+                "I)ruid" if is_final_fallback and current_entity_id == 2
+                else _entity_name_lookup(current_entity_id) or current_entity_name
+            )
+
+            if current_entity_id in exhausted_chain:
+                # Defensive: avoid infinite loop if reassignment somehow
+                # cycles back to an already-exhausted entity.
+                break
+
         actual_channel = _map_cascade_to_channel(
-            max_level, ent["channels"], ent["is_agent"]
+            max_level, current_channels, current_is_agent
         )
-        eligible_entities.append({
-            "entity_id": entity_id,
-            "entity_name": ent["entity_name"],
+
+        entry: dict[str, Any] = {
+            "entity_id": current_entity_id,
+            "entity_name": current_entity_name,
             "selected_blockers": selected,
             "max_cascade_level": max_level,
             "actual_channel": actual_channel,
-            "is_agent": ent["is_agent"],
-        })
+            "is_agent": current_is_agent,
+            "exhausted": exhaustion_hold,
+        }
+        if reassigned:
+            entry["reassigned_from_entity_id"] = entity_id
+        eligible_entities.append(entry)
 
     total = sum(len(e["selected_blockers"]) for e in eligible_entities)
     if total > 0:

--- a/motivation/scripts/proactive-gate-check.py
+++ b/motivation/scripts/proactive-gate-check.py
@@ -790,14 +790,17 @@ def check_step8_blocker_outreach() -> dict:
             attempt_count, latest_attempt,
         ) = row
 
-        # Entity master cooldown: strict > 24h means latest ANY outreach must be
-        # older than cutoff (or absent).
+        # Entity master cooldown: strict > 24h elapsed required to be eligible,
+        # i.e. blocked while master_latest >= cutoff (elapsed <= 24h exactly
+        # still blocks).
         master_latest = entity_master.get(entity_id)
-        if master_latest is not None and master_latest > entity_cooldown_cutoff:
+        if master_latest is not None and master_latest >= entity_cooldown_cutoff:
             continue
 
-        # Per-blocker cooldown: strict > 72h
-        if latest_attempt > blocker_cooldown_cutoff:
+        # Per-blocker cooldown: strict > 72h elapsed required to be eligible,
+        # i.e. blocked while latest_attempt >= cutoff (elapsed <= 72h exactly
+        # still blocks).
+        if latest_attempt >= blocker_cooldown_cutoff:
             continue
 
         cascade_level = int(attempt_count) + 1

--- a/motivation/scripts/proactive-gate-check.py
+++ b/motivation/scripts/proactive-gate-check.py
@@ -1107,7 +1107,7 @@ def check_step8_blocker_outreach() -> dict:
 
 
 def check_step9_unsolved_problems() -> dict:
-    """Step 9: Unsolved problems with status != 'solved' and not researched in the last 3 days."""
+    """Step 9: Unsolved problems with status != 'solved'."""
     try:
         conn = _db_connect()
         try:
@@ -1116,17 +1116,15 @@ def check_step9_unsolved_problems() -> dict:
                     cur.execute("""
                         SELECT count(*) FROM unsolved_problems
                         WHERE status != 'solved'
-                          AND (last_worked_at IS NULL
-                               OR last_worked_at < NOW() - INTERVAL '3 days')
                     """)
                     count = cur.fetchone()[0]
             if count > 0:
                 return {
                     "actionable": True,
-                    "reason": f"{count} unsolved problem(s) due for research (3-day cooldown)",
+                    "reason": f"{count} unsolved problem(s) awaiting research",
                     "data": {"count": count},
                 }
-            return {"actionable": False, "reason": "All unsolved problems researched within the last 3 days"}
+            return {"actionable": False, "reason": "0 unsolved problems"}
         finally:
             conn.close()
     except Exception as exc:

--- a/motivation/tests/test_proactive_gate_check.py
+++ b/motivation/tests/test_proactive_gate_check.py
@@ -985,12 +985,16 @@ class TestStep9UnsolvedProblems:
         with patch.object(m, "_db_connect", return_value=self._mock_conn(0)):
             result = m.check_step9_unsolved_problems()
         assert result["actionable"] is False
+        # D-2 revert: no last_worked_at/3-day-cooldown predicate in this PR;
+        # reason string restored to the pre-PR count-only form.
+        assert result["reason"] == "0 unsolved problems"
 
     def test_unsolved_problems_present(self, m):
         with patch.object(m, "_db_connect", return_value=self._mock_conn(3)):
             result = m.check_step9_unsolved_problems()
         assert result["actionable"] is True
         assert result["data"]["count"] == 3
+        assert result["reason"] == "3 unsolved problem(s) awaiting research"
 
     def test_db_failure(self, m):
         with patch.object(m, "_db_connect", side_effect=Exception("db error")):
@@ -1243,6 +1247,262 @@ class TestStep8BlockerOutreach:
             result = m.check_step8_blocker_outreach()
         entity = result["data"]["eligible_entities"][0]
         assert entity["actual_channel"] == "discord_channel"
+
+    # ---- cascade exhaustion + reassignment (D-1 fix, ruling #7 / TC-D07) ----
+
+    def test_zero_channels_zero_attempts_triggers_reassignment(self, m):
+        """Entity with 0 contact channels and 0 prior attempts (cascade_level=1)
+        is immediately exhausted (1 > 0 available channels) — must reassign
+        rather than silently returning 'none'."""
+        rows = [self._row(1, entity_id=10, attempt_count=0)]
+        p1, p2, p3 = self._patched(m, rows, entity_master={}, channels={}, is_agent=False)
+        with (
+            p1, p2, p3,
+            patch.object(m, "_reassign_exhausted_entity", return_value=(20, False)) as mock_reassign,
+            patch.object(m, "_entity_channel_facts", side_effect=lambda eid: {"discord_channel": "abc"} if eid == 20 else {}),
+            patch.object(m, "_entity_is_agent", return_value=False),
+            patch.object(m, "_entity_name_lookup", return_value="Next Entity"),
+        ):
+            result = m.check_step8_blocker_outreach()
+        entity = result["data"]["eligible_entities"][0]
+        mock_reassign.assert_called_once_with(10, {10})
+        assert entity["entity_id"] == 20
+        assert entity["reassigned_from_entity_id"] == 10
+        assert entity["exhausted"] is False
+        assert entity["max_cascade_level"] == 1
+        assert entity["actual_channel"] == "discord_channel"
+
+    def test_n_channels_level_n_plus_1_triggers_reassignment(self, m):
+        """Entity with N channels, cascade_level = N+1 (first exhaustion past
+        the ceiling) — must reassign rather than repeating the last channel
+        silently."""
+        # attempt_count=2 -> cascade_level=3; only 2 channels available (N=2)
+        # so level 3 > 2 available channels -> exhausted.
+        rows = [self._row(1, entity_id=11, attempt_count=2)]
+        channels = {"discord_channel": "123", "discord_dm": "123"}
+        p1, p2, p3 = self._patched(m, rows, entity_master={}, channels=channels, is_agent=False)
+        with (
+            p1, p2, p3,
+            patch.object(m, "_reassign_exhausted_entity", return_value=(30, False)) as mock_reassign,
+            patch.object(m, "_entity_channel_facts", side_effect=lambda eid: {"signal": "sig"} if eid == 30 else channels),
+            patch.object(m, "_entity_is_agent", return_value=False),
+            patch.object(m, "_entity_name_lookup", return_value="Reassigned Entity"),
+        ):
+            result = m.check_step8_blocker_outreach()
+        entity = result["data"]["eligible_entities"][0]
+        mock_reassign.assert_called_once_with(11, {11})
+        assert entity["entity_id"] == 30
+        assert entity["reassigned_from_entity_id"] == 11
+        assert entity["max_cascade_level"] == 1
+        assert entity["actual_channel"] == "signal"
+
+    def test_iruid_exhausted_holds_no_reassignment(self, m):
+        """Entity is I)ruid (entity_id=2); cascade_level exceeds his channel
+        count. Must NOT reassign — holds at his last available channel and
+        is marked exhausted=True so the agent turn knows to keep the 72h
+        cadence rather than escalate further."""
+        # attempt_count=3 -> cascade_level=4; only 1 channel available -> exhausted.
+        rows = [self._row(1, entity_id=2, attempt_count=3)]
+        channels = {"discord_channel": "123"}
+        p1, p2, p3 = self._patched(m, rows, entity_master={}, channels=channels, is_agent=False)
+        with (
+            p1, p2, p3,
+            patch.object(m, "_reassign_exhausted_entity") as mock_reassign,
+        ):
+            result = m.check_step8_blocker_outreach()
+        entity = result["data"]["eligible_entities"][0]
+        mock_reassign.assert_not_called()
+        assert entity["entity_id"] == 2
+        assert entity["exhausted"] is True
+        assert entity["max_cascade_level"] == 4
+        assert entity["actual_channel"] == "discord_channel"
+        assert "reassigned_from_entity_id" not in entity
+
+    def test_full_reassignment_chain_falls_to_iruid(self, m):
+        """Original entity exhausted -> reassigned entity ALSO exhausted ->
+        falls through to I)ruid (entity_id=2) as final fallback."""
+        rows = [self._row(1, entity_id=10, attempt_count=0)]
+        p1, p2, p3 = self._patched(m, rows, entity_master={}, channels={}, is_agent=False)
+
+        # First reassignment: 10 -> 40 (also exhausted, 0 channels).
+        # Second reassignment: 40 -> 2 (I)ruid, final fallback), with channels.
+        reassign_calls = {"count": 0}
+
+        def fake_reassign(entity_id, exclude_ids):
+            reassign_calls["count"] += 1
+            if reassign_calls["count"] == 1:
+                assert entity_id == 10
+                assert exclude_ids == {10}
+                return 40, False
+            assert entity_id == 40
+            assert exclude_ids == {10, 40}
+            return 2, True
+
+        def fake_channels(eid):
+            if eid == 2:
+                return {"discord_channel": "999"}
+            return {}
+
+        with (
+            p1, p2, p3,
+            patch.object(m, "_reassign_exhausted_entity", side_effect=fake_reassign) as mock_reassign,
+            patch.object(m, "_entity_channel_facts", side_effect=fake_channels),
+            patch.object(m, "_entity_is_agent", return_value=False),
+            patch.object(m, "_entity_name_lookup", return_value="I)ruid"),
+        ):
+            result = m.check_step8_blocker_outreach()
+        entity = result["data"]["eligible_entities"][0]
+        assert mock_reassign.call_count == 2
+        assert entity["entity_id"] == 2
+        assert entity["reassigned_from_entity_id"] == 10
+        assert entity["exhausted"] is False  # landed on I)ruid with a channel, not a hold
+        assert entity["max_cascade_level"] == 1
+        assert entity["actual_channel"] == "discord_channel"
+
+
+# ---------------------------------------------------------------------------
+# Cascade exhaustion helpers — direct unit coverage (D-1 fix)
+# ---------------------------------------------------------------------------
+
+class TestIsCascadeExhausted:
+    def test_agent_never_exhausted(self, m):
+        assert m._is_cascade_exhausted(99, {}, is_agent=True) is False
+
+    def test_zero_channels_exhausted_at_level_1(self, m):
+        assert m._is_cascade_exhausted(1, {}, is_agent=False) is True
+
+    def test_level_within_available_channels_not_exhausted(self, m):
+        channels = {"discord_channel": "1", "discord_dm": "1", "signal": "s"}
+        assert m._is_cascade_exhausted(3, channels, is_agent=False) is False
+
+    def test_level_exceeding_available_channels_exhausted(self, m):
+        channels = {"discord_channel": "1", "discord_dm": "1"}
+        assert m._is_cascade_exhausted(3, channels, is_agent=False) is True
+
+
+class TestEntityDomainTopics:
+    def _mock_conn_for_topics(self, agent_rows, user_rows, exists_rows=None):
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        state = {"last": None}
+
+        def fake_execute(sql, params=None):
+            state["last"] = "agent" if "ad.domain_topic" in sql else "user"
+
+        def fake_fetchall():
+            if state["last"] == "agent":
+                return agent_rows
+            return user_rows
+
+        mock_cur.execute.side_effect = fake_execute
+        mock_cur.fetchall.side_effect = fake_fetchall
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.close = MagicMock()
+        return mock_conn
+
+    def test_combines_agent_and_user_domain_topics(self, m):
+        conn = self._mock_conn_for_topics(
+            agent_rows=[("Software Engineering",)],
+            user_rows=[("Project Leadership",)],
+        )
+        with patch.object(m, "_db_connect", return_value=conn):
+            topics = m._entity_domain_topics(2)
+        assert topics == ["Project Leadership", "Software Engineering"]
+
+    def test_db_failure_returns_empty_list(self, m):
+        with patch.object(m, "_db_connect", side_effect=Exception("db down")):
+            topics = m._entity_domain_topics(2)
+        assert topics == []
+
+
+class TestNextDomainEntity:
+    def _mock_conn(self, agent_row, user_row):
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        state = {"last": None}
+
+        def fake_execute(sql, params=None):
+            state["last"] = "agent" if "agent_domains ad" in sql else "user"
+
+        def fake_fetchone():
+            return agent_row if state["last"] == "agent" else user_row
+
+        mock_cur.execute.side_effect = fake_execute
+        mock_cur.fetchone.side_effect = fake_fetchone
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.close = MagicMock()
+        return mock_conn
+
+    def test_agent_domains_wins_when_present_and_not_excluded(self, m):
+        conn = self._mock_conn(agent_row=(50,), user_row=(60,))
+        with patch.object(m, "_db_connect", return_value=conn):
+            result = m._next_domain_entity("Software Engineering", set())
+        assert result == 50
+
+    def test_falls_back_to_user_domains_when_agent_excluded(self, m):
+        conn = self._mock_conn(agent_row=(50,), user_row=(60,))
+        with patch.object(m, "_db_connect", return_value=conn):
+            result = m._next_domain_entity("Software Engineering", {50})
+        assert result == 60
+
+    def test_returns_none_when_no_candidate(self, m):
+        conn = self._mock_conn(agent_row=None, user_row=None)
+        with patch.object(m, "_db_connect", return_value=conn):
+            result = m._next_domain_entity("obscure-topic", set())
+        assert result is None
+
+    def test_db_failure_returns_none(self, m):
+        with patch.object(m, "_db_connect", side_effect=Exception("db down")):
+            result = m._next_domain_entity("Software Engineering", set())
+        assert result is None
+
+
+class TestReassignExhaustedEntity:
+    def test_reassigns_to_next_domain_entity(self, m):
+        with (
+            patch.object(m, "_entity_domain_topics", return_value=["Software Engineering"]),
+            patch.object(m, "_next_domain_entity", return_value=99),
+        ):
+            new_id, is_final = m._reassign_exhausted_entity(10, set())
+        assert new_id == 99
+        assert is_final is False
+
+    def test_falls_back_to_iruid_when_no_topics_owned(self, m):
+        with patch.object(m, "_entity_domain_topics", return_value=[]):
+            new_id, is_final = m._reassign_exhausted_entity(10, set())
+        assert new_id == 2
+        assert is_final is True
+
+    def test_falls_back_to_iruid_when_all_topic_candidates_excluded(self, m):
+        with (
+            patch.object(m, "_entity_domain_topics", return_value=["Some Topic"]),
+            patch.object(m, "_next_domain_entity", return_value=None),
+        ):
+            new_id, is_final = m._reassign_exhausted_entity(10, set())
+        assert new_id == 2
+        assert is_final is True
+
+    def test_exclude_set_includes_entity_itself(self, m):
+        """The exhausted entity is always added to the exclusion set passed
+        to _next_domain_entity, even if the caller's exclude set didn't
+        already contain it."""
+        with (
+            patch.object(m, "_entity_domain_topics", return_value=["Topic"]),
+            patch.object(m, "_next_domain_entity") as mock_next,
+        ):
+            mock_next.return_value = 5
+            m._reassign_exhausted_entity(10, {7})
+        mock_next.assert_called_once_with("Topic", {7, 10})
 
 
 # ---------------------------------------------------------------------------

--- a/motivation/tests/test_proactive_gate_check.py
+++ b/motivation/tests/test_proactive_gate_check.py
@@ -3,8 +3,8 @@ Tests for motivation/scripts/proactive-gate-check.py
 
 Covers:
 - Idle detection (active, idle, boundary, missing file, malformed, bot-only, custom threshold)
-- All 10 gate check steps (actionable / not-actionable paths)
-- D100 logic (mandatory vs optional)
+- All 11 gate check steps (actionable / not-actionable paths)
+- D100 logic (mandatory vs optional vs forced by roll staleness)
 - Error handling (DB failure, missing state files, gh unavailable)
 - Output format validation (required fields, correct types)
 """
@@ -247,66 +247,97 @@ class TestStep1AgentChat:
 # ---------------------------------------------------------------------------
 
 class TestStep2UnansweredSessions:
-    def _make_openclaw_output(self, sessions: list[dict]) -> str:
-        return json.dumps({"sessions": sessions})
+    """check_step2_unanswered_sessions() reads SESSIONS_JSON directly and, for
+    each recent user-facing session, inspects the last conversational role in
+    its JSONL session file via _last_conversational_role()."""
 
-    def test_recent_user_sessions_found(self, m):
-        payload = self._make_openclaw_output([
-            {"key": "agent:nova:discord:channel:123", "ageMs": 1000},
-            {"key": "agent:nova:discord:channel:456", "ageMs": 2000},
-        ])
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = payload
+    def _write_sessions_json(self, tmp_path, entries: dict[str, dict]) -> str:
+        path = tmp_path / "sessions.json"
+        path.write_text(json.dumps(entries))
+        return str(path)
 
-        with patch("subprocess.run", return_value=mock_result):
+    def _write_session_file(self, tmp_path, name: str, roles: list[str]) -> str:
+        """Write a minimal JSONL session file; last entry in `roles` is the
+        last conversational message role."""
+        path = tmp_path / name
+        lines = [json.dumps({"message": {"role": role}}) for role in roles]
+        path.write_text("\n".join(lines) + "\n")
+        return str(path)
+
+    def test_recent_user_sessions_found(self, m, tmp_path):
+        now_ms = int(time.time() * 1000)
+        sf1 = self._write_session_file(tmp_path, "s1.jsonl", ["assistant", "user"])
+        sf2 = self._write_session_file(tmp_path, "s2.jsonl", ["assistant", "user"])
+        sessions_json = self._write_sessions_json(tmp_path, {
+            "agent:nova:discord:channel:123": {"updatedAt": now_ms - 1000, "sessionFile": sf1},
+            "agent:nova:discord:channel:456": {"updatedAt": now_ms - 2000, "sessionFile": sf2},
+        })
+        with patch.object(m, "SESSIONS_JSON", sessions_json):
             result = m.check_step2_unanswered_sessions()
         assert result["actionable"] is True
         assert result["data"]["count"] == 2
 
-    def test_no_recent_user_sessions(self, m):
-        payload = self._make_openclaw_output([
-            {"key": "agent:nova:discord:channel:123", "ageMs": 90_000_000},
-        ])
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = payload
-
-        with patch("subprocess.run", return_value=mock_result):
+    def test_no_recent_user_sessions(self, m, tmp_path):
+        now_ms = int(time.time() * 1000)
+        sf1 = self._write_session_file(tmp_path, "s1.jsonl", ["user", "assistant"])
+        sessions_json = self._write_sessions_json(tmp_path, {
+            "agent:nova:discord:channel:123": {"updatedAt": now_ms - 90_000_000, "sessionFile": sf1},
+        })
+        with patch.object(m, "SESSIONS_JSON", sessions_json):
             result = m.check_step2_unanswered_sessions()
         assert result["actionable"] is False
 
-    def test_excludes_bot_sessions(self, m):
-        payload = self._make_openclaw_output([
-            {"key": "agent:nova:discord:channel:123", "ageMs": 1000},
-            {"key": "agent:nova:main:heartbeat", "ageMs": 500},
-            {"key": "agent:nova:cron:abc", "ageMs": 300},
-        ])
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = payload
+    def test_answered_session_not_actionable(self, m, tmp_path):
+        """Last conversational message is from the assistant -> not unanswered."""
+        now_ms = int(time.time() * 1000)
+        sf1 = self._write_session_file(tmp_path, "s1.jsonl", ["user", "assistant"])
+        sessions_json = self._write_sessions_json(tmp_path, {
+            "agent:nova:discord:channel:123": {"updatedAt": now_ms - 1000, "sessionFile": sf1},
+        })
+        with patch.object(m, "SESSIONS_JSON", sessions_json):
+            result = m.check_step2_unanswered_sessions()
+        assert result["actionable"] is False
 
-        with patch("subprocess.run", return_value=mock_result):
+    def test_excludes_bot_sessions(self, m, tmp_path):
+        now_ms = int(time.time() * 1000)
+        sf1 = self._write_session_file(tmp_path, "s1.jsonl", ["assistant", "user"])
+        sf2 = self._write_session_file(tmp_path, "s2.jsonl", ["assistant", "user"])
+        sf3 = self._write_session_file(tmp_path, "s3.jsonl", ["assistant", "user"])
+        sessions_json = self._write_sessions_json(tmp_path, {
+            "agent:nova:discord:channel:123": {"updatedAt": now_ms - 1000, "sessionFile": sf1},
+            "agent:nova:main:heartbeat": {"updatedAt": now_ms - 500, "sessionFile": sf2},
+            "agent:nova:cron:abc": {"updatedAt": now_ms - 300, "sessionFile": sf3},
+        })
+        with patch.object(m, "SESSIONS_JSON", sessions_json):
             result = m.check_step2_unanswered_sessions()
         # Only the discord channel should count
         assert result["data"]["count"] == 1
 
-    def test_openclaw_cli_not_found(self, m):
-        import subprocess as sp
-        with patch("subprocess.run", side_effect=FileNotFoundError):
+    def test_sessions_json_missing(self, m, tmp_path):
+        missing = str(tmp_path / "no-such-sessions.json")
+        with patch.object(m, "SESSIONS_JSON", missing):
             result = m.check_step2_unanswered_sessions()
         assert result["actionable"] is False
         assert "error" in result
 
-    def test_openclaw_cli_failure(self, m):
-        mock_result = MagicMock()
-        mock_result.returncode = 1
-        mock_result.stderr = "something went wrong"
-
-        with patch("subprocess.run", return_value=mock_result):
+    def test_sessions_json_malformed(self, m, tmp_path):
+        path = tmp_path / "sessions.json"
+        path.write_text("not json")
+        with patch.object(m, "SESSIONS_JSON", str(path)):
             result = m.check_step2_unanswered_sessions()
         assert result["actionable"] is False
         assert "error" in result
+
+    def test_missing_session_file_skipped(self, m, tmp_path):
+        """A session entry with no sessionFile on disk should be skipped, not error."""
+        now_ms = int(time.time() * 1000)
+        missing_file = str(tmp_path / "does-not-exist.jsonl")
+        sessions_json = self._write_sessions_json(tmp_path, {
+            "agent:nova:discord:channel:123": {"updatedAt": now_ms - 1000, "sessionFile": missing_file},
+        })
+        with patch.object(m, "SESSIONS_JSON", sessions_json):
+            result = m.check_step2_unanswered_sessions()
+        assert result["actionable"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -665,7 +696,10 @@ class TestStep3IntrospectionDualMirror:
     def test_same_timestamp_uses_primary(self, m, tmp_path):
         primary_file = tmp_path / "primary.json"
         alt_file = tmp_path / "alt.json"
-        fixed_ts = "2026-06-21T10:00:00Z"
+        # Relative (3h ago) rather than a hardcoded absolute date so this test
+        # doesn't bit-rot as real time passes and eventually cross the
+        # INTROSPECT_TIME_THRESHOLD_H threshold regardless of tie-break winner.
+        fixed_ts = _iso(3.0)
         primary_file.write_text(json.dumps({
             "lastIntrospection": {
                 "dailyLogLines": 100,
@@ -935,7 +969,7 @@ class TestStep7GithubIssues:
 # Step 8 — unsolved problems
 # ---------------------------------------------------------------------------
 
-class TestStep8UnsolvedProblems:
+class TestStep9UnsolvedProblems:
     def _mock_conn(self, count: int) -> MagicMock:
         mock_cur = MagicMock()
         mock_cur.__enter__ = MagicMock(return_value=mock_cur)
@@ -949,80 +983,398 @@ class TestStep8UnsolvedProblems:
 
     def test_no_unsolved_problems(self, m):
         with patch.object(m, "_db_connect", return_value=self._mock_conn(0)):
-            result = m.check_step8_unsolved_problems()
+            result = m.check_step9_unsolved_problems()
         assert result["actionable"] is False
 
     def test_unsolved_problems_present(self, m):
         with patch.object(m, "_db_connect", return_value=self._mock_conn(3)):
-            result = m.check_step8_unsolved_problems()
+            result = m.check_step9_unsolved_problems()
         assert result["actionable"] is True
         assert result["data"]["count"] == 3
 
     def test_db_failure(self, m):
         with patch.object(m, "_db_connect", side_effect=Exception("db error")):
-            result = m.check_step8_unsolved_problems()
+            result = m.check_step9_unsolved_problems()
         assert result["actionable"] is False
         assert "error" in result
 
 
 # ---------------------------------------------------------------------------
-# Step 9 — filesystem hygiene
+# Step 8 — blocker outreach
 # ---------------------------------------------------------------------------
 
-class TestStep9FilesystemHygiene:
+class TestStep8BlockerOutreach:
+    """Tests for check_step8_blocker_outreach().
+
+    The function issues three DB round-trips via a single connection:
+      1. main SELECT joining blockers + entities + LATERAL proactive_outreach
+         (per-blocker attempt_count / latest_attempt)
+      2. entity master-cooldown SELECT (MAX(attempted_at) GROUP BY entity_id)
+      3. (helpers) _entity_channel_facts / _entity_is_agent, one query each,
+         called per-entity outside the main connection block.
+
+    We mock _db_connect to return a context-manager connection whose
+    cursor.execute/fetchall are driven by a small dispatcher keyed on the
+    SQL text, and separately patch _entity_channel_facts / _entity_is_agent
+    since those open their own connections.
+    """
+
+    def _row(
+        self,
+        bid: int,
+        entity_id: int,
+        entity_name: str = "entity",
+        priority: int = 5,
+        first_seen_hours_ago: float = 1.0,
+        attempt_count: int = 0,
+        latest_attempt_hours_ago: float | None = None,
+        source_type: str = "task",
+        source_ref: str = "ref-1",
+    ):
+        latest_attempt = (
+            "epoch"
+            if latest_attempt_hours_ago is None
+            else datetime.now(timezone.utc) - timedelta(hours=latest_attempt_hours_ago)
+        )
+        if latest_attempt == "epoch":
+            latest_attempt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        return (
+            bid,
+            source_type,
+            source_ref,
+            f"desc-{bid}",
+            f"needs-{bid}",
+            entity_id,
+            entity_name,
+            priority,
+            datetime.now(timezone.utc) - timedelta(hours=first_seen_hours_ago),
+            attempt_count,
+            latest_attempt,
+        )
+
+    def _mock_conn(self, rows: list, entity_master: dict[int, Any]):
+        """Build a mock connection whose cursor dispatches on query text."""
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+
+        state = {"last": None}
+
+        def fake_execute(sql, params=None):
+            if "FROM blockers b" in sql:
+                state["last"] = "main"
+            elif "GROUP BY entity_id" in sql:
+                state["last"] = "master"
+            else:
+                state["last"] = "other"
+
+        def fake_fetchall():
+            if state["last"] == "main":
+                return rows
+            if state["last"] == "master":
+                return list(entity_master.items())
+            return []
+
+        mock_cur.execute.side_effect = fake_execute
+        mock_cur.fetchall.side_effect = fake_fetchall
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.close = MagicMock()
+        return mock_conn
+
+    def _patched(self, m, rows, entity_master=None, channels=None, is_agent=None):
+        """Context manager patching _db_connect + the per-entity helpers."""
+        entity_master = entity_master or {}
+        channels = channels if channels is not None else {}
+        is_agent = is_agent if is_agent is not None else False
+        conn = self._mock_conn(rows, entity_master)
+        return (
+            patch.object(m, "_db_connect", return_value=conn),
+            patch.object(m, "_entity_channel_facts", return_value=channels),
+            patch.object(m, "_entity_is_agent", return_value=is_agent),
+        )
+
+    # ---- cooldown boundaries ----
+
+    def test_entity_master_cooldown_exactly_24h_is_blocked(self, m):
+        """Master cooldown is strict >24h: exactly 24h elapsed must still be blocked.
+
+        A 100ms safety margin is added so the row's timestamp is captured
+        very slightly *after* the true 24h mark, absorbing the microseconds
+        that elapse before the function's internal _now_utc() call runs —
+        otherwise this boundary test is flaky (real elapsed drifts just past
+        24h and is treated as eligible).
+        """
+        rows = [self._row(1, entity_id=10, attempt_count=0)]
+        master = {10: datetime.now(timezone.utc) - timedelta(hours=24.0) + timedelta(milliseconds=100)}
+        p1, p2, p3 = self._patched(m, rows, entity_master=master)
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is False
+
+    def test_entity_master_cooldown_24h_plus_1s_is_eligible(self, m):
+        rows = [self._row(1, entity_id=10, attempt_count=0)]
+        master = {10: datetime.now(timezone.utc) - timedelta(hours=24.0, seconds=1)}
+        p1, p2, p3 = self._patched(m, rows, entity_master=master)
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is True
+
+    def test_per_blocker_cooldown_exactly_72h_is_blocked(self, m):
+        """Per-blocker cooldown is strict >72h: exactly 72h elapsed must still be blocked.
+
+        Uses a 100ms-under-72h delta (see note on the 24h master-cooldown
+        boundary test above) to avoid boundary flakiness.
+        """
+        rows = [self._row(
+            1, entity_id=10, attempt_count=1,
+            latest_attempt_hours_ago=72.0 - (0.1 / 3600),
+        )]
+        p1, p2, p3 = self._patched(m, rows, entity_master={})
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is False
+
+    def test_per_blocker_cooldown_72h_plus_1s_is_eligible(self, m):
+        rows = [self._row(
+            1, entity_id=10, attempt_count=1,
+            latest_attempt_hours_ago=72.0 + (1 / 3600),
+        )]
+        p1, p2, p3 = self._patched(m, rows, entity_master={})
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is True
+
+    # ---- never-contacted entity ----
+
+    def test_never_contacted_entity_is_eligible(self, m):
+        """No proactive_outreach rows at all (empty master dict, epoch latest_attempt)."""
+        rows = [self._row(1, entity_id=10, attempt_count=0, latest_attempt_hours_ago=None)]
+        p1, p2, p3 = self._patched(m, rows, entity_master={})
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is True
+        assert result["data"]["eligible_entities"][0]["selected_blockers"][0]["cascade_level"] == 1
+
+    # ---- non-blocker outreach triggers master but not per-blocker cooldown ----
+
+    def test_non_blocker_outreach_triggers_master_not_per_blocker(self, m):
+        """A proactive_outreach row for a *different* blocker_type/id still counts
+        toward the entity master cooldown (any row for the entity), but the
+        per-blocker cooldown for THIS blocker is independent — attempt_count
+        for this blocker's LATERAL join is 0 since the row is keyed to a
+        different blocker_id, so its own cooldown is unaffected. The master
+        cooldown (recent) should block the entity outright.
+        """
+        rows = [self._row(1, entity_id=10, attempt_count=0, latest_attempt_hours_ago=None)]
+        # Master cooldown recent (1h ago) from an unrelated (e.g. non-blocker) row
+        master = {10: datetime.now(timezone.utc) - timedelta(hours=1.0)}
+        p1, p2, p3 = self._patched(m, rows, entity_master=master)
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        # Blocked by master cooldown even though per-blocker attempt_count is 0
+        assert result["actionable"] is False
+
+    # ---- top-3 tiebreak determinism ----
+
+    def test_top_3_tiebreak_determinism(self, m):
+        """5 blockers for one entity, all same priority/first_seen — only first
+        3 by id (as returned in SQL ORDER BY) are selected."""
+        now_h = 1.0
+        rows = [
+            self._row(i, entity_id=10, priority=5, first_seen_hours_ago=now_h, attempt_count=0)
+            for i in range(1, 6)
+        ]
+        p1, p2, p3 = self._patched(m, rows, entity_master={})
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is True
+        selected = result["data"]["eligible_entities"][0]["selected_blockers"]
+        assert len(selected) == 3
+        assert [b["id"] for b in selected] == [1, 2, 3]
+
+    def test_top_3_respects_priority_ordering(self, m):
+        """Lower priority number sorts first (already ordered by SQL); function
+        must preserve incoming row order, not re-sort."""
+        rows = [
+            self._row(3, entity_id=10, priority=1, attempt_count=0),
+            self._row(1, entity_id=10, priority=2, attempt_count=0),
+            self._row(2, entity_id=10, priority=3, attempt_count=0),
+        ]
+        p1, p2, p3 = self._patched(m, rows, entity_master={})
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        selected = result["data"]["eligible_entities"][0]["selected_blockers"]
+        assert [b["id"] for b in selected] == [3, 1, 2]
+
+    # ---- empty tables ----
+
+    def test_empty_blockers_table(self, m):
+        p1, p2, p3 = self._patched(m, rows=[], entity_master={})
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is False
+        assert "reason" in result
+
+    def test_db_failure(self, m):
+        with patch.object(m, "_db_connect", side_effect=Exception("db error")):
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is False
+        assert "error" in result
+
+    # ---- cascade level -> channel mapping ----
+
+    def test_cascade_level_maps_to_agent_chat_for_agents(self, m):
+        rows = [self._row(1, entity_id=99, attempt_count=0)]
+        p1, p2, p3 = self._patched(m, rows, entity_master={}, is_agent=True)
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        entity = result["data"]["eligible_entities"][0]
+        assert entity["actual_channel"] == "agent_chat"
+
+    def test_cascade_level_maps_to_available_human_channel(self, m):
+        rows = [self._row(1, entity_id=2, attempt_count=0)]
+        channels = {"discord_channel": "123", "discord_dm": "123", "email": "x@y.com"}
+        p1, p2, p3 = self._patched(m, rows, entity_master={}, channels=channels, is_agent=False)
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        entity = result["data"]["eligible_entities"][0]
+        assert entity["actual_channel"] == "discord_channel"
+
+
+# ---------------------------------------------------------------------------
+# Step 10 — filesystem hygiene
+# ---------------------------------------------------------------------------
+
+class TestStep10FilesystemHygiene:
     def test_recently_audited_not_actionable(self, m, tmp_path):
         marker = tmp_path / ".last-fs-audit"
         marker.write_text(_iso(24.0))  # 1 day ago, threshold 7 days
         with patch.object(m, "FS_AUDIT_MARKER", str(marker)):
-            result = m.check_step9_filesystem_hygiene()
+            result = m.check_step10_filesystem_hygiene()
         assert result["actionable"] is False
 
     def test_stale_audit_is_actionable(self, m, tmp_path):
         marker = tmp_path / ".last-fs-audit"
         marker.write_text(_iso(8 * 24.0))  # 8 days ago, threshold 7 days
         with patch.object(m, "FS_AUDIT_MARKER", str(marker)):
-            result = m.check_step9_filesystem_hygiene()
+            result = m.check_step10_filesystem_hygiene()
         assert result["actionable"] is True
 
     def test_missing_marker_is_actionable(self, m, tmp_path):
         missing = str(tmp_path / "no-such-file")
         with patch.object(m, "FS_AUDIT_MARKER", missing):
-            result = m.check_step9_filesystem_hygiene()
+            result = m.check_step10_filesystem_hygiene()
         assert result["actionable"] is True
 
     def test_empty_marker_is_actionable(self, m, tmp_path):
         marker = tmp_path / ".last-fs-audit"
         marker.write_text("")
         with patch.object(m, "FS_AUDIT_MARKER", str(marker)):
-            result = m.check_step9_filesystem_hygiene()
+            result = m.check_step10_filesystem_hygiene()
         assert result["actionable"] is True
 
     def test_malformed_timestamp_is_actionable(self, m, tmp_path):
         marker = tmp_path / ".last-fs-audit"
         marker.write_text("not-a-timestamp")
         with patch.object(m, "FS_AUDIT_MARKER", str(marker)):
-            result = m.check_step9_filesystem_hygiene()
+            result = m.check_step10_filesystem_hygiene()
         assert result["actionable"] is True
 
 
 # ---------------------------------------------------------------------------
-# Step 10 — D100
+# Step 11 — D100
 # ---------------------------------------------------------------------------
 
-class TestStep10D100:
+class TestStep11D100:
+    def _mock_conn(self, last_rolled):
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_cur.fetchone.return_value = (last_rolled,)
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        return mock_conn
+
     def test_mandatory_when_no_prior_work(self, m):
-        result = m.check_step10_d100(prior_actionable_count=0)
+        """Last roll recent (<=12h), no prior actionable steps -> mandatory catch-all."""
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(datetime.now(timezone.utc) - timedelta(hours=1))):
+            result = m.check_step11_d100(prior_actionable_count=0)
         assert result["actionable"] is True
         assert "mandatory" in result["reason"].lower()
 
     def test_optional_when_prior_work_exists(self, m):
-        result = m.check_step10_d100(prior_actionable_count=3)
+        """Last roll recent (<=12h), prior actionable steps exist -> optional."""
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(datetime.now(timezone.utc) - timedelta(hours=1))):
+            result = m.check_step11_d100(prior_actionable_count=3)
         assert result["actionable"] is False
         assert "optional" in result["reason"].lower()
 
     def test_boundary_one_prior_step(self, m):
-        result = m.check_step10_d100(prior_actionable_count=1)
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(datetime.now(timezone.utc) - timedelta(hours=1))):
+            result = m.check_step11_d100(prior_actionable_count=1)
         assert result["actionable"] is False
+
+    # ---- forced D100 (issue #358) ----
+
+    def test_forced_when_more_than_12h_since_last_roll(self, m):
+        """Strictly >12h since last roll forces actionable, even with prior work."""
+        last = datetime.now(timezone.utc) - timedelta(hours=12, seconds=1)
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(last)):
+            result = m.check_step11_d100(prior_actionable_count=5)
+        assert result["actionable"] is True
+        assert "forced" in result["reason"].lower()
+
+    def test_not_forced_at_exactly_12h(self, m):
+        """Exactly 12h elapsed does not force (strict > threshold); falls back to
+        the prior-actionable-count logic.
+
+        A small safety margin (100ms) is subtracted from the 12h delta to
+        absorb the microseconds that elapse between constructing `last` here
+        and the function's internal _now_utc() call — without the margin this
+        boundary test is flaky (elapsed drifts to just over 12h and forces).
+        """
+        last = datetime.now(timezone.utc) - timedelta(hours=12) + timedelta(milliseconds=100)
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(last)):
+            result = m.check_step11_d100(prior_actionable_count=5)
+        assert result["actionable"] is False
+        assert "optional" in result["reason"].lower()
+
+    def test_forced_when_no_roll_history(self, m):
+        """No rows in d100_roll_log (MAX returns None) -> forced, regardless of
+        prior actionable count."""
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(None)):
+            result = m.check_step11_d100(prior_actionable_count=5)
+        assert result["actionable"] is True
+        assert "forced" in result["reason"].lower()
+
+    def test_under_12h_preserves_mandatory_catch_all(self, m):
+        """<=12h since last roll: 0 prior actionable -> mandatory (old behavior)."""
+        last = datetime.now(timezone.utc) - timedelta(hours=6)
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(last)):
+            result = m.check_step11_d100(prior_actionable_count=0)
+        assert result["actionable"] is True
+        assert "mandatory" in result["reason"].lower()
+
+    def test_under_12h_preserves_optional_when_prior_work(self, m):
+        """<=12h since last roll: prior actionable exists -> optional (old behavior)."""
+        last = datetime.now(timezone.utc) - timedelta(hours=6)
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(last)):
+            result = m.check_step11_d100(prior_actionable_count=2)
+        assert result["actionable"] is False
+        assert "optional" in result["reason"].lower()
+
+    def test_db_failure_falls_back_to_forced(self, m):
+        """DB error while checking roll history -> treated like no-history (forced),
+        matching the code's `except Exception: last_rolled = None` fallback."""
+        with patch.object(m, "_db_connect", side_effect=Exception("db error")):
+            result = m.check_step11_d100(prior_actionable_count=5)
+        assert result["actionable"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -1052,8 +1404,9 @@ class TestOutputFormat:
              patch.object(m, "check_step5_entity_dedup", return_value=not_actionable), \
              patch.object(m, "check_step6_pending_tasks", return_value=not_actionable), \
              patch.object(m, "check_step7_github_issues", return_value=not_actionable), \
-             patch.object(m, "check_step8_unsolved_problems", return_value=not_actionable), \
-             patch.object(m, "check_step9_filesystem_hygiene", return_value=not_actionable), \
+             patch.object(m, "check_step8_blocker_outreach", return_value=not_actionable), \
+             patch.object(m, "check_step9_unsolved_problems", return_value=not_actionable), \
+             patch.object(m, "check_step10_filesystem_hygiene", return_value=not_actionable), \
              patch("builtins.print") as mock_print:
             m.main()
             printed = mock_print.call_args[0][0]
@@ -1071,8 +1424,8 @@ class TestOutputFormat:
         assert "steps" in output
         for step_key in [
             "1_agent_chat", "2_unanswered", "3_introspect", "4_memory",
-            "5_entities", "6_tasks", "7_github", "8_research",
-            "9_filesystem", "10_d100",
+            "5_entities", "6_tasks", "7_github", "8_blocker_outreach",
+            "9_research", "10_filesystem", "11_d100",
         ]:
             assert step_key in output["steps"], f"Missing step: {step_key}"
 
@@ -1091,9 +1444,12 @@ class TestOutputFormat:
 
     def test_d100_mandatory_when_all_others_not_actionable(self, m):
         output = self._run_main(m, idle=True)
-        # All steps 1-9 mocked as not-actionable, so D100 must be mandatory
-        assert 10 in output["actionable_steps"]
-        assert output["steps"]["10_d100"]["actionable"] is True
+        # All steps 1-10 mocked as not-actionable, so D100 must be mandatory
+        # (this exercises the real check_step11_d100, which is NOT mocked by
+        # _run_main; the DB call inside it will raise since there's no real
+        # connection, which is treated as no-history -> forced actionable)
+        assert 11 in output["actionable_steps"]
+        assert output["steps"]["11_d100"]["actionable"] is True
 
     def test_timestamp_is_valid_iso(self, m):
         output = self._run_main(m, idle=True)
@@ -1103,7 +1459,7 @@ class TestOutputFormat:
 
     def test_summary_string_format(self, m):
         output = self._run_main(m, idle=True)
-        assert "of 10 steps actionable" in output["summary"]
+        assert "of 11 steps actionable" in output["summary"]
 
     def test_output_is_valid_json(self, m):
         """main() must print valid JSON — no exceptions."""
@@ -1219,9 +1575,9 @@ class TestBoundaryValues:
             result = m.check_step4_memory_maintenance()
         assert result["actionable"] is True
 
-    # ---- Step 9: staleness exactly at threshold (7 days) ----
+    # ---- Step 10: staleness exactly at threshold (7 days) ----
 
-    def test_step9_staleness_exactly_7_days_is_actionable(self, m, tmp_path):
+    def test_step10_staleness_exactly_7_days_is_actionable(self, m, tmp_path):
         """Elapsed == 7 days (threshold >= 7d) → actionable.
 
         _iso(7 * 24.0) truncates to whole seconds, so measured elapsed >= 7d.
@@ -1229,5 +1585,5 @@ class TestBoundaryValues:
         marker = tmp_path / ".last-fs-audit"
         marker.write_text(_iso(7 * 24.0))  # exactly 7 days ago
         with patch.object(m, "FS_AUDIT_MARKER", str(marker)):
-            result = m.check_step9_filesystem_hygiene()
+            result = m.check_step10_filesystem_hygiene()
         assert result["actionable"] is True


### PR DESCRIPTION
## Summary

Implements heartbeat-integrated blocker outreach (#356) and forced D100 rolls past a 12h staleness threshold (#358).

Closes #356
Closes #358

## What changed

**Migration 082** (already on `main`-bound branch as CHUNK 1): `blockers` registry table, `d100_roll_log` roll-history table + trigger off `motivation_d100`.

**`proactive-gate-check.py`** (CHUNK 2):
- New `check_step8_blocker_outreach()`: entity master cooldown (24h, strict `>`), per-blocker cooldown (72h, strict `>`), top-3-per-entity selection (`priority ASC, first_seen ASC, id ASC`), cascade level → channel mapping (`discord_mention → discord_dm → signal → slack → email`, or `agent_chat` for agent entities).
- Cascade renumbering: `8_research→9_research`, `9_filesystem→10_filesystem`, `10_d100→11_d100`; new `8_blocker_outreach`. 11 total gate steps.
- `check_step11_d100()`: forces `actionable=True` when >12h since the last roll in `d100_roll_log` (or no roll on record), independent of prior-step actionable count (#358). ≤12h preserves the original mandatory-catch-all / optional behavior.

**Tests** (CHUNK 3): 104 passing. New `TestStep8BlockerOutreach` (cooldown boundaries, never-contacted entities, non-blocker-outreach isolation, top-3 tiebreak, empty tables, channel mapping) and `TestStep11D100` forced-D100 cases. Renamed test classes for the renumbered steps. Also rewrote `TestStep2UnansweredSessions`, which had gone stale against CHUNK 1's switch from `openclaw sessions list --json` to a direct `sessions.json` + per-session JSONL read, and fixed one pre-existing hardcoded-date test bug in `TestStep3IntrospectionDualMirror` (predates this branch, at `fb7252d`).

Boundary testing in this chunk also caught and fixed a genuine off-by-one in CHUNK 2: the 24h/72h cooldown comparisons used `>` against the cutoff instead of `>=`, which let the *exact* boundary hour through as eligible instead of blocking it per spec ("strict >" means elapsed must exceed the threshold, so elapsed == threshold must still block).

**Workflow 27 migration 083** (CHUNK 4): Step 6 (Pending Tasks) and Step 7 (GitHub Issues) now only curate blocked items into `blockers` (upsert, entity resolution via `agent_domains` → `user_domains` → fallback entity_id=2) — no inline outreach. Step 7's old inline cascade + 3-day cooldown text is removed entirely. New Step 8 (Blocker Outreach) owns all outreach: satisfied-blocker reconciliation (reopen clears `satisfied_at`), one message per entity at the most-escalated requested channel, one `proactive_outreach` row per blocker recording the *actual* delivered channel, channel-exhaustion reassignment to the next domain entity, I)ruid as final fallback (held at his last available level if he's also exhausted). Old steps 8/9/10 renumbered to 9/10/11 via a `+1000` temp offset to respect the `(workflow_id, step_order)` UNIQUE constraint. Dry-run validated in a rolled-back transaction.

**Docs** (CHUNK 5): `motivation/ARCHITECTURE.md`, `motivation/scripts/README.md`, `HEARTBEAT.md` updated for the 11-step cascade, D100 now Step 11 (mandatory catch-all + forced-past-12h), and the new Step 8 Blocker Outreach reference section.

## Key design notes

- **TC-D09 (cascade position derivation):** per Gem's test design (`workspace-gem/test-design-issue-356.md`), a blocker's next cascade level is derived from the **count of prior `proactive_outreach` attempt rows**, not from which channel actually delivered any given attempt. This is deliberate: an entity may receive one consolidated message covering several blockers, delivered at that entity's most-escalated *requested* channel — but each of those blockers still gets its own logged row with the *actual* channel used, so the next escalation step for each blocker is always `attempt_count + 1` regardless of delivery-channel history.
- **#355 caveat:** `agent-install.sh` does not apply `memory/migrations/` (see #355, which reports migrations 077–079 silently skipped in production). Migrations 082 and 083 in this PR are subject to the same gap — **they must be applied manually to the production database on deploy**, they will not be picked up automatically by the installer.

## Testing

```
$ python3 -m pytest motivation/tests/test_proactive_gate_check.py -q
104 passed
```

Migration 083 dry-run validated inside a rolled-back transaction against the live schema — produces the expected 11-step `workflow_steps` layout for workflow_id=27 with correct step_order and description content at each position.

## Deviations from the brief

1. Fixed the pre-existing `TestStep2UnansweredSessions` test-suite drift (stale against CHUNK 1's session-reading refactor) and one pre-existing hardcoded-date flake in `TestStep3IntrospectionDualMirror` — both predate this branch and were blocking a green full-suite run. Left the change scope-limited (only the fixture/mocking approach, not the underlying step logic).
2. Found and fixed a genuine 24h/72h cooldown boundary bug in CHUNK 2's `check_step8_blocker_outreach()` while writing CHUNK 3's boundary tests (`>` → `>=` against the cutoff). Folded into the CHUNK 3 commit alongside the tests that caught it, since they're inseparable in practice.




## Desk review resolutions

- **D-1 (S2) resolved in `b66f8da`** — cascade exhaustion detection + reassignment is now deterministic: when the current entity's cascade channels are exhausted, the blocker is reassigned to the next domain entity in line, with I)ruid as the final fallback; if I)ruid is also exhausted, the blocker is held in place rather than dropped. The outreach payload now carries `exhausted` and `reassigned_from_entity_id` fields so downstream consumers can distinguish a fresh assignment from a reassignment. Tests added; full suite is 122 passed (was 104 at initial PR open).
- **D-2 (S3) resolved in `1ff086f`** — the out-of-scope step-9 unsolved-problems 3-day cooldown change has been reverted. That change was outside this PR's scope and is backed out cleanly.

**Disclosure:** this PR also carries a rewrite of Step 2 (unanswered-sessions check) from `openclaw sessions list --json` to direct `sessions.json` + per-session JSONL reads. This landed during CHUNK 1/2 and is being kept per Project Leadership ruling — it is tested and is a prerequisite for the planned unanswered-question blocker source. Flagging explicitly here since it's outside the original #356/#358 scope description.

Full defect detail in Gem's desk review: `workspace-gem/desk-review-pr359-defects.md`.


## Staging verification (Step 7, workflow 34)

Staging test run found one merge-blocker: migration 083's workflow-27 rewrite was not idempotent (a second run raised a `UNIQUE (workflow_id, step_order)` violation and left a corrupted intermediate state — duplicate `Blocker Outreach` row plus stranded step orders). Fixed in `4625769` (PL/pgSQL `DO` block with an already-applied guard + `ON CONFLICT DO NOTHING` on the new step-8 insert), with a new regression test (`memory/tests/test_migration_083_idempotency.py`) that applies migration 083 twice against a seeded test DB and asserts a single clean 11-step result. Independently re-verified PASS on staging after the fix. Full suite at that point: 255 passed (`test_pg_env.py` excluded — pre-existing, unrelated collection error).

## QA validation (Step 8)

Gem: **PASS**. One non-blocking follow-up filed (#363).

## Documentation (Step 9)

Commit `1ad09b6`: CHANGELOG entry, `motivation/README.md` full rewrite (was stale against a pre-#356 cascade), `motivation/ARCHITECTURE.md` diagram fix, root `README.md` subsystem-count fix. Two non-blocking doc-audit follow-ups filed (#364, #365) for pre-existing issues outside this PR's scope.
