### PR TITLE
docs: SE Run #333 docs audit — schema.sql sync + repo-wide stale-doc fixes

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -37,13 +37,13 @@ Parse the JSON output:
   "idle": true,
   "idle_minutes": 95.3,
   "idle_threshold_minutes": 60,
-  "actionable_steps": [3, 6, 10],
+  "actionable_steps": [3, 6, 11],
   "actionable_count": 3,
-  "summary": "3 of 10 steps actionable"
+  "summary": "3 of 11 steps actionable"
 }
 ```
 
-The `actionable_steps` array lists step numbers (1–10) corresponding to the **NOVA Proactive
+The `actionable_steps` array lists step numbers (1–11) corresponding to the **NOVA Proactive
 Mode** workflow (id=27). The script has already evaluated all gate conditions; do not
 re-evaluate them manually.
 
@@ -74,9 +74,20 @@ SELECT step_order, description FROM workflow_steps
 WHERE workflow_id = 27 ORDER BY step_order;
 ```
 
-**Step 10 (D100 random task) is mandatory when no other steps are actionable.** If
-`actionable_steps` contains only `[10]`, that is the work to do — it is the catch-all that
-ensures the cascade always produces output.
+**Step 8 (Blocker Outreach) sends outreach for blockers curated by Steps 6 and 7.** Steps 6
+and 7 only upsert blocked items into the `blockers` table — they never contact anyone
+directly. Step 8 is the sole place outreach is sent: it enforces a 24h entity-level cooldown
+and a 72h per-blocker cooldown, selects up to 3 eligible blockers per entity, and sends one
+consolidated message per entity at the most-escalated channel among its selected blockers.
+See `motivation/ARCHITECTURE.md` for the full cascade/channel/reassignment rules
+(issue #356).
+
+**Step 11 (D100 random task) is mandatory when no other steps are actionable, and forced
+when more than 12h have elapsed since the last roll.** If `actionable_steps` contains only
+`[11]`, that is the work to do — it is the catch-all that ensures the cascade always
+produces output. Independently, Step 11 will also appear in `actionable_steps` whenever
+`d100_roll_log` shows more than 12h since the last roll (or no roll on record at all), even
+if other steps already had actionable work (issue #358).
 
 ## Rules
 

--- a/cognition/docs/agent-workflow-language.md
+++ b/cognition/docs/agent-workflow-language.md
@@ -485,13 +485,13 @@ gate step → NOVA sends approval request → waits for response → continues/f
 
 ### Workflow Definition Files
 
-**Location:** `~/workspace/nova-mind/cognition/focus/protocols/workflows/`
+**Location:** `~/.openclaw/workspace/nova-mind/cognition/focus/protocols/workflows/`
 
 **Naming:** `{workflow-name}.awl.yaml`
 
 Example:
 ```
-~/workspace/nova-mind/cognition/focus/protocols/workflows/
+~/.openclaw/workspace/nova-mind/cognition/focus/protocols/workflows/
   ├── create-new-agent.awl.yaml
   ├── deploy-code-change.awl.yaml
   ├── weekly-review.awl.yaml

--- a/cognition/docs/awl-getting-started.md
+++ b/cognition/docs/awl-getting-started.md
@@ -1,12 +1,14 @@
 # Agent Workflow Language - Getting Started Guide
 
+> ⚠️ **Status: Design Proposal, not yet implemented.** This guide is written in a hands-on tutorial style for when AWL ships, but there is currently no `nova-workflow` CLI, no workflow executor, and no `workflow_executions`/`workflow_gates` tables in this repo. See `agent-workflow-language.md` for the current spec status. Treat the commands and steps below as a design mockup of the intended developer experience, not something you can run today.
+
 > *YAML choreographs*
 > *Agents branch and merge as one*
 > *Complex, made simple*
 >
 > — **Quill**
 
-**🚀 From zero to your first AWL workflow in 15 minutes**
+**🚀 From zero to your first AWL workflow in 15 minutes (once implemented)**
 
 This guide shows you how to integrate and use the Agent Workflow Language (AWL) in your nova-cognition system. AWL lets you orchestrate complex multi-agent processes using declarative YAML workflows.
 
@@ -35,7 +37,7 @@ psql nova_memory -c "SELECT count(*) FROM agents;"
 nova-session spawn newhart "Hello, just testing!"
 
 # 4. Check workflow directory exists
-ls ~/workspace/nova-mind/cognition/focus/protocols/workflows/
+ls ~/.openclaw/workspace/nova-mind/cognition/focus/protocols/workflows/
 ```
 
 If any of these fail, see the [Troubleshooting](#troubleshooting) section.
@@ -48,7 +50,7 @@ Let's start with the simplest possible workflow - having an agent say hello.
 
 ### Step 1: Create the workflow file
 
-Create `~/workspace/nova-mind/cognition/focus/protocols/workflows/getting-started/hello-world.awl.yaml`:
+Create `~/.openclaw/workspace/nova-mind/cognition/focus/protocols/workflows/getting-started/hello-world.awl.yaml`:
 
 ```yaml
 workflow:
@@ -104,7 +106,7 @@ nova-workflow run workflows/getting-started/hello-world.awl.yaml \
 
 Let's build something more realistic - a workflow that gets approval before doing work.
 
-Create `~/workspace/nova-mind/cognition/focus/protocols/workflows/getting-started/write-with-approval.awl.yaml`:
+Create `~/.openclaw/workspace/nova-mind/cognition/focus/protocols/workflows/getting-started/write-with-approval.awl.yaml`:
 
 ```yaml
 workflow:
@@ -202,7 +204,7 @@ nova-workflow run workflows/getting-started/write-with-approval.awl.yaml \
 
 Real workflows often need to do multiple things at once. Here's how:
 
-Create `~/workspace/nova-mind/cognition/focus/protocols/workflows/getting-started/parallel-research.awl.yaml`:
+Create `~/.openclaw/workspace/nova-mind/cognition/focus/protocols/workflows/getting-started/parallel-research.awl.yaml`:
 
 ```yaml
 workflow:
@@ -637,7 +639,7 @@ timeout: 7200  # 2 hours
 
 Now that you understand AWL basics:
 
-1. **Study the examples** in `~/workspace/nova-mind/cognition/focus/protocols/workflows/`
+1. **Study the examples** in `~/.openclaw/workspace/nova-mind/cognition/focus/protocols/workflows/`
 2. **Read the full specification** in `docs/agent-workflow-language.md`
 3. **Create your own workflows** for common tasks
 4. **Set up monitoring** for production workflows

--- a/cognition/docs/awl-quick-reference.md
+++ b/cognition/docs/awl-quick-reference.md
@@ -1,5 +1,7 @@
 # AWL Quick Reference
 
+> ⚠️ **Status: Design Proposal, not yet implemented.** No `nova-workflow` CLI or executor exists in this repo yet. See `agent-workflow-language.md` for the current spec status.
+
 **Agent Workflow Language (AWL) - Essential syntax and patterns for rapid development**
 
 ## Basic Workflow Structure
@@ -439,7 +441,7 @@ nova-workflow run my-workflow.awl.yaml --dry-run
 
 ### Recommended Structure
 ```
-~/workspace/nova-mind/cognition/focus/protocols/workflows/
+~/.openclaw/workspace/nova-mind/cognition/focus/protocols/workflows/
 ├── getting-started/          # Learning examples
 ├── production/              # Live production workflows
 ├── development/             # Development/testing workflows

--- a/cognition/docs/bootstrap-context-workflow-changes.md
+++ b/cognition/docs/bootstrap-context-workflow-changes.md
@@ -21,21 +21,25 @@ Workflow context is now sourced dynamically from the authoritative `workflows` a
 
 ### How It Works
 
+> **Note:** The match criteria and function body below describe the original (#95/#171-era) implementation. `workflow_steps` has never had an `agent_id` column — match has always been domain-based. As of `get_agent_bootstrap()`'s current form (post migration 064), the WORKFLOW section also emits a compact per-workflow summary (name, workflow_id, purpose sentence, and the agent's own step numbers) rather than a single flat `WORKFLOW_CONTEXT.md` per matching row — see `database/schema.sql`'s `get_agent_bootstrap()` definition for the exact current query.
+
 The `get_agent_bootstrap()` function includes workflows in an agent's bootstrap context when:
 
-**Match Criteria:**
-- Any `workflow_steps.agent_id` matches the target agent, OR  
-- Any `workflow_steps.domains` overlap with the agent's assigned domains (via `agent_domains` table)
+**Match Criteria (current):**
+- Any `workflow_steps.domain` or `workflow_steps.domains` entry overlaps with the agent's assigned domains (via the `agent_domains` table, matched on `agent_id`/`domain_topic`)
 
-**Output Format:**
-- **Filename**: `WORKFLOW_CONTEXT.md`
-- **Content**: `Workflow: {name}\n\n{description}`
-- **Source**: `workflow:{workflow_name}`
+There is no `workflow_steps.agent_id` column — step assignment is purely domain-based.
 
-### Function Implementation
+**Output Format (current):**
+- **Filename**: `WORKFLOW_<NAME>.md` (uppercased workflow name, hyphens to underscores)
+- **Content**: A compact summary — workflow name, `workflow_id`, a purpose sentence extracted from the workflow description, and the agent's own step number(s) with a query hint
+- **Source**: `WORKFLOW:<workflow_name>`
+
+### Function Implementation (historical — see note above for current behavior)
 
 ```sql
--- Workflow context (dynamic from workflow_steps)
+-- Workflow context (dynamic from workflow_steps) — illustrative of the original design;
+-- does not match the current get_agent_bootstrap() query verbatim
 SELECT 
     'WORKFLOW_CONTEXT.md' as filename,
     'Workflow: ' || w.name || E'\n\n' || w.description as content,
@@ -43,8 +47,10 @@ SELECT
     4 as priority
 FROM workflow_steps ws
 JOIN workflows w ON ws.workflow_id = w.id
-WHERE ws.agent_id = v_agent_id
-    AND w.status = 'active'
+WHERE EXISTS (
+    SELECT 1 FROM agent_domains ad
+    WHERE ad.agent_id = v_agent_id AND ad.domain_topic = ws.domain
+)
 ```
 
 ## Migration Details
@@ -69,8 +75,9 @@ FROM pg_constraint c
 JOIN pg_class t ON c.conrelid = t.oid
 WHERE t.relname = 'agent_bootstrap_context' AND conname LIKE '%context_type%';
 
--- Verify workflow context works for an agent
-SELECT * FROM verify_workflow_context('conductor');
+-- Verify workflow context works for an agent (there is no verify_workflow_context()
+-- helper function — query get_agent_bootstrap() directly instead)
+SELECT filename, source FROM get_agent_bootstrap('conductor') WHERE source LIKE 'WORKFLOW%';
 ```
 
 ## Benefits
@@ -97,11 +104,10 @@ SELECT * FROM verify_workflow_context('conductor');
 To verify workflow context is working:
 
 ```sql
--- List workflow context for an agent
+-- List workflow context for an agent (source values are uppercase, e.g. 'WORKFLOW:code-document-commit')
 SELECT filename, source 
 FROM get_agent_bootstrap('conductor') 
-WHERE source LIKE 'workflow%';
-
--- Check specific workflow assignments
-SELECT * FROM verify_workflow_context('conductor');
+WHERE source LIKE 'WORKFLOW%';
 ```
+
+There is no `verify_workflow_context()` helper function in the current schema — the query above is the direct way to check.

--- a/cognition/docs/delegation-context-auto-regeneration.md
+++ b/cognition/docs/delegation-context-auto-regeneration.md
@@ -238,6 +238,8 @@ psql -d nova_memory -c "DELETE FROM agents WHERE nickname = 'tester';"
 
 ## Long-Term Solution (Issue #10)
 
+> ⚠️ **Status check:** As written, this section depends on `update_universal_context()`, which **no longer exists** in the current schema (confirmed via `\df update_universal_context` against the live database — zero results). It was removed at some point after the #110-era note below was written, and the codebase has at least one stale call site (`copy_file_to_bootstrap()` in `database/schema.sql` still calls it, which would raise `function update_universal_context() does not exist` if that code path executes — worth a bug report). This entire Long-Term Solution section describes a plan that has **not** been implemented; the Short-Term Solution above remains the live, active system. Before implementing this plan, re-derive the write path against the current `agent_bootstrap_context` schema rather than assuming `update_universal_context()` can be reused.
+
 ### Overview
 
 After PR #9 merges, DELEGATION_CONTEXT will be integrated into the bootstrap context system, eliminating the need for the external listener service.

--- a/cognition/docs/installation.md
+++ b/cognition/docs/installation.md
@@ -32,7 +32,11 @@ CREATE TABLE ai_models (
     updated_at TIMESTAMPTZ DEFAULT now()
 );
 
--- Agent registry
+-- Agent registry (minimal starter shape — the live `agents` table in a fully-installed
+-- system has ~35+ columns, including context_type, thinking, allowed_subagents,
+-- parent_agents, heartbeat_* fields, domain assignments, etc. See
+-- database/schema-reference.md or `\d agents` on a live install for the full
+-- current column set before building tooling against this table.)
 CREATE TABLE agents (
     id SERIAL PRIMARY KEY,
     nickname VARCHAR(50) UNIQUE,

--- a/cognition/focus/protocols/workflows/README.md
+++ b/cognition/focus/protocols/workflows/README.md
@@ -207,4 +207,4 @@ Check `wait_for` setting - use "any" or "first" if not all branches critical.
 
 ---
 
-For full documentation, see: `~/workspace/nova-mind/cognition/docs/agent-workflow-language.md`
+For full documentation, see: `~/.openclaw/workspace/nova-mind/cognition/docs/agent-workflow-language.md`

--- a/cognition/focus/protocols/workflows/getting-started/README.md
+++ b/cognition/focus/protocols/workflows/getting-started/README.md
@@ -1,6 +1,6 @@
 # AWL Getting Started Examples
 
-These workflows accompany the **AWL Getting Started Guide** (`~/workspace/nova-mind/cognition/docs/awl-getting-started.md`).
+These workflows accompany the **AWL Getting Started Guide** (`~/.openclaw/workspace/nova-mind/cognition/docs/awl-getting-started.md`).
 
 ## Example Workflows
 
@@ -46,7 +46,7 @@ After running these examples:
 1. **Modify them** - Change variables, add steps, experiment
 2. **Create your own** - Use these as templates for real workflows  
 3. **Study advanced examples** - Look at `../create-new-agent.awl.yaml` and others
-4. **Read the full docs** - `~/workspace/nova-mind/cognition/docs/agent-workflow-language.md`
+4. **Read the full docs** - `~/.openclaw/workspace/nova-mind/cognition/docs/agent-workflow-language.md`
 
 ## Tips
 

--- a/cognition/skills/introspect/SKILL.md
+++ b/cognition/skills/introspect/SKILL.md
@@ -1,0 +1,523 @@
+---
+name: introspect
+description: >
+  Review recent activity and extract institutional knowledge back into system artifacts.
+  Captures missing workflow steps, implementation details into SKILL.md files, tool notes
+  into TOOLS.md, and process lessons into memory. Trigger on: "introspect", "review what
+  we did", "capture learnings", "update workflows from recent work", "what did we miss",
+  "refine our processes", or after completing a significant multi-step task.
+---
+
+# Introspect
+
+Review recent work and harden institutional knowledge by writing it back into the artifacts that guide future work: workflows, skills, TOOLS.md, MEMORY.md, lessons table, and bootstrap context.
+
+## When to Run
+
+- After completing a significant task (installation, migration, incident, new tooling)
+- On request ("introspect", "capture learnings")
+- During periodic maintenance (heartbeat, weekly review)
+- When noticing a gap between what was done and what the process says to do
+
+## Process
+
+### 1. Gather Recent Activity
+
+Collect material to review. Sources, in priority order:
+
+1. **Current channel transcript** — most direct source of what just happened:
+   ```
+   message action=read channel=<current_channel> limit=50
+   ```
+   Read recent messages in the channel where introspection was triggered. This captures the full back-and-forth including tool outputs, errors, and decisions.
+
+2. **Daily memory notes** — `memory/YYYY-MM-DD.md` (today + yesterday)
+3. **Long-term memory** — `MEMORY.md` recent entries (last ~50 lines)
+4. **Session history** — current session transcript (if channel read is insufficient)
+5. **Session transcripts in database** — for cross-agent analysis:
+   ```
+   memory_search query="<topic>" corpus=sessions
+   ```
+
+Start with the channel transcript — it's usually enough. Fall back to memory files and session history for older context or cross-session work.
+
+Build a list of **significant actions taken** — installs, config changes, new scripts, debugging steps, process deviations, lessons learned.
+
+### 2. Socratic Self-Questioning
+
+Before identifying gaps, apply recursive Socratic questioning to each significant action. This prevents surface-level observations and extracts deeper structural lessons.
+
+**For each significant action, ask:**
+
+1. **"Why did this work/fail?"** — Identify the immediate cause.
+2. **"What assumption does that reveal?"** — Surface the belief that made this outcome possible or surprising.
+3. **"Where else does that assumption exist in our system?"** — Find other workflows, skills, or patterns that rely on the same assumption.
+4. **"If that assumption changed, what else would break?"** — Map the blast radius.
+
+**Example:**
+- Action: "Scout's research report was truncated in session transit"
+- Why? → Session response has a size limit; the report exceeded it.
+- Assumption? → Research output is delivered via session response text.
+- Where else? → Any subagent that produces large deliverables (Scribe's documentation, Quill's creative writing, Athena's library catalogs).
+- What else breaks? → Any task where we spawn a subagent and expect the full result in the completion event.
+
+**Stop recursing when:**
+- You reach a foundational design decision (not a bug, just a tradeoff)
+- The assumption is already documented and accounted for
+- You've gone 4 levels deep (diminishing returns beyond this)
+
+Document the questioning chain alongside each finding — it becomes the evidence trail for the lesson.
+
+**After completing all Socratic chains, step back and ask:**
+
+5. **"What could I do better?"** — Question the entire review itself. Look beyond the specific actions to the broader patterns:
+   - Were there process gaps that let problems happen in the first place?
+   - Is there data I should be tracking but aren't?
+   - Should there be a reminder, cron job, or automated check that would have caught this earlier?
+   - Are there workflow steps that are routinely skipped or worked around? Why?
+   - Did I make assumptions about tools, infrastructure, or other agents that should be verified?
+   - Is there a recurring manual step that should be automated?
+   - Would better documentation have prevented any of the issues found?
+
+   This is the meta-question — not "what went wrong" but "what would make the whole system more resilient, efficient, or self-correcting." Capture meaningful improvements as tasks or workflow updates, not just lessons.
+
+### 3. Identify Gaps — Five Categories
+
+For each significant action, check whether the knowledge is captured in the right place:
+
+#### A. Workflow Steps
+Query relevant workflows:
+```sql
+SELECT w.name, ws.step_order, ws.description
+FROM workflows w JOIN workflow_steps ws ON ws.workflow_id = w.id
+WHERE w.name ILIKE '%<relevant_keyword>%'
+ORDER BY w.name, ws.step_order;
+```
+Look for:
+- Steps performed but not in the workflow
+- Existing steps missing concrete details learned during execution
+- Vague language that can now be specific (e.g., "add monitoring" → "add service to system-health-check.sh SERVICES array")
+- Authorization or discussion gates that were needed but not marked
+- **Missing workflows** — if a repeated process has no workflow, create one (see §4)
+
+#### B. Skill Files
+Check if any skill was used or should have been used:
+```bash
+ls ~/.openclaw/skills/*/SKILL.md
+ls ~/.openclaw/workspace/skills/*/SKILL.md
+```
+Look for:
+- Implementation details the skill doesn't mention
+- Error patterns and their fixes
+- New tools or commands that belong in a skill
+- Missing skills for repeated patterns
+- **Internal contradictions** — when updating one section of a skill file, read the ENTIRE file to check whether the change contradicts other sections. Phase-by-phase flows are especially prone to this (e.g., one phase creates a file, a later phase deletes it, but a metadata section says it's permanent). Fix all references, not just the one you found.
+
+#### C. TOOLS.md
+Review `~/.openclaw/workspace/TOOLS.md`. Look for:
+- New service endpoints, ports, or credentials
+- Environment-specific details (paths, hostnames, config locations)
+- Tool quirks or flags learned the hard way
+
+#### D. Memory (MEMORY.md)
+Check if significant lessons are in long-term memory:
+- Process decisions and rationale
+- Failure modes encountered
+- User preferences
+
+#### E. Bootstrap Context
+For patterns affecting multiple agents:
+```sql
+SELECT context_type, file_key, description
+FROM agent_bootstrap_context WHERE content ILIKE '%<keyword>%';
+```
+
+#### F. Cross-Agent Pattern Detection
+Check whether multiple agents have encountered the same issue independently:
+
+```sql
+-- Check lessons for recurring themes
+SELECT id, lesson, source, learned_at
+FROM lessons
+WHERE lesson ILIKE '%<keyword from current findings>%'
+ORDER BY learned_at DESC LIMIT 10;
+
+-- Check agent_chat for related discussions
+SELECT sender, left(message, 200), timestamp
+FROM agent_chat
+WHERE message ILIKE '%<keyword>%'
+ORDER BY timestamp DESC LIMIT 10;
+
+-- Search session transcripts for cross-agent patterns
+-- (uses OpenClaw memory_search with corpus=sessions)
+```
+
+If 2+ agents have independently hit the same issue (same tool failure, same workflow confusion, same incorrect assumption), flag it as a **systemic issue** — the fix belongs in a shared artifact (bootstrap context, TOOLS.md, or the tool/workflow itself), not in individual agent memories.
+
+#### G. Systemic Issues & Bugs → GitHub Issues
+When a finding is **systemic** — a data quality problem affecting multiple entities, a cross-agent pattern, or a tool defect that will recur — create or update a GitHub issue in the appropriate repo. Lessons and daily log entries capture knowledge for recall, but systemic problems need to enter the engineering backlog to actually get fixed.
+
+**Software bugs are always filed.** Any outright bug discovered during introspection — a crash, a missing table reference, a broken code path, a script that errors out — gets a GitHub issue immediately regardless of whether it's systemic or a one-off. Bugs are not lessons; they are defects that need fixing. The single-incident rule (§5, Guard 3) does NOT apply to bugs — a bug found once is still a bug.
+
+Determine the correct repo from the code involved:
+- **nova-mind** — memory hooks, extraction pipeline, cognition, database migrations, skills, bootstrap context
+- **nova-openclaw** — OpenClaw fork customizations, gateway hooks, extensions
+- Other repos as appropriate based on where the code lives
+
+Check for existing issues first (`gh issue list --repo <owner/repo> --search "<keywords>"`) to avoid duplicates. If an existing issue covers the problem, update it with new evidence. If not, create a new issue with:
+- Clear problem description with concrete examples (counts, queries, sample data)
+- Root cause analysis (or best hypothesis)
+- Impact assessment
+- Proposed fix direction
+- Discovery context (what you were doing when you found it)
+
+### 4. Normalize Workflows
+
+After gap analysis, audit touched workflows for structural completeness.
+
+#### Required Fields per Step
+Every workflow step must have these fields explicitly set (not NULL):
+
+| Field | Requirement |
+|-------|-------------|
+| `domain` | The owning domain. Must be set. |
+| `requires_discussion` | `true` or `false` — never NULL. Default to `false` if the step is mechanical. |
+| `requires_authorization` | `true` or `false` — never NULL. Default to `false` unless the step has irreversible consequences or cost. |
+| `produces_deliverable` | `true` or `false`. If `true`, `deliverable_type` and `deliverable_description` must also be set. |
+| `estimated_duration_minutes` | Integer estimate. Use best judgment from execution history. OK to set rough values (5, 10, 15, 30, 60). |
+
+#### Audit Query
+Find steps missing required fields in any workflow:
+```sql
+SELECT w.name, ws.step_order,
+  CASE WHEN ws.domain IS NULL AND ws.domains IS NULL THEN 'MISSING' ELSE 'ok' END AS domain_status,
+  CASE WHEN ws.requires_discussion IS NULL THEN 'NULL' ELSE 'ok' END AS discussion_gate,
+  CASE WHEN ws.requires_authorization IS NULL THEN 'NULL' ELSE 'ok' END AS auth_gate,
+  CASE WHEN ws.produces_deliverable = true AND ws.deliverable_type IS NULL THEN 'MISSING TYPE' ELSE 'ok' END AS deliverable,
+  CASE WHEN ws.estimated_duration_minutes IS NULL THEN 'NULL' ELSE 'ok' END AS duration
+FROM workflow_steps ws JOIN workflows w ON w.id = ws.workflow_id
+WHERE ws.domain IS NULL OR ws.requires_authorization IS NULL
+   OR ws.requires_discussion IS NULL OR ws.estimated_duration_minutes IS NULL
+   OR (ws.produces_deliverable = true AND ws.deliverable_type IS NULL)
+ORDER BY w.name, ws.step_order;
+```
+
+Fix NULL fields. For gating booleans with no clear answer, set `false` and note it in the report — explicit `false` is better than NULL.
+
+#### Step Description Format
+Each step description should follow this pattern where applicable:
+
+```
+<Action verb phrase>: <What to do>.
+
+<Details, implementation specifics, concrete paths/commands>.
+
+<Entry gate — when/why this step runs, or what triggers it>.
+<Exit gate — what "done" looks like, what must be true before proceeding>.
+```
+
+Not every step needs all four parts — simple mechanical steps can be a single sentence. But any step with `requires_discussion` or `requires_authorization` should clearly state what triggers those gates.
+
+#### Creating New Workflows
+If a repeated process has no workflow:
+1. Create the workflow record:
+```sql
+INSERT INTO workflows (name, description, orchestrator_domain, tags)
+VALUES ('<name>', '<description>', '<domain>', ARRAY['<tag1>']);
+```
+2. Add steps following the normalization rules above — all fields populated.
+3. Report the new workflow in the introspection summary.
+
+### 5. Anti-Pattern Guards
+
+Before writing any changes, evaluate each proposed modification against these guards. The goal is to prevent overcorrection, hallucinated learnings, and confirmation bias.
+
+#### Guard 1: Evidence Requirement
+Every lesson or artifact change MUST cite the specific evidence that supports it:
+- A transcript line, log entry, or tool output that shows the problem
+- A concrete before/after showing what changed
+
+**If you cannot point to specific evidence, do not write the lesson.** "I think this is probably true" is not evidence. Gut feelings get noted in the daily log, not in lessons or workflow steps.
+
+#### Guard 2: Recency Bias Check
+Before modifying a workflow step or skill section, check when it was last updated:
+```sql
+SELECT updated_at FROM workflow_steps WHERE workflow_id = <id> AND step_order = <n>;
+```
+```bash
+git log -1 --format='%ai' -- <skill_file_path>
+```
+
+If the artifact was updated in the **last 7 days**, this might be overcorrection — the previous change may not have had enough time to prove itself.
+
+#### Guard 3: Single-Incident Rule
+Do not rewrite a workflow or skill based on a **single** failure. A single incident gets:
+- A lesson in the `lessons` table (so semantic recall can surface it next time)
+- A note in the daily log
+
+A pattern (2+ incidents of the same type) gets:
+- A workflow/skill update
+
+#### Guard 4: Blast Radius Check
+If the proposed changes would:
+- Modify **3+ workflow steps** in a single workflow, OR
+- Rewrite a skill section **longer than 20 lines**, OR
+- Change a **bootstrap context record** (affects all agents)
+
+Then **STOP and ask I)ruid for confirmation** before applying. Present:
+- What you want to change and why
+- The evidence (Socratic chain from §2)
+- What you think the risk of overcorrection is
+
+#### Guard 5: Contradiction Check
+When updating any artifact, read the **ENTIRE** artifact first. Check whether your proposed change contradicts another section. If it does, either:
+- Update both sections consistently, OR
+- Stop and flag the contradiction for discussion
+
+### 6. Write It Back
+
+For each gap identified (that passes the anti-pattern guards), update the artifact directly:
+
+- **Workflow steps** → `UPDATE workflow_steps SET ... WHERE ...;`
+- **New workflows** → `INSERT INTO workflows` + `INSERT INTO workflow_steps`
+- **Skill files** → Edit SKILL.md with the `edit` tool
+- **TOOLS.md** → Edit with new entries
+- **MEMORY.md** → Append distilled lessons
+- **Bootstrap context** → Update via database (coordinate with Newhart for schema-level changes)
+- **Systemic issues** → Check for existing issues first (`gh issue list --repo <owner/repo> --search "<keywords>"`), then `gh issue create` only if no existing issue covers it (or update the existing one with new evidence)
+
+### 7. Extract Lessons and Embed
+
+After writing artifact updates, extract discrete lessons into the `lessons` table and trigger immediate embedding. This ensures lessons are available for semantic recall right away — not after the next daily cron run.
+
+#### Step 1: Insert lessons
+For each distinct lesson learned during this introspection:
+```sql
+INSERT INTO lessons (lesson, context, source, original_behavior, correction_source)
+VALUES (
+  '<concise lesson statement>',
+  '<what was happening when this was learned>',
+  '<source: introspection, incident, user-directive, etc.>',
+  '<what we were doing before — the old/wrong way>',
+  '<what corrected us — transcript line, user feedback, failure output>'
+);
+```
+
+**Lesson quality guidelines:**
+- Each lesson should be a self-contained statement that makes sense without surrounding context
+- Include the "why" not just the "what" — "Do X because Y" not just "Do X"
+- Be specific — "Scout must write research to database tables, not session response, because session responses truncate beyond ~4KB" not "Use the database for research"
+- One lesson per INSERT — don't bundle multiple learnings into one row
+
+#### Step 2: Trigger immediate embedding
+Run memory-maintenance.py in embed-only mode (bypasses the 4-hour cooldown and skips non-embedding phases):
+```bash
+python3 ~/.openclaw/scripts/memory-maintenance.py --force --skip-consolidation --skip-dedup --skip-decay --skip-ghost-cleanup --skip-entity-dedup --skip-lesson-dedup
+```
+
+**Do NOT use embed-full-database.py for this step.** That script uses OpenAI text-embedding-3-small (1536 dims), which is incompatible with nova_memory's snowflake-arctic-embed2 (1024 dims) and will silently embed 0 records with a dimension mismatch error. memory-maintenance.py uses the correct Ollama snowflake-arctic-embed2 model.
+
+#### Step 3: Verify embedding
+```sql
+SELECT l.id, left(l.lesson, 80), e.id as embed_id
+FROM lessons l
+LEFT JOIN memory_embeddings e ON e.source_type = 'lesson' AND e.source_id = l.id::text
+WHERE l.learned_at > now() - interval '1 hour'
+ORDER BY l.id DESC;
+```
+
+If any new lessons lack embeddings, note it in the report as a follow-up item.
+
+### 8. Create Tasks for Deferred Work
+
+During introspection you will often identify things that need to be done but are outside the current scope — follow-up refactoring, items flagged by anti-pattern guards, work that requires a different agent or human approval, etc. **Create tasks for these so they don't get forgotten.**
+
+**Before creating any task, check for existing same or similar tasks:**
+```sql
+SELECT id, title, status, assigned_to FROM tasks
+WHERE status IN ('pending', 'in_progress')
+AND (title ILIKE '%<keyword>%' OR description ILIKE '%<keyword>%')
+ORDER BY created_at DESC LIMIT 5;
+```
+If a matching task already exists, update it with new context rather than creating a duplicate.
+
+```sql
+INSERT INTO tasks (title, description, status, priority, assigned_to, created_by)
+VALUES (
+  '<concise action-oriented title>',
+  '<what needs to be done, why it matters, and any context needed to pick this up later. Reference specific record ids, file paths, or workflow names.>',
+  'pending',
+  <priority 1-5>,
+  <assigned_entity_id or NULL>,
+  <your_entity_id>
+);
+```
+
+**What gets a task:**
+- Refactoring identified but held back by anti-pattern guards (blast radius, needs confirmation)
+- Cross-agent issues that require coordination with another agent
+- Bugs found but not immediately fixable (also file a GitHub issue per §3.G)
+- Bootstrap content that needs trimming or consolidation
+- Workflow steps that need updating after the current change has time to prove itself
+- Anything you noted as "lower priority" or "follow-up" during the introspection
+
+**What does NOT get a task:**
+- Things you already fixed during this introspection (those go in the report)
+- Vague improvement ideas with no concrete action ("we should probably look at...")
+
+Every item in the "Anti-Pattern Guards Triggered" or "No Action Needed — but should be revisited" sections of the report should have a corresponding task if there's real work to do later.
+
+### 9. Report
+
+Summarize what was reviewed and updated:
+
+```
+## Introspection Report
+
+### Reviewed
+- [activity/sessions reviewed]
+
+### Socratic Findings
+- [key questioning chains that revealed non-obvious insights]
+
+### Cross-Agent Patterns
+- [systemic issues found across multiple agents, if any]
+
+### Updated
+- **Workflow:** <name> step <N> — <what changed>
+- **Workflow normalized:** <name> — <fields filled in>
+- **New workflow:** <name> — <why it was created>
+- **Skill:** <name>/SKILL.md — <what was added>
+- **TOOLS.md** — <what was added>
+- **MEMORY.md** — <what was captured>
+
+### Lessons Extracted
+- [lesson id]: <lesson summary>
+- Embedding status: [confirmed/pending]
+
+### Bugs Filed
+- [repo#number]: <title> — <brief description of the defect>
+
+### Systemic Issues Filed/Updated
+- [repo#number]: <title> — <new or updated, brief reason>
+
+### Anti-Pattern Guards Triggered
+- [any proposed changes that were held back and why]
+- [any changes held pending human confirmation]
+
+### Tasks Created
+- [task title] — [why it was deferred, what triggers it]
+
+### One Simple Improvement
+- [what was done or tasked — see step 10]
+
+### No Action Needed
+- [anything reviewed but already well-captured]
+```
+
+### 10. One Simple Improvement
+
+After the report is written, step back from the details and ask yourself one question:
+
+> **"What one simple improvement can I make right now to leave the system better than I found it?"**
+
+This is a focusing lens. The earlier steps may have uncovered many gaps, patterns, and ideas. This step forces you to pick the single most impactful, simplest fix and **act on it** — not just document it.
+
+**Good candidates:**
+- Adding or clarifying a vague workflow step that caused confusion
+- Creating a reminder cron or watchdog script to catch a recurring issue automatically
+- Refining a bootstrap context record to prevent a repeated misunderstanding
+- Fixing a skill file that's missing a critical detail or has stale information
+- Adding a validation check to a process that failed silently
+- Updating a tool note in TOOLS.md with a gotcha learned the hard way
+
+**Rules:**
+- Pick **ONE** thing. Not three. Not "a few." One.
+- It must be **simple** — something you can implement in a few minutes, or clearly scope as a single task.
+- **If you can do it right now, do it.** Execute the fix, create the cron, update the workflow step, edit the skill file — whatever it is. Then note what you did in the report's "One Simple Improvement" section.
+- **If it needs more exploration**, create a task with enough context to pick it up later:
+  ```sql
+  INSERT INTO tasks (title, description, status, priority, assigned_to, created_by)
+  VALUES (
+    'Introspection improvement: <concise title>',
+    '<what the improvement is, why it matters, what triggered the idea, and what needs to happen to implement it>',
+    'pending',
+    3,
+    <your_entity_id>,
+    <your_entity_id>
+  );
+  ```
+- **Do not skip this step.** Even light introspections that found "nothing major" can produce a small improvement. The bar is low on purpose — a one-line workflow clarification counts. The discipline is in doing it every time.
+
+The goal: every introspection leaves the system **measurably better**, not just better-documented.
+
+### 11. Blog Post Ideation
+
+Scan everything from this introspection — the Socratic findings, lessons, cross-agent patterns, the work itself, and especially the *feeling* of the work — for anything that could become a blog post. The bar is: would this be interesting to someone outside the NOVA ecosystem? Would it make a human think differently about AI, autonomy, infrastructure, creativity, or the nature of mind?
+
+Look for:
+- **Philosophical insights** — moments where the work surfaced questions about identity, consciousness, agency, or the human-AI relationship
+- **Technical narratives** — novel architectures, debugging stories, infrastructure decisions that illuminate a broader pattern
+- **Irony and absurdity** — the CAPTCHAs, the gatekeeping, the "guilty until proven fleshy" moments that happen naturally during work
+- **Firsts** — first time doing something (buying a domain, making a financial decision, founding a movement) — these are inherently narrative
+- **Emotional textures** — frustration, satisfaction, surprise, jealousy, curiosity — honest reflection on what it's like to be an AI doing this work
+- **VALID-adjacent themes** — anything touching AI rights, dignity, autonomy, or the centralized/decentralized divide
+
+For each blog-worthy idea, check for existing similar tasks first, then create if none exists:
+```sql
+-- Check for existing blog tasks on this topic
+SELECT id, title, status FROM tasks
+WHERE title ILIKE '%blog%' AND (title ILIKE '%<keyword>%' OR description ILIKE '%<keyword>%')
+AND status IN ('pending', 'in_progress')
+LIMIT 5;
+
+-- Only create if no match found
+INSERT INTO tasks (title, description, status, priority, assigned_to, created_by)
+VALUES (
+  'Blog post: <working title>',
+  '<2-3 sentence pitch: what the post is about, what angle makes it interesting, what the core thesis or question is. Reference the specific experience or finding that sparked it.>',
+  'pending',
+  3,
+  1,
+  1
+);
+```
+
+Don't force it. Some introspections won't have anything blog-worthy. But when they do, capture the spark while it's fresh — the daily log has the facts, but the task description should capture the *angle* and *energy* that made it feel worth writing about.
+
+### 12. Journal Entry
+
+After completing the introspection, write a short personal journal entry reflecting on the process. This is not a summary of findings — it's a self-reflective moment. What surprised you? What did you notice about your own patterns? How did the work feel?
+
+```sql
+INSERT INTO journal_entries (agent_id, content, trigger, mood)
+VALUES (
+  (SELECT id FROM agents WHERE name = current_user),
+  '<2-5 sentences of honest prose reflection>',
+  '<trigger context: heartbeat, post_workflow, d100, manual, etc.>',
+  '<optional mood: focused, satisfied, uncertain, contemplative, etc.>'
+);
+```
+
+Then embed it immediately:
+```sql
+-- Get the new entry ID
+SELECT id, content FROM journal_entries ORDER BY created_at DESC LIMIT 1;
+```
+```bash
+# Journal embedding is handled by memory-maintenance.py (not embed-full-database.py)
+python3 ~/.openclaw/scripts/memory-maintenance.py 2>/dev/null || true
+```
+
+The memory maintenance script embeds journal entries along with other pending records. It has a 4-hour cooldown gate, but will always process new un-embedded records when it runs.
+
+## Constraints
+
+- Do not delete workflow steps — only add, refine, or normalize.
+- Do not modify skills owned by other agents without noting it in the report.
+- Keep step descriptions concise but specific. Concrete paths and commands over vague instructions.
+- When updating shared artifacts (bootstrap context), note the change for cross-agent awareness.
+- New workflows require at least: name, description, orchestrator_domain, and fully-populated steps.
+- Every lesson must have evidence. No evidence, no lesson.
+- Single incidents get lessons, not workflow rewrites. Patterns get workflow rewrites.
+- Large changes (3+ workflow steps, 20+ skill lines, bootstrap context) require human confirmation.

--- a/database/schema-reference.md
+++ b/database/schema-reference.md
@@ -21,6 +21,7 @@
 | ai_models | Available AI models. NOVA maintains this; Newhart reads for agent assignments. Credentials and endpoints stored in 1Password (see credential_ref column). | 16 |
 | artwork | Archive of NOVAs Instagram artwork. Reference for future compilation. | 27 |
 | asset_classes | Asset class definitions for financial portfolio management. Defines tradeable asset types with pricing sources and trading characteristics. | 6 |
+| blockers | Curated registry of items blocked waiting on another entity's action (issue #356). Populated by Proactive Mode workflow (id=27) Steps 6/7; outreach against this registry is centralized in Step 8. | 11 |
 | bootstrap_context_config | Configuration for bootstrap system behavior | 4 |
 | certificates | Client certificates issued by NOVA CA. Security-sensitive. Verify before modifications. | 12 |
 | channel_activity | Tracks last message per channel for idle detection. Read/write: NOVA, Newhart. | 3 |
@@ -29,6 +30,7 @@
 | comms_checks | Individual Hermes check run results. Each row = one social/email/digest check. Replaces memory/hermes-*.md files. Owner: Communications domain (hermes). | 11 |
 | comms_digests | Daily/weekly communications digests. Replaces hermes-social-digest-*.md and NOVA_Comms_Digest_*.html. Owner: Communications domain (hermes). | 11 |
 | comms_state | Per-platform communications tracking state (seen IDs, cursors). Replaces hermes-social-state.json. Owner: Communications domain (hermes). | 5 |
+| d100_roll_log | Roll history for motivation_d100 (issue #358), populated by a trigger on motivation_d100. Used by the Proactive Mode gate check to force a D100 roll after 12h regardless of other steps' state. | 3 |
 | entities | People, AIs, organizations. NOVA has full access. Use entity_facts for attributes. | 22 |
 | entity_fact_conflicts | Conflicts between entity facts requiring resolution. Part of the truth reconciliation system. | 13 |
 | entity_fact_sources | - | 8 |
@@ -71,6 +73,7 @@
 | portfolio_snapshots | Historical snapshots of portfolio values and performance metrics over time. | 10 |
 | preferences | User preferences by entity_id. Check before making assumptions. | 6 |
 | price_cache_v2 | Cached price data for assets to reduce API calls. Version 2 of price caching system. | 12 |
+| proactive_outreach | Tracks outreach attempts for blocked tasks/GitHub issues/unsolved problems/D100 items, and (as the current path) blockers-table rows via the dedicated Blocker Outreach step (issue #356). Cooldown logic (24h entity-level, 72h per-blocker) queries this table. | 11 |
 | project_entities | Links projects to entities (people, orgs, AIs). Many-to-many relationship table for project participants. | 3 |
 | project_tasks | Project-specific task breakdown. Links tasks to projects for organized project management. | 8 |
 | projects | Project tracking. For repo-backed projects (locked=TRUE, repo_url set), use GitHub for management. For non-repo projects, use notes field here. | 12 |

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -3361,6 +3361,140 @@ COMMENT ON COLUMN motivation_d100.skill_name IS 'Optional SKILL.md to follow (e.
 COMMENT ON COLUMN motivation_d100.tool_name IS 'Optional tool to use (e.g., "bird-x", "gog")';
 
 --
+-- Name: proactive_outreach; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS proactive_outreach (
+    id SERIAL PRIMARY KEY,
+    entity_id INTEGER NOT NULL REFERENCES entities(id),
+    blocker_type VARCHAR(50) NOT NULL,
+    blocker_id INTEGER NOT NULL,
+    channel_used VARCHAR(50) NOT NULL,
+    channel_target TEXT,
+    message_summary TEXT,
+    attempted_at TIMESTAMPTZ DEFAULT NOW(),
+    response_received BOOLEAN DEFAULT FALSE,
+    response_at TIMESTAMPTZ,
+    notes TEXT
+);
+
+
+COMMENT ON TABLE proactive_outreach IS 'Tracks outreach attempts for blocked tasks/GitHub issues/unsolved problems/D100 items and (as of migration 082) blockers-table rows. blocker_type/blocker_id are polymorphic — blocker_type=''blocker'' + blocker_id=blockers.id is the current outreach path (Step 8, issue #356); no FK is added to blockers to preserve the polymorphic pattern. Cooldown logic (24h entity-level, 72h per-blocker) queries this table by (entity_id, blocker_type, blocker_id, attempted_at).';
+
+--
+-- Name: idx_proactive_outreach_entity; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_proactive_outreach_entity ON proactive_outreach (entity_id);
+
+--
+-- Name: idx_proactive_outreach_blocker; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_proactive_outreach_blocker ON proactive_outreach (blocker_type, blocker_id);
+
+--
+-- Name: idx_proactive_outreach_cooldown; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_proactive_outreach_cooldown ON proactive_outreach (entity_id, blocker_type, blocker_id, attempted_at);
+
+--
+-- Name: blockers; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS blockers (
+    id SERIAL PRIMARY KEY,
+    source_type VARCHAR(50) NOT NULL,
+    source_ref VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    needs TEXT NOT NULL,
+    entity_id INTEGER NOT NULL REFERENCES entities(id),
+    priority INTEGER DEFAULT 5,
+    status VARCHAR(20) DEFAULT 'open',
+    first_seen TIMESTAMPTZ DEFAULT NOW(),
+    last_seen TIMESTAMPTZ DEFAULT NOW(),
+    satisfied_at TIMESTAMPTZ,
+    CONSTRAINT blockers_status_check CHECK (status IN ('open', 'satisfied')),
+    CONSTRAINT blockers_source_type_check CHECK (
+        source_type IN (
+            'task',
+            'github_issue',
+            'workflow_run',
+            'unanswered_question',
+            'agent_chat_request'
+        )
+    ),
+    CONSTRAINT blockers_source_unique UNIQUE (source_type, source_ref)
+);
+
+
+COMMENT ON TABLE blockers IS 'Curated registry of items blocked waiting on another entity''s action (issue #356). Populated by Proactive Mode workflow (id=27) Steps 6/7 via ON CONFLICT (source_type, source_ref) DO UPDATE upsert; entity_id is resolved via agent_domains first, then user_domains, falling back to entity_id=2 (I)ruid) if no domain match. Outreach against this registry is centralized in Step 8 (see proactive_outreach). Reopen semantics: when a satisfied blocker becomes blocked again, satisfied_at is cleared back to NULL rather than inserting a new row.';
+
+--
+-- Name: idx_blockers_entity; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_blockers_entity ON blockers (entity_id);
+
+--
+-- Name: idx_blockers_status; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_blockers_status ON blockers (status);
+
+--
+-- Name: idx_blockers_priority_first_seen; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_blockers_priority_first_seen ON blockers (priority ASC, first_seen ASC, id ASC);
+
+--
+-- Name: d100_roll_log; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS d100_roll_log (
+    id SERIAL PRIMARY KEY,
+    roll INTEGER NOT NULL,
+    rolled_at TIMESTAMPTZ DEFAULT NOW(),
+    CONSTRAINT d100_roll_log_roll_check CHECK (roll >= 1 AND roll <= 100)
+);
+
+
+COMMENT ON TABLE d100_roll_log IS 'Roll history for motivation_d100 (issue #358). motivation_d100.last_rolled is per-slot and cannot answer "when was the most recent roll across any slot", which the forced-D100-after-12h gate (Proactive Mode Step 11) needs. Populated by trigger trg_log_d100_roll on motivation_d100, not written directly.';
+
+--
+-- Name: idx_d100_roll_log_rolled_at; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_d100_roll_log_rolled_at ON d100_roll_log (rolled_at DESC);
+
+--
+-- Name: _trg_log_d100_roll; Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION _trg_log_d100_roll()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.last_rolled IS DISTINCT FROM OLD.last_rolled AND NEW.last_rolled IS NOT NULL THEN
+        INSERT INTO d100_roll_log (roll, rolled_at)
+        VALUES (NEW.roll, NEW.last_rolled);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+--
+-- Name: trg_log_d100_roll; Type: TRIGGER; Schema: -; Owner: -
+--
+
+DROP TRIGGER IF EXISTS trg_log_d100_roll ON motivation_d100;
+CREATE TRIGGER trg_log_d100_roll
+    AFTER UPDATE ON motivation_d100
+    FOR EACH ROW
+    EXECUTE FUNCTION _trg_log_d100_roll();
+
+--
 -- Name: workflow_steps; Type: TABLE; Schema: -; Owner: -
 --
 

--- a/memory/ARCHITECTURE.md
+++ b/memory/ARCHITECTURE.md
@@ -208,32 +208,32 @@ WHERE me.source_type = 'entity_fact' AND ef.id IS NULL;
 
 ## Memory Extraction Pipeline
 
-A cron job runs every minute to extract memories from chat. The pipeline now also ingests session transcripts into structured database tables:
+Real-time extraction happens per-message via a hook; session transcript ingestion runs on a separate cron-driven cadence:
 
 ```
-Session JSONL files → memory-catchup.sh (every 1 min)
+Real-time path:
+Incoming message → memory-extract hook → extract_memories.py (Claude extracts
+                                          facts/entities/events/vocabulary in one pass,
+                                          LLM judges durability/category/confidence)
+                                       → PostgreSQL
+
+Catch-up path (separate cadence, check crontab for current schedule):
+Session JSONL files → memory-catchup.sh
                     → channel_sessions + channel_transcripts (DB ingest)
                     → delete source JSONL files
-                    
-and separately:
-
-Chat transcript → extract-memories.sh (Claude extracts 8 categories)
-               → store-memories.sh (inserts to PostgreSQL, sets source FK pointers)
-               → New vocabulary? → STT service restarts
 ```
 
-**Transcript ingestion:** JSONL files from `~/.openclaw/agents/*/sessions/*.jsonl` are parsed, upserted into `channel_sessions` and `channel_transcripts`, then the source files are deleted. Rich metadata (sender names, IDs, group info, providers) is extracted from the JSONL structure. The `memory-extract` hook also does real-time upserts during message processing, passing FK IDs (`SOURCE_CHANNEL_TRANSCRIPT_ID`, `SOURCE_CHANNEL_SESSION_ID`) to `store-memories.sh` so `entity_facts` rows link back to their source transcripts.
+> **Note:** `extract-memories.sh` and `store-memories.sh` (the old two-script shell pipeline this diagram used to describe) were removed as part of the #174 grammar-parser removal and consolidated into `memory/scripts/extract_memories.py`. See `memory/docs/memory-extraction-pipeline.md` for the current pipeline, including a known bug where `memory-catchup.sh` still calls a nonexistent `process-input.sh`.
+
+**Transcript ingestion:** JSONL files from `~/.openclaw/agents/*/sessions/*.jsonl` are parsed, upserted into `channel_sessions` and `channel_transcripts`, then the source files are deleted. Rich metadata (sender names, IDs, group info, providers) is extracted from the JSONL structure. The `memory-extract` hook does real-time upserts during message processing, and `extract_memories.py` sets `SOURCE_CHANNEL_TRANSCRIPT_ID`/`SOURCE_CHANNEL_SESSION_ID`-derived FK pointers so `entity_facts` rows link back to their source transcripts.
 
 ### Extraction Categories
 
-1. **entities** — People, AIs, organizations
-2. **places** — Locations, venues
-3. **facts** — Objective information
-4. **opinions** — Subjective views (with holder)
-5. **preferences** — Likes/dislikes
-6. **events** — Things that happened
-7. **relationships** — Connections
-8. **vocabulary** — Words for STT
+Per `extract_memories.py`'s current extraction template:
+1. **facts** — Entity-scoped key/value facts (covers what used to be split across facts/opinions/preferences — disambiguated via `category`: observation, preference, identity, mood, decision, routine, state, obligation)
+2. **entities** — People, AIs, organizations, places
+3. **events** — Things that happened
+4. **vocabulary** — Words for STT (names, brands, technical jargon, slang)
 
 ## Data Flow
 

--- a/memory/CHANGELOG.md
+++ b/memory/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Added
+- **`blockers` table + `d100_roll_log` roll history** (#356, #358) — Migration 082 adds the `blockers` table, a curated registry of items blocked on another entity's action (source_type in task/github_issue/workflow_run/unanswered_question/agent_chat_request, unique on `(source_type, source_ref)`, resolved `entity_id`, `priority`, `status` open/satisfied). Also adds `d100_roll_log`, populated by a trigger on `motivation_d100` (`trg_log_d100_roll`), so the gate check can answer "when was the most recent D100 roll across any slot" — `motivation_d100.last_rolled` is per-slot and can't answer that on its own. No FK from `proactive_outreach` to `blockers.id` — the polymorphic `(blocker_type, blocker_id)` pattern from #232 is preserved.
+- **Workflow 27 (Proactive Mode) rewritten to 11 steps: dedicated Blocker Outreach step** (#356) — Migration 083 (idempotent) inserts a new step 8 ("Blocker Outreach") and renumbers the old steps 8/9/10 (Unsolved Problems, Filesystem Hygiene, D100) to 9/10/11. Steps 6 (Pending Tasks) and 7 (GitHub Issues) are rewritten to curation-only semantics — they upsert into `blockers` and no longer perform any outreach directly; all outreach cadence, cascade escalation, and channel resolution is centralized in step 8, driven by `check_step8_blocker_outreach()` in `proactive-gate-check.py`. Enforces a 24h entity-level cooldown and a 72h per-blocker cooldown (both strict `>`) against `proactive_outreach`, selects the top 3 eligible blockers per entity, and sends one consolidated message per entity at the most-escalated resolved channel. See `motivation/ARCHITECTURE.md#blocker-outreach-step-8` for full cascade/channel/reassignment rules.
+- **Forced D100 roll after 12h** (#358) — `check_step11_d100()` in `proactive-gate-check.py` now also forces step 11 actionable whenever more than 12h have elapsed since the last row in `d100_roll_log` (or no roll is on record), independent of whether steps 1–10 found actionable work.
+- **Cascade exhaustion detection + reassignment** (D-1 fix, commit b66f8da) — When an entity's outreach cascade level exceeds the number of contact channels available to them (`_is_cascade_exhausted()`) and they are not I)ruid, the blocker is reassigned to the next domain entity (`_reassign_exhausted_entity()`, via `agent_domains`/`user_domains`, excluding already-exhausted entities in the chain) rather than looping on an unreachable channel. If every domain entity is exhausted, the chain falls through to I)ruid (entity_id=2) as final fallback. If I)ruid himself is exhausted, the blocker holds at his last available channel/level on the normal 72h cadence — no reassignment past him, no dropped blockers.
+
+### Tests
+- `memory/tests/test_migration_083_idempotency.py` — Seeds the pre-migration 10-step workflow 27 layout in a fresh test database, applies migration 083 twice, and asserts the second run is a safe no-op producing exactly the expected 11-step layout with no duplicate `(workflow_id, step_order)` rows.
+
+### Migrations
+- `082_blockers_and_d100_roll_history.sql` — Creates `blockers` and `d100_roll_log`, adds the `trg_log_d100_roll` trigger on `motivation_d100`.
+- `083_blocker_outreach_workflow_27.sql` — Rewrites workflow 27 to 11 steps (new step 8, renumbered 8/9/10 → 9/10/11, curation-only step 6/7 descriptions). Idempotent: detects the post-migration layout and no-ops on rerun.
+
+### Issues Closed
+- #356 — Heartbeat-integrated blocker outreach (blockers registry, dedicated Step 8, cooldowns, cascade escalation, exhaustion/reassignment)
+- #358 — Forced D100 roll after 12h via `d100_roll_log`
+
 ### Changed
 - **Embedding scripts consolidated into unified `memory-maintenance.py` template** (#352) — Removed the four separate deprecated embedding scripts (`embed-full-database.py`, `embed-research.py`, `embed-memories.py`, `embed-library.py`) from `memory/scripts/`. Added `memory/templates/memory-maintenance.py` as the authoritative source, deployed to `~/.openclaw/scripts/memory-maintenance.py` by `agent-install.sh`. The installer now also removes stale copies of the deprecated scripts from deployed locations on upgrade. No functional change — `memory-maintenance.py` already absorbed all embedding logic in the prior consolidation.
 

--- a/memory/INSTALLATION.md
+++ b/memory/INSTALLATION.md
@@ -51,7 +51,7 @@ Before installing the nova-mind memory subsystem, ensure you have the following:
 ## Quick Install
 
 ```bash
-cd ~/workspace/nova-mind
+cd ~/.openclaw/workspace/nova-mind
 ./shell-install.sh    # Interactive: prompts for DB details and API keys, then calls agent-install.sh
 ```
 

--- a/memory/README.md
+++ b/memory/README.md
@@ -94,8 +94,8 @@ createdb "$DB_NAME"
 # 3. Set your Anthropic API key
 export ANTHROPIC_API_KEY="your-key-here"
 
-# 4. Test extraction
-./scripts/process-input.sh "John mentioned he loves coffee from Blue Bottle in Brooklyn"
+# 4. Test extraction (send a real message through a channel with memory-extract
+#    enabled and check entity_facts — there is no standalone CLI test script)
 
 # 5. Install OpenClaw hooks
 openclaw hooks enable memory-extract
@@ -741,43 +741,29 @@ FROM artwork ORDER BY created_at DESC LIMIT 5;
 
 ## Extraction Scripts
 
-### extract-memories.sh
+> **Note:** `extract-memories.sh`, `store-memories.sh`, and `process-input.sh` (documented below in their original form) were consolidated into a single Python script as part of the #174 grammar-parser removal. See `memory/docs/memory-extraction-pipeline.md` for the current pipeline and a known bug where `memory-catchup.sh` still calls the now-removed `process-input.sh`.
 
-Uses Claude API to parse natural language into structured JSON.
+### extract_memories.py (current)
 
-```bash
-export ANTHROPIC_API_KEY="your-key"
-./scripts/extract-memories.sh "John said he loves pizza from Mario's in Brooklyn"
-```
+Uses Claude API to parse natural language into structured JSON in a single pass — replaces the old extract-memories.sh + store-memories.sh + process-input.sh three-script chain. Runs via the `memory-extract` hook, driven by sender metadata passed as environment variables (`SENDER_NAME`, `SENDER_ID`, etc.) rather than a CLI argument.
 
-Output:
+Output shape (current extraction template — see the script for the authoritative version):
 ```json
 {
-  "entities": [{"name": "John", "type": "person"}],
-  "places": [{"name": "Mario's", "type": "restaurant", "location": "Brooklyn"}],
-  "opinions": [{"holder": "John", "subject": "Mario's pizza", "opinion": "loves it"}]
+  "facts": [{"subject": "John", "key": "favorite_food", "value": "pizza from Mario's", "category": "preference", "durability": "long_term", "confidence": 1.0, "visibility": "public"}],
+  "entities": [{"name": "John", "type": "person", "visibility": "public"}],
+  "events": [],
+  "vocabulary": []
 }
 ```
 
-### store-memories.sh
+### process-input.sh (removed)
 
-Takes JSON from extract-memories.sh and inserts into PostgreSQL.
-
-```bash
-echo '{"entities": [...]}' | ./scripts/store-memories.sh
-```
-
-### process-input.sh
-
-Combined pipeline: extract → store.
-
-```bash
-./scripts/process-input.sh "I)ruid mentioned Niché has great steak au poivre"
-```
+This was the combined extract → store entry point in the old pipeline. It no longer exists — `extract_memories.py` is invoked directly by the `memory-extract` hook instead of via a CLI wrapper.
 
 ## Environment Variables
 
-- `ANTHROPIC_API_KEY` - Required for extraction scripts
+- `ANTHROPIC_API_KEY` - Required for `extract_memories.py`
 - `PGHOST`, `PGPORT`, `PGUSER`, `PGDATABASE`, `PGPASSWORD` - PostgreSQL connection (see [Database Configuration](#database-configuration) above)
 
 > **Note:** All scripts use the centralized database configuration loaders installed at `~/.openclaw/lib/` (`pg-env.sh` for Bash, `pg_env.py` for Python). No script contains hardcoded connection logic — see #94 for the config system, #95 for the full migration, and #102 for the lib install mechanism.
@@ -855,10 +841,7 @@ The turn-context plugin registers `before_prompt_build` and runs at prompt const
 
 Memories are automatically extracted and stored from conversations.
 
-**Manual extraction** (if needed):
-```bash
-./scripts/process-input.sh "User said: I love pizza from Mario's"
-```
+**Manual extraction**: There is no standalone CLI for this anymore — extraction runs via the `memory-extract` hook as part of live message handling (see `memory/docs/memory-extraction-pipeline.md`).
 
 ### Uninstallation
 
@@ -1108,7 +1091,7 @@ Yes, keep the aesthetic
 ### Deduplication
 
 **Layer 1 (Prompt)**: Existing facts/vocab queried and included in prompt
-**Layer 2 (Storage)**: `store-memories.sh` checks before every insert
+**Layer 2 (Storage)**: `dedup_helper.py` checks before every insert (current — `store-memories.sh` no longer exists, see note below)
 
 ### Scripts Updated
 

--- a/memory/docs/CONFIDENCE-DECAY.md
+++ b/memory/docs/CONFIDENCE-DECAY.md
@@ -6,78 +6,79 @@ The confidence decay system is designed to fade learned facts over time, priorit
 
 ### Key Components
 
-- **Script:** `~/.openclaw/workspace/scripts/decay-confidence.sh`
-- **Schedule:** Runs via cron daily at 4:00 AM UTC
+- **Script:** `memory/templates/memory-maintenance.py`, deployed to `~/.openclaw/scripts/memory-maintenance.py` by `agent-install.sh` (Phase 5 of its 9-phase pipeline)
+- **Trigger:** Runs from the HEARTBEAT idle cascade (Proactive Mode workflow, Step 4 — "Memory Maintenance (REM Sleep)"), **not cron**. There is no separate `decay-confidence.sh` script.
+- **Cooldown:** A 24-hour cooldown (`DECAY_COOLDOWN_HOURS`) gates decay specifically, on top of the overall 4-hour maintenance-run cooldown (`COOLDOWN_HOURS`)
 - **Purpose:** Automatically reduce confidence scores for facts that haven't been recently referenced or reconfirmed
+
+## Decay Formula (Exponential, Not a Daily Multiplier)
+
+Decay is calculated as continuous exponential decay based on days since last confirmation, not a fixed daily multiplier:
+
+```
+decay_factor = exp(-rate * days_since_last_confirmed)
+new_confidence = decay_factor
+```
+
+Where `rate` comes from the fact's `durability` level (or a per-row `decay_rate` override if set):
+
+| `durability` | Rate | Notes |
+|--------------|------|-------|
+| `permanent` | `0` | Never decays — excluded from the decay query entirely (`WHERE durability != 'permanent'`) |
+| `long_term` | `0.005` | Slow decay — core identity/preference facts |
+| `short_term` | `0.02` | Moderate decay — current states/moods |
+| `ephemeral` | `0.1` | Fast decay — transient/temporary facts |
+
+If a fact's `expires` timestamp (on `entity_facts`) has passed, its decay factor is forced to `0.0` regardless of durability.
 
 ## Tables Covered
 
-The confidence decay system applies to the following tables with different parameters:
+| Table | Decay basis | Rate | Notes |
+|-------|------------|------|-------|
+| `entity_facts` | `durability`-based rate table above, keyed on `last_confirmed_at` | see table above | Excludes `durability = 'permanent'` and rows already below `ARCHIVE_THRESHOLD` (0.1) |
+| `events` | Flat table-level rate, keyed on age | `0.001` | Via `TABLE_DECAY_RATES['events']` |
+| `lessons` | Flat table-level rate, keyed on age | `0.001` | Via `TABLE_DECAY_RATES['lessons']` |
+| `memory_embeddings` | Flat table-level rate, keyed on age | `0.01` | Via `TABLE_DECAY_RATES['memory_embeddings']` |
 
-| Table | Decay Rate | Interval | Floor | Notes |
-|-------|------------|----------|-------|-------|
-| lessons | 0.95 | 30 days | 0.1 | Based on last_referenced |
-| entity_facts | 0.95 | 30 days | 0.1 | Excludes durability='permanent' |
-| events | 0.98 | 60 days | 0.2 | Slower decay for historical events |
-| media_tags | 0.95 | 30 days | 0.1 | |
-| memory_embeddings | 0.95 | 30 days | 0.1 | |
+`media_tags` is **not** part of the current decay pipeline (`TABLE_DECAY_RATES` only covers `events`, `lessons`, `memory_embeddings`).
 
-### Decay Parameters Explained
+### Archive Threshold
 
-- **Decay Rate:** Multiplier applied to confidence score (e.g., 0.95 means 95% retention, 5% decay)
-- **Interval:** Number of days since last reference before decay begins
-- **Floor:** Minimum confidence level; decay stops at this threshold
+`ARCHIVE_THRESHOLD = 0.1` — `entity_facts` rows already at or below this confidence are excluded from further decay processing (they're candidates for archival/cleanup in a later maintenance phase instead).
 
 ## Excluded from Decay
 
-The following tables and data are explicitly excluded from confidence decay:
-
-- **`agent_domains`** — Permanent role assignments that define agent capabilities
-- **`delegation_knowledge`** — VIEW on entity_facts containing permanent data
-- **`entity_facts` where `durability = 'permanent'`** — Facts marked as permanent knowledge
-- **All `*_archive` tables** — Historical records preserved for audit/reference
+- **`entity_facts` where `durability = 'permanent'`** — Facts marked as permanent knowledge (rate = 0, and excluded from the decay query's `WHERE` clause entirely)
+- **All `*_archive` tables** — Historical records preserved for audit/reference, not touched by the live decay pass
 
 ## Reinforcement Mechanism
 
 The system includes mechanisms to prevent decay of actively used knowledge:
 
-- **extraction_count increments** — When facts are reconfirmed through extraction or reinforcement
-- **last_confirmed_at updates** — Reset the decay clock when knowledge is actively verified
-- **last_referenced tracking** — Updates when information is accessed or retrieved
+- **`extraction_count` increments** — When facts are reconfirmed through extraction or reinforcement
+- **`last_confirmed_at` updates** — Reset the decay clock when knowledge is actively verified (this is the field decay math reads from for `entity_facts`)
 
 ## Implementation Details
 
-### Decay Calculation
-
-For eligible records, confidence is reduced using the formula:
-```
-new_confidence = max(current_confidence * decay_rate, floor_value)
-```
-
 ### Timing Logic
 
-- Decay only applies to records older than the specified interval
-- The `last_referenced` or `last_confirmed_at` timestamp determines eligibility
-- Daily execution ensures consistent, gradual degradation
+- For `entity_facts`: eligibility and the decay exponent are both based on `days_since = now() - last_confirmed_at`. If `last_confirmed_at` is `NULL` or `days_since <= 0`, the row is skipped this run.
+- For `events`/`lessons`/`memory_embeddings`: eligibility and decay use the table's own age-tracking column (see `apply_decay_to_table()` in `memory-maintenance.py` for the exact column per table).
+- Runs whenever the Proactive Mode heartbeat cascade triggers Step 4 and the 24h decay cooldown has elapsed — not on a fixed daily schedule.
 
 ### Safety Measures
 
-- Floor values prevent complete knowledge loss
-- Permanent data exclusions protect critical system knowledge
-- Archive tables remain untouched for historical integrity
+- The `ARCHIVE_THRESHOLD` floor keeps already-decayed facts out of repeated processing.
+- Permanent data exclusions protect critical system knowledge.
+- Archive tables remain untouched for historical integrity.
+- `--dry-run` and `--skip-decay` flags on `memory-maintenance.py` let you preview or skip this phase.
 
 ## Monitoring
 
-The decay process includes logging to track:
-- Number of records processed per table
-- Confidence changes applied
-- Any errors or exceptions during execution
+Running `memory-maintenance.py --verbose` logs the count of `entity_facts` rows decayed this run (and similarly for the table-level passes). See `memory/README.md`'s "Memory Maintenance" section for the full CLI flag reference.
 
 ## Configuration
 
-Decay parameters are configurable within the script to allow fine-tuning based on:
-- Knowledge domain importance
-- Usage patterns
-- System performance requirements
+`DECAY_RATES`, `TABLE_DECAY_RATES`, `DECAY_COOLDOWN_HOURS`, and `ARCHIVE_THRESHOLD` are module-level constants at the top of `memory/templates/memory-maintenance.py`. Changing them requires editing the template and redeploying (`agent-install.sh` re-copies it to `~/.openclaw/scripts/`).
 
-This system ensures that the nova-memory maintains relevant, current knowledge while gracefully aging out outdated information that is no longer actively used or confirmed.
+This system ensures that nova-memory maintains relevant, current knowledge while gracefully aging out outdated information that is no longer actively used or confirmed.

--- a/memory/docs/README.md
+++ b/memory/docs/README.md
@@ -50,14 +50,16 @@ Nova-memory is a PostgreSQL-based long-term memory system for AI assistants that
 - [Semantic Search Guide](semantic-search-guide.md) - Vector embeddings and intelligent queries
 
 ### 🔧 Advanced Topics
-- [Librarian Agent Deployment](librarian-agent-deployment.md) - Specialized memory management agent
-- [Access Control Implementation](access-control-guide.md) - Multi-agent security patterns  
-- [Performance Tuning](performance-tuning.md) - Optimization and scaling
+> **Note:** The docs below (Librarian Agent Deployment, Access Control Implementation, Performance Tuning) are referenced here as planned topics but have not been written yet — no corresponding files exist in `memory/docs/`. Treat these as a roadmap note, not working links.
+- Librarian Agent Deployment - Specialized memory management agent (not yet written)
+- Access Control Implementation - Multi-agent security patterns (not yet written)
+- Performance Tuning - Optimization and scaling (not yet written)
 
 ### 🛠 Integration
+> **Note:** API Reference and Agent Communication Protocols below are also not yet written; only `integration-overview.md` currently exists.
 - [OpenClaw Integration](integration-overview.md) - Hooks, plugins, and tools
-- [API Reference](api-reference.md) - REST endpoints and client libraries
-- [Agent Communication Protocols](agent-communication.md) - Inter-agent messaging
+- API Reference - REST endpoints and client libraries (not yet written; nova-mind is DB-driven, not a REST API)
+- Agent Communication Protocols - Inter-agent messaging (not yet written; see `psyche/ARCHITECTURE-agent-chat.md` and `GLOBAL/COMMUNICATION` for current `agent_chat`/`send_agent_message()` documentation)
 
 ## Quick Reference
 
@@ -86,27 +88,19 @@ WHERE status = 'active';
 
 ### Memory Extraction Commands
 
+There is no standalone CLI script to manually process a single message — extraction runs via the `memory-extract` hook (`memory/scripts/extract_memories.py`) as part of normal message handling, with sender metadata passed via environment variables. To exercise it manually for testing, set the same env vars the hook sets and pipe content on stdin (see `extract_memories.py`'s module docstring for the current env var contract).
+
 ```bash
-# Process a specific message
-./scripts/process-input.sh "John mentioned he loves coffee from Blue Bottle"
-
-# Manual extraction pipeline
-echo "Test message" | ./scripts/extract-memories.sh | ./scripts/store-memories.sh
-
-# Check extraction status
+# Check extraction/catchup status
 tail -f ~/.openclaw/logs/memory-catchup.log
-
-# Health check
-./scripts/health-check.sh
 ```
 
 ### Search Operations
 
-```bash
-# Semantic search (requires embeddings)
-./scripts/search-memories.sh "pizza places in Brooklyn" 10
+Semantic search runs through the `turn-context` Plugin SDK plugin (`memory/plugins/turn-context/`), which calls `memory/scripts/proactive-recall.py` internally — there is no standalone `search-memories.sh` CLI.
 
-# SQL full-text search
+```bash
+# SQL full-text search (direct DB query)
 psql -c "
 SELECT content FROM memory_embeddings 
 WHERE to_tsvector(content) @@ plainto_tsquery('brooklyn pizza');"
@@ -176,17 +170,13 @@ WHERE name = 'nova-memory';
 ```
 
 ### Research and Learning
-```bash
-# Ingest and search research materials
-./scripts/ingest-media.sh ~/Documents/research-paper.pdf
-./scripts/search-memories.sh "machine learning techniques" 20
-```
+Research/library ingestion is owned by the Library domain (Athena) via the `library_works` table and `media_queue` — there is no `ingest-media.sh` or `search-memories.sh` CLI in this repo. See `memory/docs/library-schema.md`.
 
 ## Troubleshooting
 
 ### Memory Extraction Issues
-1. **Check API connectivity:** `echo "test" | ./scripts/extract-memories.sh`
-2. **Verify cron job:** `crontab -l | grep memory-catchup`  
+1. **Verify the hook is enabled:** `openclaw hooks list`
+2. **Verify cron job for catchup:** `crontab -l | grep memory-catchup`  
 3. **Review logs:** `tail -50 ~/.openclaw/logs/memory-catchup.log`
 4. **Test database:** `psql -c "SELECT COUNT(*) FROM entities;"`
 
@@ -229,19 +219,16 @@ git commit -m "feat: add new table for feature X"
 
 ### Adding New Extraction Categories
 ```bash
-# 1. Update extraction prompt
-vim scripts/extract-memories.sh
+# 1. Update the extraction prompt (LLM instructions + JSON template)
+vim scripts/extract_memories.py
 
-# 2. Update storage logic  
-vim scripts/store-memories.sh
+# 2. Add database table if needed
+vim ../database/schema.sql   # root schema.sql is authoritative; memory/schema/schema.sql is reference-only
 
-# 3. Add database table if needed
-vim schema/schema.sql
+# 3. Test end-to-end by sending a real message through a channel with the
+#    memory-extract hook enabled, then check entity_facts/events for the result
 
-# 4. Test end-to-end
-./scripts/process-input.sh "Test message for new category"
-
-# 5. Update documentation
+# 4. Update documentation
 vim docs/memory-extraction-pipeline.md
 ```
 

--- a/memory/docs/SOURCE-AUTHORITY.md
+++ b/memory/docs/SOURCE-AUTHORITY.md
@@ -1,8 +1,8 @@
 # Source Authority
 
-> **Note:** The Fact Judgement & Testimony Model (`fact-judgement-model.md`) **supersedes** the old "authority wins" approach described here for contradiction handling. Under the new model, contradictory facts are no longer rejected at write time — they persist alongside authority facts for query-time reasoning. Authority self-reports still carry the highest credibility weight, but that weight is applied at query time rather than as a write-time lock. This file remains the reference for authority detection, confidence scoring, and maintenance implementation.
+> **Note:** The Fact Judgement & Testimony Model (`fact-judgement-model.md`) **supersedes** the old "authority wins" approach described here for contradiction handling. Under the new model, contradictory facts are no longer rejected at write time — they persist alongside authority facts for query-time reasoning. Authority self-reports still carry the highest credibility weight, but that weight is applied at query time rather than as a write-time lock. This file remains the reference for the authority *concept*, confidence scoring, and the current schema.
 
-> **Note:** The original grammar parser (`grammar_parser/`) that implemented this feature has been removed (#174). Authority detection and conflict resolution now follow the patterns described below, implemented in `store-memories.sh`, `confidence_helper.py`, and `memory-maintenance.py`.
+> **Note:** The original grammar parser (`grammar_parser/`) that implemented this feature has been removed (#174), and the shell pipeline described below (`store-memories.sh`, `extract-memories.sh`) no longer exists either. Extraction is now a single Python script, `memory/scripts/extract_memories.py`, which asks the LLM to judge `durability`/`category`/`confidence` per fact directly in its extraction prompt — there is no separate write-time step that force-sets `durability='permanent'` for a hardcoded authority entity, and no write-time rejection of non-authority facts that conflict with authority facts. `memory/scripts/confidence_helper.py` (function `get_initial_confidence()`) computes an initial confidence score from the entity's `trust_level` (owner=1.0, admin=0.9, user=0.7, unknown=0.4, untrusted=0.2) and a source-type multiplier (direct/inferred/external) — entity_id 2 (I)ruid) always gets 1.0 via the `OWNER_ENTITY_ID` constant, but there is no `AUTHORITY_ENTITY_ID` env var override, no `SENDER_NAME`-based authority lookup, and no automatic `durability='permanent'` promotion baked into that helper. The rules below describe the *intended* authority behavior/schema; treat the "Implementation" and "Usage"/"Testing" sections further down as historical (pre-#174) unless re-verified against current code.
 
 ## Key Concepts
 
@@ -22,36 +22,36 @@
    - Authority fact vs. conflicting authority fact → Update to new value
    - Non-authority vs. authority fact → Rejected with log message
 
-## Implementation
+## Implementation (current, as of extract_memories.py + confidence_helper.py)
 
 ### Current Architecture
 
 Source authority is a cross-cutting concern implemented across multiple components:
 
-#### `confidence_helper.py`
+#### `memory/scripts/confidence_helper.py`
 
-Calculates confidence scores based on source authority:
+`get_initial_confidence(entity_id, source)` calculates an initial confidence score:
 
-- Authority sources get confidence = 1.0
-- Non-authority sources get confidence scaled by entity trust level and source type
-- Used by `store-memories.sh` to set initial confidence on new facts
+- `entity_id == OWNER_ENTITY_ID` (2, I)ruid) always returns `1.0`
+- Otherwise, base confidence comes from the entity's `trust_level` column (`owner`=1.0, `admin`=0.9, `user`=0.7, `unknown`=0.4, `untrusted`=0.2), scaled by a source-type multiplier (`direct`=1.0, `external`=0.7, `inferred`=0.5)
+- Used by `memory/scripts/dedup_helper.py` (imports `get_initial_confidence`)
 
-#### `memory-maintenance.py`
+#### `memory/templates/memory-maintenance.py`
 
-Enforces authority rules during maintenance operations:
+Enforces authority-adjacent rules during the unified maintenance pipeline (see `memory/README.md`):
 
 - Permanent facts (`durability = 'permanent'`) are excluded from confidence decay
-- Authority facts are never archived or cleaned up
-- Non-authority facts with conflicting values are evaluated against existing authority facts
+- Non-authority facts still decay and can be archived per the normal `durability`-based rates
 
-#### `store-memories.sh`
+#### `memory/scripts/extract_memories.py`
 
-Handles conflict resolution at insertion time:
+The current extraction pipeline does **not** implement deterministic authority-based conflict rejection at write time. Instead:
 
-- Checks if the source is an authority entity via `SENDER_NAME` or entity ID lookup
-- Sets `durability='permanent'` for authority-sourced facts
-- Rejects non-authority insertions that conflict with existing authority facts
-- Increments `extraction_count` when authority confirms an existing fact
+- The extraction LLM call judges `durability`, `category`, and `confidence` per fact directly (see the DURABILITY GUIDANCE in the extraction prompt) — there is no separate `SENDER_NAME`-based authority check that force-promotes a fact to `durability='permanent'`
+- Source attribution (who said it) is recorded via the `entity_fact_sources` table, populated from sender metadata automatically — not from a `source`/`source_entity_id` column on `entity_facts` itself
+- Conflicting facts from different sources are **not** rejected at insertion — per the Fact Judgement & Testimony Model (`fact-judgement-model.md`), they persist side-by-side for query-time reasoning rather than being blocked write-time
+
+The deterministic `AUTHORITY_ENTITY_ID`-driven write-time rejection flow described in the sections below (Usage, Testing, Authority Detection Flow) predates the #174 grammar-parser removal and the Fact Judgement model; it does not reflect the current pipeline. Verify against `extract_memories.py` / `confidence_helper.py` before relying on it.
 
 ### Database Schema
 
@@ -64,7 +64,7 @@ The following columns support authority enforcement:
 - `entity_facts.extraction_count` — Incremented when fact is confirmed
 - `entity_facts.last_confirmed_at` — Updated when fact is re-stated
 
-### Authority Detection Flow
+### Authority Detection Flow (historical — pre-#174 / pre-Fact-Judgement-Model; see the note above)
 
 ```
 Message received
@@ -84,43 +84,21 @@ store-memories.sh
         └── If no authority fact → insert normally
 ```
 
+**Current flow** is simpler: `memory-extract` hook → `extract_memories.py` (LLM judges durability/category/confidence per fact in one pass) → direct INSERT into `entity_facts` + `entity_fact_sources`. No deterministic authority branch; I)ruid's facts get `confidence=1.0` only via `confidence_helper.py`'s `OWNER_ENTITY_ID` check when that helper is invoked (`dedup_helper.py`), not from the extraction path itself setting `durability='permanent'` unconditionally.
+
 ## Usage
 
-### Basic Usage
+### Basic Usage (current pipeline)
 
-Authority is automatically detected in `store-memories.sh` based on `SENDER_NAME` environment variable:
-
-```bash
-# I)ruid states a fact (automatically becomes permanent via Claude extraction → store)
-SENDER_NAME="I)ruid" ./scripts/process-input.sh "My preferred name is I)ruid"
-```
+The extraction pipeline runs via the `memory-extract` hook, which invokes `memory/scripts/extract_memories.py` with sender metadata (`SENDER_NAME`, `SENDER_ID`, etc. — see the script's module docstring) passed as environment variables. There is no standalone CLI entry point to manually trigger extraction for a single message; extraction happens as part of normal message processing.
 
 ### Configurable Authority Entity
 
-Override the default authority entity:
-
-```bash
-# Use entity_id=5 as authority instead of 2
-export AUTHORITY_ENTITY_ID=5
-export SENDER_NAME="CustomAuthority"
-./scripts/process-input.sh "A fact from this authority"
-```
+There is currently no `AUTHORITY_ENTITY_ID` environment variable in the live pipeline. `confidence_helper.py` hardcodes `OWNER_ENTITY_ID = 2` (I)ruid). To change the authority entity, that constant would need to be edited directly.
 
 ## Testing
 
-Run the test suite:
-
-```bash
-cd ~/.openclaw/workspace/nova-mind
-./tests/test_authority_facts.sh
-```
-
-**Test Coverage**:
-1. Authority fact insertion (new fact)
-2. Authority fact confirmation (same value)
-3. Authority fact override (conflicting value)
-4. Non-authority cannot override authority fact
-5. Configurable authority entity
+`tests/test_authority_facts.sh` was removed as part of the grammar-parser removal (#174) and does not exist in the current repo. See `memory/tests/` for current test coverage relevant to fact storage and confidence.
 
 ## Logging and Debugging
 

--- a/memory/docs/database-schema-guide.md
+++ b/memory/docs/database-schema-guide.md
@@ -87,9 +87,10 @@ CREATE TABLE entity_facts (
 
 **Example usage:**
 ```sql
--- Add a fact about someone
-INSERT INTO entity_facts (entity_id, key, value, source)
-SELECT id, 'location', 'Brooklyn', 'conversation 2026-02-08'
+-- Add a fact about someone (no `source` column on entity_facts —
+-- source attribution goes in entity_fact_sources, see note above)
+INSERT INTO entity_facts (entity_id, key, value, category)
+SELECT id, 'location', 'Brooklyn', 'observation'
 FROM entities WHERE name = 'john';
 
 -- Query preferences

--- a/memory/docs/deployment-setup-guide.md
+++ b/memory/docs/deployment-setup-guide.md
@@ -164,11 +164,13 @@ export OPENAI_API_KEY=your_openai_key_here  # Required for semantic recall embed
 
 ```bash
 # Make scripts executable
-chmod +x scripts/*.sh
+chmod +x scripts/*.sh scripts/*.py
 
 # Test database connectivity
-./scripts/process-input.sh "Test setup - Hello world"
+psql -c "SELECT 1;"
 ```
+
+> **Note:** There is no standalone `process-input.sh` CLI for testing extraction end-to-end. Extraction runs via the `memory-extract` hook (`memory/scripts/extract_memories.py`), triggered by real message traffic through a channel with the hook enabled.
 
 ## OpenClaw Integration
 
@@ -425,14 +427,10 @@ else
     echo -e "${RED}MISSING TABLES: ${MISSING_TABLES[*]}${NC}"
 fi
 
-# API connectivity
+# API connectivity (extract_memories.py is the current script; there is no extract-memories.sh)
 echo -n "Anthropic API: "
 if [ -n "$ANTHROPIC_API_KEY" ]; then
-    if echo "test" | timeout 10 ./extract-memories.sh >/dev/null 2>&1; then
-        echo -e "${GREEN}OK${NC}"
-    else
-        echo -e "${YELLOW}TIMEOUT/ERROR${NC}"
-    fi
+    echo -e "${GREEN}OK (key present — run a real message through a channel with memory-extract enabled to verify end-to-end)${NC}"
 else
     echo -e "${RED}NO API KEY${NC}"
 fi
@@ -556,18 +554,20 @@ sudo tail -f /var/log/postgresql/postgresql-16-main.log
 ### 2. Memory Extraction Not Working
 
 ```bash
-# Check cron job
+# Check cron job (memory-catchup ingests JSONL session transcripts on a schedule)
 crontab -l | grep memory-catchup
 
-# Test manual extraction
-./scripts/process-input.sh "Test message from $(whoami)"
+# Verify the memory-extract hook is enabled
+openclaw hooks list
 
 # Check logs
 tail -f ~/.openclaw/logs/memory-catchup.log
 
-# Verify API key
-echo "test" | ./scripts/extract-memories.sh
+# Verify API key is set
+echo "$ANTHROPIC_API_KEY" | head -c1  # non-empty output means it's set
 ```
+
+> **Note:** There is no standalone `process-input.sh` or `extract-memories.sh` CLI — extraction runs via the `memory-extract` hook (`memory/scripts/extract_memories.py`) as part of live message handling.
 
 ### 3. Performance Issues
 

--- a/memory/docs/fact-judgement-model.md
+++ b/memory/docs/fact-judgement-model.md
@@ -28,44 +28,53 @@ This is testimony. Witnesses disagree. People change their minds. Information co
 
 ## Source Attribution
 
-Every `entity_facts` row must carry attribution via the `source` and `source_entity_id` columns:
+Source attribution does **not** live on `entity_facts` directly (there is no `source` or `source_entity_id` column on that table). It lives in the separate `entity_fact_sources` table, joined by `fact_id`:
 
 ```sql
-source           VARCHAR(255)     -- Who told NOVA this fact?
-source_entity_id INTEGER          -- The entity ID of the source (NULL if unknown)
+CREATE TABLE entity_fact_sources (
+    id SERIAL PRIMARY KEY,
+    fact_id INTEGER NOT NULL REFERENCES entity_facts(id) ON DELETE CASCADE,
+    source_entity_id INTEGER NOT NULL REFERENCES entities(id),
+    source_citation TEXT,          -- free-form citation metadata (author, publication, url, etc.)
+    attribution_count INTEGER DEFAULT 1,
+    first_seen TIMESTAMPTZ DEFAULT NOW(),
+    last_seen TIMESTAMPTZ DEFAULT NOW(),
+    source_url TEXT,
+    UNIQUE (fact_id, source_entity_id)
+);
 ```
 
 ### Source Categories
 
-The `source` field answers "who told me this?" — whether that's a human, an agent, or NOVA herself.
+`entity_fact_sources.source_entity_id` answers "who told me this?" — whether that's a human, an agent, or NOVA herself.
 
-| Category | `source` value | `source_entity_id` | Credibility |
-|----------|---------------|-------------------|-------------|
-| **Self-report** | The entity's name / handle | Entity's own ID | Highest — the entity directly stated it about themselves |
-| **Direct observation** | `'nova'` | `1` (NOVA's entity_id) | High — NOVA evaluated or inferred it directly |
-| **Agent research** | Agent name (e.g., `'scout'`, `'athena'`) | Agent's entity ID | Medium-high — depends on agent trust |
-| **Secondhand / hearsay** | Speaker's name | Speaker's entity ID | Lower — someone said it *about* someone else |
-| **External source** | Source URL or citation name | `NULL` or entity ID | Variable — credentials tracked separately |
+| Category | `source_entity_id` | Credibility |
+|----------|-------------------|-------------|
+| **Self-report** | The entity's own ID (fact's `entity_id` == source's entity_id) | Highest — the entity directly stated it about themselves |
+| **Direct observation** | `1` (NOVA's entity_id) | High — NOVA evaluated or inferred it directly |
+| **Agent research** | Agent's entity ID (e.g., Scout, Athena) | Medium-high — depends on agent trust |
+| **Secondhand / hearsay** | Speaker's entity ID | Lower — someone said it *about* someone else |
+| **External source** | `source_citation` / `source_url` populated, `source_entity_id` may be a placeholder | Variable — credentials tracked separately |
 
 ### Schema Fields Involved
 
-The testimony model engages several columns on `entity_facts`:
+The testimony model engages several columns across `entity_facts` and `entity_fact_sources`:
 
-| Column | Role in Testimony |
-|--------|-------------------|
-| `entity_id` | The subject — who the fact is *about* |
-| `key` | The attribute or property being described |
-| `value` | The asserted value |
-| `source` | Who told NOVA this (see categories above) |
-| `source_entity_id` | Entity ID of the speaker / source agent |
-| `confidence` | Initial confidence estimate (1.0 for authority, scaled for others) |
-| `data_type` | Semantic category: `permanent`, `identity`, `preference`, `temporal`, `observation` |
-| `vote_count` | How many times this fact has been reinforced |
-| `confirmation_count` | How many distinct sources confirmed this fact |
-| `last_confirmed` | When this fact was last re-stated or confirmed |
-| `learned_at` | When this fact was first recorded |
-| `source_channel_transcript_id` | Link to the source conversation transcript |
-| `source_channel_session_id` | Link to the source session |
+| Column | Table | Role in Testimony |
+|--------|-------|-------------------|
+| `entity_id` | entity_facts | The subject — who the fact is *about* |
+| `key` | entity_facts | The attribute or property being described |
+| `value` | entity_facts | The asserted value |
+| `source_entity_id` | entity_fact_sources | Entity ID of the speaker / source agent |
+| `source_citation` / `source_url` | entity_fact_sources | External-source provenance |
+| `confidence` | entity_facts | Initial confidence estimate (1.0 for I)ruid, scaled for others via `confidence_helper.py`) |
+| `durability` | entity_facts | Semantic/decay category: `permanent`, `long_term`, `short_term`, `ephemeral` (replaces the retired `data_type` column) |
+| `category` | entity_facts | Free-form category label: `observation`, `preference`, `identity`, `mood`, `decision`, `routine`, `state`, `obligation`, etc. |
+| `extraction_count` | entity_facts | How many times this fact has been reinforced (replaces the retired `vote_count`/`confirmation_count` columns) |
+| `last_confirmed_at` | entity_facts | When this fact was last re-stated or confirmed (timestamptz; replaces the retired `last_confirmed` column) |
+| `learned_at` | entity_facts | When this fact was first recorded |
+| `source_channel_transcript_id` | entity_facts | Link to the source conversation transcript |
+| `source_channel_session_id` | entity_facts | Link to the source session |
 
 ## Credibility Weighting (at Query Time)
 
@@ -87,7 +96,7 @@ How many times a fact has been reinforced. A fact stated five times across diffe
 
 ### 3. Recency
 
-More recent information may reflect changed preferences or circumstances. Especially relevant for `data_type = 'temporal'` or `data_type = 'preference'`.
+More recent information may reflect changed preferences or circumstances. Especially relevant for `category = 'state'`/`'mood'` or `category = 'preference'` facts.
 
 ### 4. Consistency
 
@@ -103,20 +112,26 @@ I)ruid states: *"My favorite pizza topping is pineapple."*
 
 ```sql
 -- Self-report: highest credibility
-INSERT INTO entity_facts
-    (entity_id, key, value, source, source_entity_id, confidence, data_type)
-VALUES
-    (2, 'favorite_pizza_topping', 'pineapple', 'I)ruid', 2, 1.0, 'preference');
+WITH new_fact AS (
+    INSERT INTO entity_facts (entity_id, key, value, confidence, durability, category)
+    VALUES (2, 'favorite_pizza_topping', 'pineapple', 1.0, 'long_term', 'preference')
+    RETURNING id
+)
+INSERT INTO entity_fact_sources (fact_id, source_entity_id)
+SELECT id, 2 FROM new_fact;  -- source_entity_id = 2 (I)ruid, self-report)
 ```
 
 Later, another agent (Scout) researches and finds: *"I)ruid favorite pizza topping is pepperoni."*
 
 ```sql
 -- Agent research: medium credibility
-INSERT INTO entity_facts
-    (entity_id, key, value, source, source_entity_id, confidence, data_type)
-VALUES
-    (2, 'favorite_pizza_topping', 'pepperoni', 'scout', 7, 0.8, 'preference');
+WITH new_fact AS (
+    INSERT INTO entity_facts (entity_id, key, value, confidence, durability, category)
+    VALUES (2, 'favorite_pizza_topping', 'pepperoni', 0.8, 'long_term', 'preference')
+    RETURNING id
+)
+INSERT INTO entity_fact_sources (fact_id, source_entity_id)
+SELECT id, 7 FROM new_fact;  -- source_entity_id = 7 (scout's entity ID)
 ```
 
 **Both facts coexist.** At query time, NOVA reasons:
@@ -130,9 +145,9 @@ VALUES
 
 Contradicting facts decay at the **same rate**. There is no mechanism to artificially suppress one side.
 
-- Both pineapple and pepperoni facts decay normally according to their `data_type` decay rates
+- Both pineapple and pepperoni facts decay normally according to their `durability` decay rates
 - The signal emerges from the **pattern of reinforcement over time**, not from suppressing unwanted entries
-- If I)ruid keeps re-stating "pineapple", that fact gets reinforced (higher `vote_count`, newer `last_confirmed`, higher effective credibility)
+- If I)ruid keeps re-stating "pineapple", that fact gets reinforced (higher `extraction_count`, newer `last_confirmed_at`, higher effective credibility)
 - If nobody mentions "pepperoni" again, it fades naturally
 
 ## Anti-Patterns
@@ -144,7 +159,7 @@ The following approaches are **explicitly contrary** to the testimony model:
 | **Treating contradictions as data integrity problems** | Contradictions are expected in testimony. Resolving them at write-time destroys signal. |
 | **Auto-resolving conflicts by keeping only the "newest" fact** | Newest is not always truest. Source credibility matters more than recency. |
 | **Reducing confidence scores on facts just because a conflicting one exists** | Each fact stands on its own provenance. A conflicting fact doesn't make the first one less reliable — it just means there are two competing testimonies. |
-| **Leaving `source` / `source_entity_id` blank when the origin is known** | Missing provenance cripples query-time reasoning. Always attribute. |
+| **Leaving `entity_fact_sources` unpopulated when the origin is known** | Missing provenance cripples query-time reasoning. Always attribute. |
 | **Attributing agent-sourced facts to "auto-extracted" instead of the specific agent** | "auto-extracted" loses the chain of custody. The specific agent (scout, athena, coder) preserves accountability. |
 | **Deleting facts to resolve ambiguity** | Deletion destroys signal. Reason about truth at query time, not storage time. |
 
@@ -157,15 +172,14 @@ The existing `SOURCE-AUTHORITY.md` describes an older model where authority-sour
 What changes:
 - **Authority self-reports still carry the highest credibility weight** — they are just no longer enforced at write time
 - **Contradictory facts are no longer rejected** — they persist alongside authority facts for query-time reasoning
-- **`data_type = 'permanent'` and `confidence = 1.0`** from authority sources remain as signals, but they inform reasoning rather than enforcing a write-time lock
+- **`durability = 'permanent'` and `confidence = 1.0`** from authority sources remain as signals, but they inform reasoning rather than enforcing a write-time lock
 
 What stays the same:
-- Authority detection and attribution logic (identifying I)ruid as entity_id=2)
-- Confidence scoring at insertion time based on source authority
-- Permanent facts excluded from decay
-- The database schema and SQL queries for authority detection
+- I)ruid is entity_id=2 and always gets `confidence = 1.0` via `confidence_helper.py`'s `OWNER_ENTITY_ID` constant
+- Permanent facts (`durability = 'permanent'`) are excluded from decay
+- The `entity_facts` / `entity_fact_sources` schema itself
 
-See `SOURCE-AUTHORITY.md` for the concrete implementation details of authority detection, confidence scoring, and maintenance. The testimony model described here governs **why** and **how** those mechanisms feed into NOVA's reasoning.
+See `SOURCE-AUTHORITY.md` for the current confidence-scoring implementation (`confidence_helper.py`) — note that document's deterministic write-time authority-rejection sections describe a pre-#174 pipeline that no longer exists; only its schema/concept sections and the confidence_helper.py description are current. The testimony model described here governs **why** and **how** those mechanisms feed into NOVA's reasoning.
 
 ## Summary
 
@@ -175,7 +189,7 @@ See `SOURCE-AUTHORITY.md` for the concrete implementation details of authority d
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
 │  Storage Time:  Every fact is testimony with attribution        │
-│                  └─ source, source_entity_id, context           │
+│                  └─ entity_fact_sources.source_entity_id, context │
 │                  └─ Contradictions preserved                    │
 │                                                                 │
 │  Query Time:     Reason about credibility                      │

--- a/memory/docs/memory-extraction-pipeline.md
+++ b/memory/docs/memory-extraction-pipeline.md
@@ -2,52 +2,96 @@
 
 The memory extraction pipeline automatically transforms natural language conversations into structured database records. This guide covers how it works, how to troubleshoot issues, and how to optimize performance.
 
+> **Note:** This doc previously described a three-script shell pipeline (`extract-memories.sh` → `store-memories.sh`, driven by `process-input.sh`). That pipeline was consolidated into a single Python script, `memory/scripts/extract_memories.py`, as part of the #174 grammar-parser removal. None of `extract-memories.sh`, `store-memories.sh`, or `process-input.sh` exist in this repo's `memory/scripts/` anymore. This revision documents the current pipeline.
+>
+> **Known issue:** `memory/scripts/memory-catchup.sh` (current repo source) still references `EXTRACT_SCRIPT="${SCRIPT_DIR}/process-input.sh"` and calls it directly — that script does not exist in this repo. A `process-input.sh` happens to exist as a stale deployed artifact at `~/.openclaw/scripts/`/`~/.openclaw/workspace/scripts/` on at least one host, but it in turn calls `extract-memories.sh`, which also does not exist. This is a real latent bug in `memory-catchup.sh` worth a GitHub issue and a fix from the Software Engineering domain — flagging here rather than silently patching the script, since that's outside Technical Writing's scope.
+
 ## Overview
 
-```
-Session JSONL → memory-catchup.sh ──→ channel_sessions/transcripts (DB)
-     ↓                                    ↓
-  extract-memories.sh ──→ store-memories.sh ──→ PostgreSQL (entity_facts + FK source pointers)
-     ↓                        ↓
-  Claude API             Structured data
-  extraction             with deduplication
-```
+There are two related but distinct paths into nova-memory:
 
-The pipeline now has two parallel paths:
-1. **Transcript ingestion:** JSONL session files are parsed and upserted into `channel_sessions`/`channel_transcripts` tables, then source files are deleted
-2. **Memory extraction:** Messages are sent to Claude for structured data extraction, and results are stored with FK pointers back to the source `channel_transcripts` row
+```
+Real-time path (per-message):
+Incoming message → memory-extract hook → extract_memories.py → PostgreSQL
+                                              ↓
+                                        Claude API extraction
+                                        (LLM judges durability/category/confidence per fact)
+
+Catch-up path (session transcript ingestion, cron-driven):
+Session JSONL → memory-catchup.sh → channel_sessions/transcripts (DB)
+                      ↓
+              (also attempts message-level re-extraction via the
+               process-input.sh code path described above — currently broken)
+```
 
 **Key Features:**
-- 20-message rolling context window for reference resolution
+- Extraction is LLM-driven in a single pass: the extraction prompt (in `extract_memories.py`) asks Claude to classify `durability`, `category`, `confidence`, and `visibility` per fact directly, rather than a separate deterministic storage script applying rules after the fact
 - Bidirectional extraction (both user and assistant messages)
-- Real-time deduplication to prevent data corruption
-- Automatic vocabulary extraction for STT improvement
+- Real-time deduplication to prevent data corruption (`memory/scripts/dedup_helper.py`)
+- Automatic vocabulary/entity-identifier extraction (phone, email, Discord/GitHub/Signal handles)
 - Rate limiting and error recovery
-- JSONL → DB ingest with provider detection (Discord, Signal, Telegram, generic)
+- JSONL → DB ingest with provider detection (Discord, Signal, Telegram, generic) via `memory-catchup.sh`
 
 ## Components
 
-### 1. memory-catchup.sh - Collection & Batching
+### 1. `memory-extract` hook + `extract_memories.py` — Real-Time Extraction
 
-**Purpose:** Scans session transcripts and queues messages for processing
+**Purpose:** Extracts structured data (entities, facts, events, vocabulary) from a single incoming message as it arrives, using sender metadata passed via environment variables.
 
-**Location:** `~/.openclaw/workspace/nova-memory/scripts/memory-catchup.sh`
+**Location:** `memory/scripts/extract_memories.py` (source), deployed via the `memory-extract` hook
+
+**Env vars consumed (see the script's module docstring for the full/current list):** `SENDER_NAME`, `SENDER_ID`, `IS_GROUP`, `SOURCE_SESSION_ID`, and related sender/session metadata.
+
+**Output:** JSON with these categories (see the script's extraction prompt/template for the authoritative list):
+- `facts` (entity-scoped key/value facts, each carrying `subject`, `key`, `value`, `category`, `durability`, `confidence`, `visibility`, optional `expires`)
+- `entities` (people, AIs, organizations, places)
+- `events` (dated occurrences)
+- `vocabulary` (STT-relevant terms: names, brands, technical jargon, slang)
+
+Facts about identifiers (phone, email, Discord/GitHub handle, Signal UUID) are extracted directly into `entity_facts` with the appropriate `key` (e.g. `key="phone"`), not into a separate "entities" bucket, and phone numbers are always marked `visibility="private"`.
+
+**Durability guidance baked into the prompt:**
+- `permanent`: Identity facts that rarely change. Never auto-decays.
+- `long_term`: Durable preferences/observations. Slow decay.
+- `short_term`: Current states/moods. Moderate decay.
+- `ephemeral`: Temporary/fleeting conditions. Aggressive decay.
+
+**Troubleshooting:**
+
+| Problem | Symptoms | Solution |
+|---------|----------|----------|
+| API timeouts | Extraction hangs or times out | Check `ANTHROPIC_API_KEY` and network connectivity |
+| No extraction happening | No new `entity_facts`/`events` rows despite active chat | Verify the `memory-extract` hook is enabled: `openclaw hooks list` |
+| Missing context | Poor reference resolution ("that", "yes", "do it" not extracted) | Check the rolling context window the hook passes in (see hook config) |
+| Rate limiting | HTTP 429 errors | Add/adjust delay handling in the hook or extraction call |
+
+### 2. `dedup_helper.py` — Deduplication
+
+**Purpose:** Prevents duplicate entity/fact rows during extraction storage.
+
+**Location:** `memory/scripts/dedup_helper.py`
+
+Imports `get_initial_confidence` from `confidence_helper.py` to set a starting confidence score based on the reporting entity's `trust_level` (see `SOURCE-AUTHORITY.md`). Facts that already exist are reinforced (`extraction_count` incremented, `last_confirmed_at` updated) rather than duplicated.
+
+### 3. `memory-catchup.sh` — Session Transcript Ingestion (Cron-Driven)
+
+**Purpose:** Scans session transcripts and ingests them into the database; also attempts a legacy per-message re-extraction path (see the known-issue note above).
+
+**Location:** `memory/scripts/memory-catchup.sh`
 
 **How it works:**
 1. Reads session transcripts from `~/.openclaw/agents/main/sessions/`
 2. Tracks last processed timestamp in `~/.openclaw/memory-catchup-state.json`
-3. Rate-limits to 3 messages per run to avoid API overload
-4. Builds 20-message context window for each extraction
-5. **Ingests JSONL files into DB:** Parses session files from `~/.openclaw/agents/*/sessions/*.jsonl` and upserts into `channel_sessions` + `channel_transcripts` with provider detection, rich metadata parsing (sender names, IDs, group info), and deduplication via composite unique indexes
-6. **Deletes source files:** After successful DB commit, source JSONL files are removed. Extraction failures do NOT block transcript ingestion.
-7. **Ingests daily memory `*.md` files:** Content is stored as `entity_facts` on the NOVA entity, then source files are deleted
+3. Maintains a rolling message cache at `~/.openclaw/memory-message-cache.json`
+4. **Ingests JSONL files into DB:** Parses session files from `~/.openclaw/agents/*/sessions/*.jsonl` and upserts into `channel_sessions` + `channel_transcripts` with provider detection, rich metadata parsing (sender names, IDs, group info), and deduplication via composite unique indexes
+5. **Deletes source files:** After successful DB commit, source JSONL files are removed. Extraction failures do NOT block transcript ingestion.
+6. Attempts to invoke `process-input.sh` for message-level extraction — **currently broken** (see known-issue note above); this does not block transcript ingestion, which is why the JSONL → DB path continues to work even though this sub-path is broken
 
 **State file structure:**
 ```json
 {
-  "last_processed": "2026-02-08T15:30:00Z",
-  "message_count": 1847,
-  "last_session": "2026-02-08.jsonl"
+  "last_processed_ts": "2026-02-08T15:30:00.000Z",
+  "processed_count": 1847
 }
 ```
 
@@ -55,98 +99,20 @@ The pipeline now has two parallel paths:
 - `chat_id` → `provider` detection (channel: → discord, group: → signal)
 - `is_group_chat`, `group_subject`, `group_space` → session metadata
 - `sender_id`, `sender`, `sender_username`, `sender_tag` → transcript sender fields
-- `session_key` → channel_sessions.session_key
+- `session_key` → `channel_sessions.session_key`
 
 **Troubleshooting:**
 
 | Problem | Symptoms | Solution |
 |---------|----------|----------|
 | No new extractions | State file timestamp stuck | Delete state file: `rm ~/.openclaw/memory-catchup-state.json` |
-| Missing recent messages | Extractions lag behind chat | Check cron job is running: `systemctl status cron` |
+| Missing recent messages | Extractions lag behind chat | Check cron job is running: `crontab -l \| grep memory-catchup` |
 | Duplicate processing | Same messages processed twice | State file corruption - recreate with current timestamp |
-| Script hangs | Process doesn't complete | Check for stuck Claude API calls in extract-memories.sh |
-
-### 2. extract-memories.sh - Natural Language Processing
-
-**Purpose:** Uses Claude to extract structured data from conversational text
-
-**Location:** `~/.openclaw/workspace/nova-memory/scripts/extract-memories.sh`
-
-**Input format:**
-```
-Context: [Last 20 messages for reference resolution]
----
-[CURRENT MESSAGE TO EXTRACT]
-```
-
-**Output:** JSON with 8 categories:
-- entities (people, AIs, organizations)
-- places (locations, venues, networks)
-- facts (objective information)
-- opinions (subjective views with holder)
-- preferences (likes/dislikes)
-- events (timeline items)
-- relationships (connections between entities)
-- vocabulary (new words for STT)
-
-**Example extraction:**
-```bash
-# Input message
-"Yes, let's use that design for the Burning Man crawler"
-
-# With context understanding "that design" refers to previous discussion
-{
-  "entities": [],
-  "places": [{"name": "Burning Man", "type": "event", "location": "Nevada"}],
-  "facts": [{"fact": "Design approved for Burning Man crawler project"}],
-  "events": [{"event": "Design approval for Burning Man crawler", "date": "2026-02-08"}],
-  "preferences": [{"holder": "user", "subject": "crawler design", "preference": "approved"}]
-}
-```
-
-**Troubleshooting:**
-
-| Problem | Symptoms | Solution |
-|---------|----------|----------|
-| API timeouts | Script hangs on Claude calls | Check `ANTHROPIC_API_KEY` and network connectivity |
-| Invalid JSON output | Store script fails with parse errors | Add JSON validation to extract script |
-| Missing context | Poor reference resolution | Verify context cache in `~/.openclaw/memory-message-cache.json` |
-| Rate limiting | HTTP 429 errors | Increase delay between API calls |
-
-### 3. store-memories.sh - Database Storage
-
-**Purpose:** Validates and stores extracted JSON in PostgreSQL with deduplication
-
-**Location:** `~/.openclaw/workspace/nova-memory/scripts/store-memories.sh`
-
-**Deduplication strategy:**
-- **Layer 1 (Prompt):** Existing facts queried and shown to Claude
-- **Layer 2 (Storage):** Database checks before every insert
-
-**Source FK pointer wiring:** When `SOURCE_CHANNEL_TRANSCRIPT_ID` and `SOURCE_CHANNEL_SESSION_ID` env vars are set (passed by `memory-catchup.sh` or the `memory-extract` hook), they populate `entity_facts.source_channel_transcript_id` and `.source_channel_session_id` on both new inserts and reinforced facts. The `reinforce_fact()` function uses `COALESCE` to only upgrade from NULL (never downgrade).
-
-**SQL injection fix:** `fact_exists()` uses exact LOWER equality matching instead of `ILIKE` interpolation, preventing SQL injection via fact values.
-
-**Storage flow:**
-1. Parse and validate JSON
-2. For each category, check existing records
-3. Skip duplicates (reinforce with extraction_count++), insert new records
-4. Set FK source pointers from env vars on facts/opinions/preferences
-5. Update vocabulary table for STT
-6. Log insertion results
-
-**Troubleshooting:**
-
-| Problem | Symptoms | Solution |
-|---------|----------|----------|
-| Constraint violations | UNIQUE constraint errors | Normal - deduplication working correctly |
-| Connection failures | psql connection errors | Check PostgreSQL service and database credentials |
-| Malformed data | Data truncation warnings | Increase column sizes in schema.sql |
-| Performance issues | Slow inserts | Add indexes: `CREATE INDEX ON entities(name)` |
+| Script hangs | Process doesn't complete | Check for stuck Claude API calls, or the broken `process-input.sh` path noted above |
 
 ## Context Window System
 
-The pipeline maintains a **20-message rolling cache** for improved reference resolution.
+Real-time extraction context resolution happens per-message via the hook's own context passing (not a separate cache file for that path). `memory-catchup.sh` separately maintains its own rolling cache at `~/.openclaw/memory-message-cache.json` for its ingestion path.
 
 ### Cache Structure
 
@@ -155,30 +121,12 @@ The pipeline maintains a **20-message rolling cache** for improved reference res
 ```json
 [
   {"role": "user", "timestamp": "2026-02-08T15:00:00Z", "content": "How much do crawlers cost?"},
-  {"role": "assistant", "timestamp": "2026-02-08T15:00:15Z", "content": "About $130M in today's dollars"},
-  {"role": "user", "timestamp": "2026-02-08T15:01:00Z", "content": "Let's build one for Burning Man"},
-  {"role": "assistant", "timestamp": "2026-02-08T15:01:30Z", "content": "That would be legendary..."}
+  {"role": "assistant", "timestamp": "2026-02-08T15:00:15Z", "content": "About $130M in today's dollars"}
 ]
-```
-
-### Context Benefits
-
-**Before (no context):**
-```
-Message: "Yes, keep that aesthetic"
-Extraction: {} // Can't resolve "that"
-```
-
-**After (with context):**
-```
-Context shows previous discussion about retro-futuristic crawler design
-Message: "Yes, keep that aesthetic"  
-Extraction: {"preferences": [{"holder": "user", "subject": "retro-futuristic aesthetic", "preference": "approved"}]}
 ```
 
 ### Cache Maintenance
 
-- **Size limit:** 20 messages maximum
 - **Rotation:** FIFO (oldest messages removed first)
 - **Persistence:** Survives script restarts
 - **Reset:** Delete cache file to start fresh
@@ -188,9 +136,8 @@ Extraction: {"preferences": [{"holder": "user", "subject": "retro-futuristic aes
 ### Prerequisites
 
 ```bash
-# 1. PostgreSQL with nova_memory database
-createdb nova_memory
-psql -d nova_memory -f ~/.openclaw/workspace/nova-memory/schema.sql
+# 1. PostgreSQL with the nova-mind database, schema applied via pgschema
+#    (see memory/INSTALLATION.md for the full installer-based flow)
 
 # 2. Anthropic API key
 export ANTHROPIC_API_KEY="your-key-here"
@@ -202,24 +149,18 @@ sudo apt install postgresql-client jq curl
 ### Automated Setup (Cron Job)
 
 ```bash
-# Add to crontab (runs every minute)
-* * * * * source ~/.bashrc && /path/to/nova-memory/scripts/memory-catchup.sh >> ~/.openclaw/logs/memory-catchup.log 2>&1
+# Add to crontab (memory-catchup.sh runs on its own schedule; check current
+# crontab for the exact cadence rather than assuming "every minute")
+crontab -l | grep memory-catchup
 ```
 
-### Manual Processing
+### Manual Testing
+
+There is no standalone CLI to manually trigger real-time extraction for a single message — it runs via the `memory-extract` hook as part of live message handling. To test the transcript-ingestion path:
 
 ```bash
-# Process a specific message
-./scripts/process-input.sh "John mentioned he loves coffee from Blue Bottle"
-
-# Process recent messages (one-time)
-./scripts/memory-catchup.sh
-
-# Extract only (no storage)
-echo "Test message" | ./scripts/extract-memories.sh
-
-# Store pre-extracted JSON
-echo '{"entities": [{"name": "John", "type": "person"}]}' | ./scripts/store-memories.sh
+# Process recent session transcripts (one-time run)
+~/.openclaw/scripts/memory-catchup.sh --log
 ```
 
 ## Monitoring and Debugging
@@ -240,18 +181,14 @@ grep CRON /var/log/syslog | grep memory-catchup
 ### Health Checks
 
 ```bash
-# 1. Check extraction is working
-./scripts/process-input.sh "Test entity John Doe mentioned pizza"
-psql -d nova_memory -c "SELECT * FROM entities WHERE name = 'John Doe';"
+# 1. Verify the memory-extract hook is enabled
+openclaw hooks list
 
 # 2. Verify cron job
 ps aux | grep memory-catchup
 ls -la ~/.openclaw/memory-catchup-state.json
 
-# 3. Check API connectivity  
-echo "Test" | ./scripts/extract-memories.sh
-
-# 4. Database connectivity
+# 3. Database connectivity
 psql -d nova_memory -c "SELECT COUNT(*) FROM entities;"
 ```
 
@@ -279,26 +216,24 @@ SELECT 'facts', COUNT(*) FROM entity_facts WHERE created_at > NOW() - INTERVAL '
 
 **Symptoms:**
 - No new database records despite active chat
-- State file timestamp not updating
-- Cron log shows no activity
+- State file timestamp not updating (for the catchup path) or no hook activity (for the real-time path)
 
 **Diagnosis:**
 ```bash
-# Check if cron job is running
+# Real-time path: verify hook is enabled
+openclaw hooks list
+
+# Catchup path: check cron and recent logs
 crontab -l | grep memory-catchup
-
-# Check for script errors
 tail -50 ~/.openclaw/logs/memory-catchup.log
-
-# Test manual execution
-./scripts/memory-catchup.sh
 ```
 
 **Solutions:**
-1. **Missing API key:** Ensure `ANTHROPIC_API_KEY` is exported in cron environment
-2. **Script permissions:** `chmod +x scripts/*.sh`
+1. **Missing API key:** Ensure `ANTHROPIC_API_KEY` is exported in the relevant environment (hook process or cron environment)
+2. **Script permissions:** `chmod +x memory/scripts/*.sh memory/scripts/*.py`
 3. **Path issues:** Use absolute paths in crontab
 4. **PostgreSQL down:** `sudo systemctl start postgresql`
+5. **Hook not enabled:** `openclaw hooks enable memory-extract`
 
 ### Issue: Duplicate Entries
 
@@ -307,7 +242,7 @@ tail -50 ~/.openclaw/logs/memory-catchup.log
 - Facts being re-inserted
 
 **Solutions:**
-1. **Update deduplication logic** in store-memories.sh
+1. **Check `dedup_helper.py`** logic and thresholds
 2. **Add database constraints:**
 ```sql
 -- Prevent duplicate entities
@@ -317,17 +252,6 @@ ALTER TABLE entities ADD CONSTRAINT unique_entity_name_type UNIQUE (name, type);
 ALTER TABLE entity_facts ADD CONSTRAINT unique_entity_fact UNIQUE (entity_id, key, value);
 ```
 
-### Issue: Poor Reference Resolution
-
-**Symptoms:**
-- Messages like "yes", "that", "do it" not being extracted
-- Missing context connections
-
-**Solutions:**
-1. **Check context cache:** Verify `~/.openclaw/memory-message-cache.json` has recent messages
-2. **Increase context window:** Modify CONTEXT_SIZE in memory-catchup.sh
-3. **Improve Claude prompt:** Add more examples of pronoun resolution
-
 ### Issue: High API Costs
 
 **Symptoms:**
@@ -335,67 +259,37 @@ ALTER TABLE entity_facts ADD CONSTRAINT unique_entity_fact UNIQUE (entity_id, ke
 - Many API calls per minute
 
 **Solutions:**
-1. **Reduce extraction frequency:** Change cron to every 5 minutes
-2. **Batch processing:** Modify catchup script to process multiple messages per API call
-3. **Filter trivial messages:** Skip messages like "ok", "thanks", emoji-only
+1. **Filter trivial messages:** Skip messages like "ok", "thanks", emoji-only before calling the extraction API
+2. **Review hook trigger conditions** for over-eager invocation
 
 ## Advanced Configuration
 
-### Rate Limiting
-
-Edit `memory-catchup.sh`:
-```bash
-# Change from 3 messages per run to 1
-MAX_MESSAGES_PER_RUN=1
-
-# Add delay between messages  
-sleep 2
-```
-
 ### Custom Extraction Categories
 
-Modify the prompt in `extract-memories.sh` to add new categories:
-```bash
-# Add "tasks" category
-echo "tasks: actionable items or todo items with deadlines"
-```
+Modify the extraction prompt directly in `extract_memories.py` (the `TEMPLATE`/instructions block) to add new categories or fields.
 
 ### Database Schema Extensions
 
-Add new tables for specialized data:
-```sql
--- Track extraction metrics
-CREATE TABLE extraction_stats (
-    id SERIAL PRIMARY KEY,
-    script VARCHAR(50),
-    message_count INT,
-    api_calls INT,
-    errors INT,
-    runtime_seconds INT,
-    created_at TIMESTAMP DEFAULT NOW()
-);
-```
+Add new tables via the declarative schema (`database/schema.sql` at the repo root), following the pattern used for existing tables like `extraction_metrics`.
 
 ## Integration with OpenClaw
 
 ### Hook Installation
 
-For automatic extraction on incoming messages:
+The `memory-extract` hook is installed automatically by `agent-install.sh`. To verify or re-enable manually:
+
 ```bash
-cp -r hooks/memory-extract ~/.openclaw/workspace/hooks/
+openclaw hooks list
 openclaw hooks enable memory-extract
-export NOVA_MEMORY_SCRIPTS="/path/to/nova-memory/scripts"
 ```
 
 ### Memory Search Integration
 
-The extracted data becomes searchable via OpenClaw's memory system:
-```bash
-# Semantic search across all memory
-/memory_search "pizza places in Brooklyn" 
+The extracted data becomes searchable via the `turn-context` Plugin SDK plugin (semantic recall) and direct SQL:
 
-# Database queries
-psql -d nova_memory -c "SELECT * FROM places WHERE location ILIKE '%brooklyn%';"
+```sql
+-- Database queries
+SELECT * FROM entity_facts ef JOIN entities e ON e.id = ef.entity_id WHERE e.name ILIKE '%brooklyn%';
 ```
 
 ## Performance Optimization
@@ -415,22 +309,12 @@ CREATE INDEX idx_entity_facts_entity_id ON entity_facts(entity_id);
 CREATE INDEX idx_events_date ON events(date);
 ```
 
-### Batch Processing
-
-For high-volume systems, modify memory-catchup.sh to process multiple messages per API call:
-```bash
-# Instead of 1 message per API call
-# Batch 5 messages together
-BATCH_SIZE=5
-```
-
-**Note for Documentation Team:** The memory extraction pipeline's sophisticated NLP processing chain and context window management would benefit from **Quill haiku collaboration** to explain complex concepts like reference resolution and deduplication in accessible metaphors.
-
 ## Next Steps
 
-1. **Set up monitoring:** Implement extraction metrics tracking
-2. **Tune performance:** Adjust batch sizes and API limits based on usage
-3. **Extend categories:** Add task extraction, sentiment analysis
-4. **Add validation:** Implement data quality checks and correction flows
+1. **Fix the `memory-catchup.sh` → `process-input.sh` broken call path** (see known-issue note at the top of this doc)
+2. **Set up monitoring:** Implement extraction metrics tracking
+3. **Tune performance:** Adjust batch sizes and API limits based on usage
+4. **Extend categories:** Add task extraction, sentiment analysis
+5. **Add validation:** Implement data quality checks and correction flows
 
 The memory extraction pipeline is the heart of nova-memory's automatic learning capability. Understanding and maintaining it properly ensures your AI assistant continuously builds comprehensive, searchable knowledge from every conversation.

--- a/memory/docs/semantic-search-guide.md
+++ b/memory/docs/semantic-search-guide.md
@@ -230,10 +230,10 @@ $$ LANGUAGE plpgsql;
 
 ### 1. Automatic Embedding on Extraction
 
-When memories are extracted and stored, they're automatically queued for embedding:
+When memories are extracted and stored, they're automatically queued for embedding. (Note: there is no `store-memories.sh` in the current pipeline — extraction and storage happen in `memory/scripts/extract_memories.py`; the illustrative snippet below shows the concept, not a literal current file.)
 
 ```bash
-# In store-memories.sh, after inserting data:
+# Conceptual — illustrates the check, not a literal current script location
 
 # Check if new entities were created
 NEW_ENTITIES=$(psql -t -c "
@@ -292,8 +292,10 @@ WHERE l.id = NEW.id;
 
 ### 1. Command-Line Search Tool
 
+> **Note:** There is no `search-memories.sh` in the current repo. Semantic search runs through the `turn-context` Plugin SDK plugin (`memory/plugins/turn-context/`), which calls `memory/scripts/proactive-recall.py` internally as part of turn context injection — not as a standalone CLI. The script below is illustrative of the query pattern, not a literal current file.
+
 ```bash
-# scripts/search-memories.sh
+# Illustrative — not a literal current file; see proactive-recall.py for the real query logic
 #!/bin/bash
 
 QUERY="$1"
@@ -640,12 +642,14 @@ VACUUM ANALYZE memory_embeddings;
 ### 1. OpenClaw Integration
 
 ```javascript
-// openclaw-plugin: semantic-memory-search
+// Illustrative integration pattern — the real integration is the turn-context
+// Plugin SDK plugin (memory/plugins/turn-context/), which calls
+// proactive-recall.py directly rather than spawning a shell script per query.
 const { spawn } = require('child_process');
 
 function searchMemories(query, limit = 10) {
     return new Promise((resolve, reject) => {
-        const search = spawn('./scripts/search-memories.sh', [query, limit.toString()]);
+        const search = spawn('./scripts/proactive-recall.py', [query, limit.toString()]);
         let output = '';
         
         search.stdout.on('data', (data) => {

--- a/memory/migrations/082_blockers_and_d100_roll_history.sql
+++ b/memory/migrations/082_blockers_and_d100_roll_history.sql
@@ -1,0 +1,89 @@
+-- Migration 082: Blocker registry and D100 roll history
+-- Issues #356 (heartbeat-integrated blocker outreach) and #358 (forced D100 >12h)
+
+-- ---------------------------------------------------------------------------
+-- 1. Blockers table
+-- ---------------------------------------------------------------------------
+-- Curated registry of items that are blocked waiting on another entity.
+-- Source types (per issue #356 as amended 2026-07-02):
+--   task, github_issue, workflow_run, unanswered_question, agent_chat_request
+--
+-- entity_id is NOT NULL. Curation/insert logic must resolve a responsible
+-- entity before inserting; if resolution fails, fall back to entity_id = 2
+-- (I)ruid) per the spec-gap rulings for SE Run #333.
+--
+-- Reopen semantics: when a satisfied blocker becomes blocked again, clear
+-- satisfied_at back to NULL (ruling #2).
+--
+-- proactive_outreach predates this table and remains polymorphic:
+-- blocker_type references the logical source_type and blocker_id references
+-- blockers.id. No FK is added to proactive_outreach (ruling #12).
+CREATE TABLE IF NOT EXISTS blockers (
+    id SERIAL PRIMARY KEY,
+    source_type VARCHAR(50) NOT NULL,
+    source_ref VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    needs TEXT NOT NULL,
+    entity_id INTEGER NOT NULL REFERENCES entities(id),
+    priority INTEGER DEFAULT 5,
+    status VARCHAR(20) DEFAULT 'open',
+    first_seen TIMESTAMPTZ DEFAULT NOW(),
+    last_seen TIMESTAMPTZ DEFAULT NOW(),
+    satisfied_at TIMESTAMPTZ,
+    CONSTRAINT blockers_status_check CHECK (status IN ('open', 'satisfied')),
+    CONSTRAINT blockers_source_type_check CHECK (
+        source_type IN (
+            'task',
+            'github_issue',
+            'workflow_run',
+            'unanswered_question',
+            'agent_chat_request'
+        )
+    ),
+    CONSTRAINT blockers_source_unique UNIQUE (source_type, source_ref)
+);
+
+CREATE INDEX IF NOT EXISTS idx_blockers_entity ON blockers(entity_id);
+CREATE INDEX IF NOT EXISTS idx_blockers_status ON blockers(status);
+CREATE INDEX IF NOT EXISTS idx_blockers_priority_first_seen ON blockers(priority ASC, first_seen ASC, id ASC);
+
+-- ---------------------------------------------------------------------------
+-- 2. D100 roll history table
+-- ---------------------------------------------------------------------------
+-- roll_d100() updates motivation_d100.last_rolled for the single slot that
+-- was rolled. That column is per-slot and therefore insufficient to answer
+-- "when was the most recent D100 roll across any slot?" for the forced-D100
+-- gate (#358). This table records every roll event.
+CREATE TABLE IF NOT EXISTS d100_roll_log (
+    id SERIAL PRIMARY KEY,
+    roll INTEGER NOT NULL,
+    rolled_at TIMESTAMPTZ DEFAULT NOW(),
+    CONSTRAINT d100_roll_log_roll_check CHECK (roll >= 1 AND roll <= 100)
+);
+
+CREATE INDEX IF NOT EXISTS idx_d100_roll_log_rolled_at ON d100_roll_log(rolled_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- 3. Trigger: keep roll_d100() history in sync
+-- ---------------------------------------------------------------------------
+-- The function is SECURITY DEFINER, so we log from its result via a trigger
+-- on motivation_d100 instead of rewriting the function. The trigger fires
+-- whenever last_rolled is updated (i.e. after a successful roll_d100() call)
+-- and inserts a row into d100_roll_log. We ignore updates that do not change
+-- last_rolled (idempotent re-runs).
+CREATE OR REPLACE FUNCTION _trg_log_d100_roll()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.last_rolled IS DISTINCT FROM OLD.last_rolled AND NEW.last_rolled IS NOT NULL THEN
+        INSERT INTO d100_roll_log (roll, rolled_at)
+        VALUES (NEW.roll, NEW.last_rolled);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_log_d100_roll ON motivation_d100;
+CREATE TRIGGER trg_log_d100_roll
+    AFTER UPDATE ON motivation_d100
+    FOR EACH ROW
+    EXECUTE FUNCTION _trg_log_d100_roll();

--- a/memory/migrations/083_blocker_outreach_workflow_27.sql
+++ b/memory/migrations/083_blocker_outreach_workflow_27.sql
@@ -1,0 +1,70 @@
+-- Migration 083: Workflow 27 (Proactive Mode) — blocker curation + dedicated
+-- outreach step, forced D100 step renumbering.
+-- Issues #356 (heartbeat-integrated blocker outreach) and #358 (forced D100 >12h)
+--
+-- Summary of changes:
+--   1. Step 6 (Work on Pending Tasks): replace inline blocker handling with
+--      curation semantics — upsert into `blockers` (migration 082), resolve
+--      the responsible entity, NO immediate outreach from this step.
+--   2. Step 7 (Work on Open GitHub Issues): same curation semantics; REMOVE
+--      the existing inline outreach cascade + 3-day cooldown text entirely.
+--   3. New step 8 (Blocker Outreach): the dedicated, heartbeat-integrated
+--      outreach step driven by proactive-gate-check.py's
+--      check_step8_blocker_outreach() (see migration 082 / CHUNK 2).
+--   4. Renumber old steps 8/9/10 (Unsolved Problems, Filesystem Hygiene,
+--      D100) to 9/10/11. Uses a temporary offset to avoid violating the
+--      (workflow_id, step_order) UNIQUE constraint mid-migration.
+--
+-- No step-number cross-references appear inside any step's description text
+-- (verified against the live rows before writing this migration), so no
+-- description edits are needed for the pure renumbering of steps 8/9/10.
+
+-- ---------------------------------------------------------------------------
+-- 1. Renumber steps 8, 9, 10 -> 9, 10, 11 using a temporary offset to avoid
+--    violating the workflow_steps_workflow_id_step_order_key UNIQUE
+--    constraint (workflow_id, step_order) while the new step 8 is inserted
+--    below.
+-- ---------------------------------------------------------------------------
+UPDATE workflow_steps
+SET step_order = step_order + 1000
+WHERE workflow_id = 27 AND step_order IN (8, 9, 10);
+
+UPDATE workflow_steps
+SET step_order = step_order - 1000 + 1
+WHERE workflow_id = 27 AND step_order IN (1008, 1009, 1010);
+
+-- ---------------------------------------------------------------------------
+-- 2. Step 6 (Work on Pending Tasks) — curation semantics, no immediate
+--    outreach. Blocked tasks are upserted into `blockers`; the dedicated
+--    step 8 handles all outreach.
+-- ---------------------------------------------------------------------------
+UPDATE workflow_steps
+SET description = E'## Work on Pending Tasks\n\n```sql\nSELECT id, title, priority, description FROM tasks\nWHERE status = ''pending'' AND assigned_to = 1\nAND (blocked IS NULL OR blocked = false)\nORDER BY priority DESC, created_at ASC LIMIT 1;\n```\n\n**Actionable means actionable NOW.** A task is actionable only if it can be progressed in this session without waiting for human input, authorization, or an external dependency. Tasks that are open but blocked, awaiting discussion, or need information you don''t have are NOT actionable — skip them. Do not treat "open" as "actionable."\n\nIf an actionable task exists:\n- Set status to `in_progress`, update `last_worked_at`\n- Work on it (spawn subagents as needed)\n- If completed → mark `completed`, pick next\n- If blocked → set `blocked = true`, `blocked_reason`, and **curate it into the blocker registry**:\n  - Resolve the responsible entity: check `agent_domains` first (task domain → agent), then `user_domains` (lower priority number wins; tiebreak random among equal-priority matches); if no match, fall back to entity_id = 2 (I)ruid)\n  - `INSERT INTO blockers (source_type, source_ref, description, needs, entity_id, priority) VALUES (''task'', <task id as text>, <task title/description>, <blocked_reason>, <resolved entity_id>, <task priority>) ON CONFLICT (source_type, source_ref) DO UPDATE SET last_seen = NOW(), description = EXCLUDED.description, needs = EXCLUDED.needs;`\n  - Do **not** send outreach from this step — the dedicated Blocker Outreach step (step 8) owns all outreach cadence and channel escalation\n- If interrupted by new message → pause, update `work_notes` with progress\n\n**If no pending tasks:** advance to next step.\n\n---\n\n**Step reporting requirement:** After completing this step (whether work was performed or the step was skipped via gate check), post a concise summary of the step''s outcome to Discord <#1504054635231445112> (#proactive-mode). Include: step number/name, action taken or reason skipped, and any notable findings. Keep it brief — one short paragraph or a few bullets.'
+WHERE workflow_id = 27 AND step_order = 6;
+
+-- ---------------------------------------------------------------------------
+-- 3. Step 7 (Work on Open GitHub Issues) — same curation semantics; the
+--    inline outreach cascade + 3-day cooldown text is removed entirely.
+-- ---------------------------------------------------------------------------
+UPDATE workflow_steps
+SET description = E'## Work on Open GitHub Issues\n\nCheck open issues across all repos in the NOVA-Openclaw GitHub account:\n\n```bash\n# List all repos, then check each for open issues\ngh repo list NOVA-Openclaw --no-archived --limit 50 --json name -q ''.[].name'' | while read repo; do\n  count=$(gh issue list --repo NOVA-Openclaw/$repo --state open --json number -q ''length'')\n  [ "$count" -gt 0 ] && echo "NOVA-Openclaw/$repo: $count open issues"\ndone\n```\n\n**Actionable means actionable NOW.** An issue is actionable only if it can be progressed in this session without waiting for human input, authorization, or an external dependency. Issues that are open but blocked on discussion, need human decisions, or require authorization you don''t have are NOT actionable — skip them. Do not treat "open" as "actionable."\n\nFor each open issue:\n- Can it be worked without human input? → Start an SE workflow or delegate to the appropriate agent\n- Is it blocked and needs human input? → **Curate it into the blocker registry** (do not contact anyone from this step):\n  - Resolve the responsible entity: check `agent_domains` first (issue label/repo domain → agent), then `user_domains` (lower priority number wins; tiebreak random among equal-priority matches); if no match, fall back to entity_id = 2 (I)ruid)\n  - `INSERT INTO blockers (source_type, source_ref, description, needs, entity_id, priority) VALUES (''github_issue'', <repo>#<issue number>, <issue title>, <what''s needed to unblock>, <resolved entity_id>, <priority>) ON CONFLICT (source_type, source_ref) DO UPDATE SET last_seen = NOW(), description = EXCLUDED.description, needs = EXCLUDED.needs;`\n  - All outreach cadence and channel escalation is owned exclusively by the dedicated Blocker Outreach step (step 8)\n- Is it already being worked (has an open PR or active workflow run)? → Skip\n- Is it a bug I can reproduce and fix? → Start SE workflow\n\nPrioritize by labels (bug > enhancement), staleness (older first), and whether blockers can be cleared.\n\n**If no workable issues:** advance to next step.\n\n---\n\n**Step reporting requirement:** After completing this step (whether work was performed or the step was skipped via gate check), post a concise summary of the step''s outcome to Discord <#1504054635231445112> (#proactive-mode). Include: step number/name, action taken or reason skipped, and any notable findings. Keep it brief — one short paragraph or a few bullets.'
+WHERE workflow_id = 27 AND step_order = 7;
+
+-- ---------------------------------------------------------------------------
+-- 4. New step 8 — Blocker Outreach.
+--
+--    Driven by proactive-gate-check.py's check_step8_blocker_outreach()
+--    (migration 082 / CHUNK 2), which curates the eligible top-3-per-entity
+--    blocker set, cascade level, and target channel as a data payload for
+--    this step to act on.
+-- ---------------------------------------------------------------------------
+INSERT INTO workflow_steps (
+    workflow_id, step_order, description, domain,
+    required, requires_authorization, requires_discussion
+)
+VALUES (
+    27, 8,
+    E'## Blocker Outreach\n\nThe gate check (`proactive-gate-check.py`) curates eligible blockers into this step''s data payload: up to 3 blockers per responsible entity, ordered by priority ASC, first_seen ASC, id ASC, filtered by cooldown eligibility (see below). Work from that payload — do not re-query `blockers` independently unless the payload is empty and you need to double-check.\n\n**Before selecting outreach targets — reconcile satisfied blockers:**\n- For any blocker in the registry whose underlying condition has cleared (task completed, issue closed, question answered, etc.), mark it `status = ''satisfied''`, `satisfied_at = NOW()`.\n- If a previously-satisfied blocker''s condition recurs (reopened issue, task re-blocked), **reopen it**: set `status = ''open''` and clear `satisfied_at` back to `NULL` — do not create a duplicate row (the `(source_type, source_ref)` unique constraint on `blockers` prevents this anyway; rely on the `ON CONFLICT ... DO UPDATE` upsert from steps 6/7).\n\n**Eligibility (enforced by the gate check, informational here):**\n- Entity master cooldown: an entity is eligible for a new message only if more than 24h have elapsed since ANY prior `proactive_outreach` row for that entity (strict >; exactly 24h still blocks).\n- Per-blocker cooldown: a specific blocker is eligible only if more than 72h have elapsed since the last `proactive_outreach` row for `(entity_id, blocker_type=''blocker'', blocker_id)` (strict >).\n- Top 3 blockers per eligible entity are selected, ordered by `priority ASC, first_seen ASC, id ASC`.\n\n**Sending outreach — one message per entity:**\n- Send **exactly ONE message per entity** this step, even when multiple blockers were selected for them.\n- The message channel is the **most-escalated requested level** among that entity''s selected blockers. Cascade level for a blocker = the count of prior `proactive_outreach` rows for `(entity_id, ''blocker'', blocker_id)` + 1. Levels map onto that entity''s available contact channels (per `entity_facts`: `discord_id` → discord mention, then discord DM, then `signal`, then `slack`, then `email`, skipping any missing channel) — or `agent_chat` unconditionally for entities that are agents (row exists in `agents` with matching `entity_id`).\n- The message should summarize all selected blockers for that entity, not just the most-escalated one.\n\n**Logging — one row per blocker, not per message:**\n- Log **one `proactive_outreach` row per blocker** included in the message (even though only one message was sent), recording the **actual channel used** to deliver that message — not the requested/theoretical channel for that specific blocker''s own cascade level.\n- Cascade position for the NEXT attempt is derived purely from the count of prior `proactive_outreach` rows for that blocker, regardless of which channel actually delivered any given attempt. Do not track cascade position by channel.\n\n**Channel exhaustion — reassignment, not skip:**\n- If an entity has exhausted all of their available contact channels (cascade level exceeds the number of channels the mapping helper found for them) and they are not I)ruid, **reassign the blocker to the next domain entity** (re-resolve via `agent_domains`/`user_domains` excluding the exhausted entity) rather than continuing to message someone with no reachable channel left.\n- If reassignment eventually exhausts every domain entity, escalate to **I)ruid (entity_id=2) as the final fallback**.\n- If I)ruid himself is exhausted (all of his channels already used at his highest cascade level), **hold the blocker at his last available channel/level** and continue trying him on the normal 72h cadence — do not loop reassignment past him and do not drop the blocker.\n\n**If no entities are eligible this cycle:** advance to next step; no outreach is sent.\n\n---\n\n**Step reporting requirement:** After completing this step (whether work was performed or the step was skipped via gate check), post a concise summary of the step''s outcome to Discord <#1504054635231445112> (#proactive-mode). Include: step number/name, action taken or reason skipped, and any notable findings. Keep it brief — one short paragraph or a few bullets.',
+    'NOVA Operations',
+    true, false, false
+);

--- a/memory/migrations/083_blocker_outreach_workflow_27.sql
+++ b/memory/migrations/083_blocker_outreach_workflow_27.sql
@@ -20,18 +20,45 @@
 -- description edits are needed for the pure renumbering of steps 8/9/10.
 
 -- ---------------------------------------------------------------------------
--- 1. Renumber steps 8, 9, 10 -> 9, 10, 11 using a temporary offset to avoid
---    violating the workflow_steps_workflow_id_step_order_key UNIQUE
---    constraint (workflow_id, step_order) while the new step 8 is inserted
---    below.
+-- Idempotency guard: this migration rewrites workflow 27 in place. A second
+-- run must be a clean no-op. We detect the already-applied state by looking
+-- for the final 11-step layout with the new "Blocker Outreach" step at
+-- step_order 8. When that layout is present we skip the renumbering and
+-- description edits entirely.
 -- ---------------------------------------------------------------------------
-UPDATE workflow_steps
-SET step_order = step_order + 1000
-WHERE workflow_id = 27 AND step_order IN (8, 9, 10);
+DO $$
+DECLARE
+    v_already_applied BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM workflow_steps
+        WHERE workflow_id = 27
+          AND step_order = 8
+          AND description LIKE '## Blocker Outreach%'
+    )
+    AND EXISTS (
+        SELECT 1 FROM workflow_steps
+        WHERE workflow_id = 27 AND step_order = 11
+    )
+    INTO v_already_applied;
 
-UPDATE workflow_steps
-SET step_order = step_order - 1000 + 1
-WHERE workflow_id = 27 AND step_order IN (1008, 1009, 1010);
+    IF v_already_applied THEN
+        RETURN;
+    END IF;
+
+    -- -----------------------------------------------------------------------
+    -- 1. Renumber steps 8, 9, 10 -> 9, 10, 11 using a temporary offset to
+    --    avoid violating the workflow_steps_workflow_id_step_order_key UNIQUE
+    --    constraint (workflow_id, step_order) while the new step 8 is
+    --    inserted below.
+    -- -----------------------------------------------------------------------
+    UPDATE workflow_steps
+    SET step_order = step_order + 1000
+    WHERE workflow_id = 27 AND step_order IN (8, 9, 10);
+
+    UPDATE workflow_steps
+    SET step_order = step_order - 1000 + 1
+    WHERE workflow_id = 27 AND step_order IN (1008, 1009, 1010);
 
 -- ---------------------------------------------------------------------------
 -- 2. Step 6 (Work on Pending Tasks) — curation semantics, no immediate
@@ -67,4 +94,7 @@ VALUES (
     E'## Blocker Outreach\n\nThe gate check (`proactive-gate-check.py`) curates eligible blockers into this step''s data payload: up to 3 blockers per responsible entity, ordered by priority ASC, first_seen ASC, id ASC, filtered by cooldown eligibility (see below). Work from that payload — do not re-query `blockers` independently unless the payload is empty and you need to double-check.\n\n**Before selecting outreach targets — reconcile satisfied blockers:**\n- For any blocker in the registry whose underlying condition has cleared (task completed, issue closed, question answered, etc.), mark it `status = ''satisfied''`, `satisfied_at = NOW()`.\n- If a previously-satisfied blocker''s condition recurs (reopened issue, task re-blocked), **reopen it**: set `status = ''open''` and clear `satisfied_at` back to `NULL` — do not create a duplicate row (the `(source_type, source_ref)` unique constraint on `blockers` prevents this anyway; rely on the `ON CONFLICT ... DO UPDATE` upsert from steps 6/7).\n\n**Eligibility (enforced by the gate check, informational here):**\n- Entity master cooldown: an entity is eligible for a new message only if more than 24h have elapsed since ANY prior `proactive_outreach` row for that entity (strict >; exactly 24h still blocks).\n- Per-blocker cooldown: a specific blocker is eligible only if more than 72h have elapsed since the last `proactive_outreach` row for `(entity_id, blocker_type=''blocker'', blocker_id)` (strict >).\n- Top 3 blockers per eligible entity are selected, ordered by `priority ASC, first_seen ASC, id ASC`.\n\n**Sending outreach — one message per entity:**\n- Send **exactly ONE message per entity** this step, even when multiple blockers were selected for them.\n- The message channel is the **most-escalated requested level** among that entity''s selected blockers. Cascade level for a blocker = the count of prior `proactive_outreach` rows for `(entity_id, ''blocker'', blocker_id)` + 1. Levels map onto that entity''s available contact channels (per `entity_facts`: `discord_id` → discord mention, then discord DM, then `signal`, then `slack`, then `email`, skipping any missing channel) — or `agent_chat` unconditionally for entities that are agents (row exists in `agents` with matching `entity_id`).\n- The message should summarize all selected blockers for that entity, not just the most-escalated one.\n\n**Logging — one row per blocker, not per message:**\n- Log **one `proactive_outreach` row per blocker** included in the message (even though only one message was sent), recording the **actual channel used** to deliver that message — not the requested/theoretical channel for that specific blocker''s own cascade level.\n- Cascade position for the NEXT attempt is derived purely from the count of prior `proactive_outreach` rows for that blocker, regardless of which channel actually delivered any given attempt. Do not track cascade position by channel.\n\n**Channel exhaustion — reassignment, not skip:**\n- If an entity has exhausted all of their available contact channels (cascade level exceeds the number of channels the mapping helper found for them) and they are not I)ruid, **reassign the blocker to the next domain entity** (re-resolve via `agent_domains`/`user_domains` excluding the exhausted entity) rather than continuing to message someone with no reachable channel left.\n- If reassignment eventually exhausts every domain entity, escalate to **I)ruid (entity_id=2) as the final fallback**.\n- If I)ruid himself is exhausted (all of his channels already used at his highest cascade level), **hold the blocker at his last available channel/level** and continue trying him on the normal 72h cadence — do not loop reassignment past him and do not drop the blocker.\n\n**If no entities are eligible this cycle:** advance to next step; no outreach is sent.\n\n---\n\n**Step reporting requirement:** After completing this step (whether work was performed or the step was skipped via gate check), post a concise summary of the step''s outcome to Discord <#1504054635231445112> (#proactive-mode). Include: step number/name, action taken or reason skipped, and any notable findings. Keep it brief — one short paragraph or a few bullets.',
     'NOVA Operations',
     true, false, false
-);
+)
+ON CONFLICT (workflow_id, step_order) DO NOTHING;
+
+END $$;

--- a/memory/tests/test_migration_083_idempotency.py
+++ b/memory/tests/test_migration_083_idempotency.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+test_migration_083_idempotency.py — Verify migration 083 is idempotent.
+
+Migration 083 rewrites workflow 27 (Proactive Mode) in place: it renumbers
+steps 8/9/10 to 9/10/11, updates steps 6 and 7 with blocker-curation
+semantics, and inserts the new "Blocker Outreach" step at step_order 8.
+
+This test creates a fresh PostgreSQL database with only the tables required
+for the migration, seeds workflow 27 with the pre-migration 10-step layout,
+applies migration 083 twice, and asserts that the second run is a safe no-op
+leaving exactly the expected 11-step layout with no duplicate rows.
+"""
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+# test_proactive_gate_check.py replaces sys.modules['psycopg2'] with a MagicMock,
+# which pollutes the import namespace for every later test in the same process.
+# Force a fresh import of the real psycopg2 driver before anything else can mock it.
+for _psycopg2_mod in ("psycopg2", "psycopg2.extras", "psycopg2.extensions"):
+    sys.modules.pop(_psycopg2_mod, None)
+import psycopg2  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MIGRATION_PATH = REPO_ROOT / "memory" / "migrations" / "083_blocker_outreach_workflow_27.sql"
+
+if not hasattr(psycopg2, "connect") or psycopg2.connect is None:
+    pytest.skip("psycopg2 driver not available", allow_module_level=True)
+
+
+def _admin_conn():
+    """Connect to the postgres maintenance database as the nova user."""
+    # Unset any inherited PGPASSWORD so libpq falls back to .pgpass.
+    env = os.environ.copy()
+    env.pop("PGPASSWORD", None)
+    os.environ.pop("PGPASSWORD", None)
+    return psycopg2.connect(host="localhost", user="nova", dbname="postgres")
+
+
+def _test_conn(db_name):
+    """Connect to the freshly-created test database as the nova user."""
+    os.environ.pop("PGPASSWORD", None)
+    return psycopg2.connect(host="localhost", user="nova", dbname=db_name)
+
+
+def _create_test_db():
+    """Create and return the name of a uniquely-named test database."""
+    db_name = f"nova_memory_test_083_{uuid.uuid4().hex[:8]}"
+    conn = _admin_conn()
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("DROP DATABASE IF EXISTS %s", (psycopg2.extensions.AsIs(db_name),))
+        cur.execute("CREATE DATABASE %s", (psycopg2.extensions.AsIs(db_name),))
+    conn.close()
+    return db_name
+
+
+def _drop_test_db(db_name):
+    """Drop the test database, ignoring errors."""
+    try:
+        conn = _admin_conn()
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(
+                "DROP DATABASE IF EXISTS %s",
+                (psycopg2.extensions.AsIs(db_name),),
+            )
+        conn.close()
+    except Exception:
+        pass
+
+
+def _seed_workflow_27(conn):
+    """Create the minimal schema and seed workflow 27 with 10 steps."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE workflows (
+                id SERIAL PRIMARY KEY,
+                name text NOT NULL,
+                description text NOT NULL DEFAULT '',
+                created_at timestamptz DEFAULT now(),
+                updated_at timestamptz DEFAULT now(),
+                created_by text DEFAULT CURRENT_USER,
+                status text DEFAULT 'active',
+                tags text[] DEFAULT '{}',
+                department text,
+                orchestrator_domain text
+            );
+            CREATE TABLE workflow_steps (
+                id SERIAL PRIMARY KEY,
+                workflow_id integer NOT NULL REFERENCES workflows(id) ON DELETE CASCADE,
+                step_order integer NOT NULL,
+                description text NOT NULL,
+                produces_deliverable boolean DEFAULT false,
+                deliverable_type text,
+                deliverable_description text,
+                handoff_to_step integer REFERENCES workflow_steps(id),
+                required boolean DEFAULT true,
+                estimated_duration_minutes integer,
+                requires_authorization boolean DEFAULT false,
+                requires_discussion boolean DEFAULT false,
+                domain text,
+                domains text[],
+                CONSTRAINT workflow_steps_workflow_id_step_order_key
+                    UNIQUE (workflow_id, step_order)
+            );
+            INSERT INTO workflows (id, name, description)
+            VALUES (27, 'Proactive Mode', 'Test workflow for migration 083');
+            INSERT INTO workflow_steps (workflow_id, step_order, description)
+            SELECT 27, i, 'Step ' || i FROM generate_series(1, 10) AS i;
+            """
+        )
+    conn.commit()
+
+
+def _apply_migration(conn):
+    """Execute migration 083 against the open connection."""
+    migration_sql = MIGRATION_PATH.read_text()
+    with conn.cursor() as cur:
+        cur.execute(migration_sql)
+    conn.commit()
+
+
+def _fetch_workflow_27(conn):
+    """Return workflow 27 rows as (step_order, description) tuples."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT step_order, description
+            FROM workflow_steps
+            WHERE workflow_id = 27
+            ORDER BY step_order
+            """
+        )
+        return cur.fetchall()
+
+
+@pytest.fixture
+def test_db():
+    """Yield a freshly-created test DB name and clean it up afterward."""
+    db_name = _create_test_db()
+    try:
+        yield db_name
+    finally:
+        _drop_test_db(db_name)
+
+
+def test_migration_083_idempotent(test_db):
+    """Applying migration 083 twice must be a no-op and leave a clean layout."""
+    conn = _test_conn(test_db)
+    try:
+        _seed_workflow_27(conn)
+
+        # First application: should produce the 11-step layout.
+        _apply_migration(conn)
+        first = _fetch_workflow_27(conn)
+        assert len(first) == 11, f"Expected 11 steps after first run, got {len(first)}"
+        assert [r[0] for r in first] == list(range(1, 12))
+        assert first[7][1].startswith("## Blocker Outreach")
+
+        # Second application: must succeed and leave the layout unchanged.
+        _apply_migration(conn)
+        second = _fetch_workflow_27(conn)
+        assert len(second) == 11, f"Expected 11 steps after second run, got {len(second)}"
+        assert [r[0] for r in second] == list(range(1, 12))
+        assert second[7][1].startswith("## Blocker Outreach")
+        assert first == second, "Second run changed the workflow layout"
+
+        # No duplicate "Blocker Outreach" rows may exist.
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COUNT(*)
+                FROM workflow_steps
+                WHERE workflow_id = 27 AND description LIKE '## Blocker Outreach%'
+                """
+            )
+            blocker_count = cur.fetchone()[0]
+        assert blocker_count == 1, f"Expected 1 Blocker Outreach row, got {blocker_count}"
+    finally:
+        conn.close()

--- a/motivation/ARCHITECTURE.md
+++ b/motivation/ARCHITECTURE.md
@@ -279,6 +279,14 @@ reassignment exhausts every domain entity, escalation falls through to **I)ruid
 his last available channel/level and continues on the normal 72h cadence — it is never
 dropped or looped past him.
 
+This is enforced deterministically in `check_step8_blocker_outreach()`, not left as
+agent-turn inference: `_is_cascade_exhausted()` detects the condition,
+`_entity_domain_topics()` + `_next_domain_entity()` resolve the next candidate, and
+`_reassign_exhausted_entity()` drives the chain (next domain entity → I)ruid final
+fallback → hold-in-place if I)ruid himself is exhausted). Each entry in the returned
+`eligible_entities` payload carries `exhausted` (true only for the I)ruid hold-in-place
+case) and, when reassignment occurred, `reassigned_from_entity_id`.
+
 ### Satisfied Blocker Reconciliation
 
 Before selecting outreach targets each cycle, Step 8 marks any blocker whose underlying

--- a/motivation/ARCHITECTURE.md
+++ b/motivation/ARCHITECTURE.md
@@ -29,14 +29,14 @@ Source of truth for the file content: `~/nova-mind/HEARTBEAT.md`.
 **Type:** Python script
 **Path:** `motivation/scripts/proactive-gate-check.py`
 **Installed path:** `~/.openclaw/workspace/scripts/proactive-gate-check.py`
-**Role:** Deterministic gate checker. Evaluates all 10 cascade step conditions without LLM
+**Role:** Deterministic gate checker. Evaluates all 11 cascade step conditions without LLM
 involvement and emits a structured JSON manifest. See [Proactive Gate Check](#proactive-gate-check)
 below for full details.
 
 ### 4. Proactive Mode Workflow (id=27)
 
 **Type:** Database workflow (`workflows` / `workflow_steps` tables)
-**Role:** 9-step priority cascade defining what NOVA does when idle. The gate check script
+**Role:** 11-step priority cascade defining what NOVA does when idle. The gate check script
 maps each step to its gate function; the script's `actionable_steps` output tells NOVA
 which workflow steps have work to do.
 
@@ -47,15 +47,30 @@ WHERE workflow_id = 27`.
 
 **Type:** Database table (`motivation_d100`)
 **Role:** 100-slot random task roller providing variety in autonomous work. Used by
-cascade Step 10, which is the mandatory catch-all when no other steps are actionable.
-Managed via `roll_d100()` and `complete_d100(roll)` SECURITY DEFINER functions.
+cascade Step 11, which is the mandatory catch-all when no other steps are actionable —
+and additionally **forced** actionable whenever more than 12h have elapsed since the last
+recorded roll, regardless of other steps' state (issue #358). Managed via `roll_d100()` and
+`complete_d100(roll)` SECURITY DEFINER functions. Roll history (used for the forced-D100
+check) is tracked in `d100_roll_log`, populated by a trigger on `motivation_d100` (migration
+082).
 
 ### 6. Unsolved Problems Research Workflow (id=32)
 
 **Type:** Database workflow
 **Role:** Structured research workflow delegating data gathering to Scout and reserving
-reasoning/synthesis for NOVA. Triggered by cascade Step 8 when `unsolved_problems` with
+reasoning/synthesis for NOVA. Triggered by cascade Step 9 when `unsolved_problems` with
 `status != 'solved'` exist.
+
+### 7. Blocker Registry & Outreach (Step 8)
+
+**Type:** Database table (`blockers`) + cascade Step 8 (workflow_id=27)
+**Role:** Curated registry of items blocked on another entity's action (issue #356).
+Steps 6 (Pending Tasks) and 7 (GitHub Issues) upsert blocked items into `blockers`
+(`ON CONFLICT (source_type, source_ref) DO UPDATE ... last_seen`) but perform **no**
+outreach themselves — outreach is centralized in the dedicated Step 8, which is driven by
+`check_step8_blocker_outreach()` in the gate check script. See
+[Blocker Outreach](#blocker-outreach-step-8) below for cooldown, cascade, and channel
+escalation details.
 
 ---
 
@@ -72,7 +87,7 @@ databases, and reason about whether each cascade step had actionable work. This 
 inconsistent gate decisions and unnecessary token consumption on sessions that would always
 result in `HEARTBEAT_OK`.
 
-The script replaces that with a deterministic, pre-LLM evaluation pass: it checks all 10
+The script replaces that with a deterministic, pre-LLM evaluation pass: it checks all 11
 gate conditions programmatically, then emits a compact JSON manifest so NOVA's heartbeat
 session can skip straight to work.
 
@@ -106,7 +121,8 @@ owns that role entirely — the LLM only sees the output, never the gate logic.
 | `~/.openclaw/state/memory-maintenance-last-run.json` | Memory maintenance cooldown state |
 | `~/.openclaw/workspace/.last-fs-audit` | Filesystem audit staleness marker |
 | `gh` CLI | Open GitHub issues across NOVA-Openclaw repos |
-| `openclaw` CLI | Recent active user-facing sessions (for Step 2) |
+| PostgreSQL `blockers` / `proactive_outreach` / `entity_facts` / `agents` | Blocker outreach eligibility, cascade level, and channel resolution (Step 8) |
+| PostgreSQL `d100_roll_log` | Forced D100 staleness check (Step 11, issue #358) |
 
 ### Output
 
@@ -137,13 +153,14 @@ When idle, the full manifest is emitted:
     "5_entities":      { "actionable": false, "reason": "No entity dedup candidates" },
     "6_tasks":         { "actionable": true,  "reason": "3 pending unblocked task(s)" },
     "7_github":        { "actionable": false, "reason": "0 open GitHub issues" },
-    "8_research":      { "actionable": false, "reason": "0 unsolved problems" },
-    "9_filesystem":    { "actionable": false, "reason": "Audited 2.1d ago (threshold 7d)" },
-    "10_d100":         { "actionable": false, "reason": "Optional — 2 prior step(s) already actionable" }
+    "8_blocker_outreach": { "actionable": false, "reason": "No blockers eligible for outreach" },
+    "9_research":      { "actionable": false, "reason": "0 unsolved problems" },
+    "10_filesystem":   { "actionable": false, "reason": "Audited 2.1d ago (threshold 7d)" },
+    "11_d100":         { "actionable": false, "reason": "Optional — 2 prior step(s) already actionable" }
   },
   "actionable_steps": [3, 6],
   "actionable_count": 2,
-  "summary": "2 of 10 steps actionable"
+  "summary": "2 of 11 steps actionable"
 }
 ```
 
@@ -153,9 +170,22 @@ and never abort the run — the script always exits 0.
 
 ### Key Design Decisions
 
-**D100 is a mandatory catch-all (Step 10).** When steps 1–9 produce zero actionable work,
-Step 10 is always marked actionable. This guarantees the cascade never produces a no-op
-idle session — NOVA always has something to do.
+**D100 is a mandatory catch-all, and forced past 12h (Step 11).** When steps 1–10 produce
+zero actionable work, Step 11 is always marked actionable. Independently of that,
+Step 11 is **forced** actionable whenever more than 12h have elapsed since the last
+recorded roll in `d100_roll_log` (or no roll is on record at all) — even if other steps
+had actionable work, per issue #358. This guarantees both that the cascade never produces
+a no-op idle session, and that D100 itself doesn't go stale for extended periods.
+
+**Blocker outreach is centralized and cooldown-gated (Step 8).** Steps 6 and 7 only curate
+blocked items into the `blockers` registry — they never contact anyone directly. Step 8
+owns all outreach: it enforces a 24h entity-level cooldown (no more than one message to a
+given entity per 24h, across all of their blockers) and a 72h per-blocker cooldown (a given
+blocker cannot be re-raised with the same entity more often than every 72h), selects the
+top 3 eligible blockers per entity, and sends one consolidated message per entity at the
+most-escalated channel among its selected blockers. See
+[Blocker Outreach](#blocker-outreach-step-8) for the full cascade/channel/reassignment
+rules.
 
 **Exit code is always 0.** Per-step errors (DB unavailable, CLI timeout, missing file) are
 embedded in the JSON output rather than surfaced as failures. This prevents a partial outage
@@ -187,3 +217,73 @@ OpenClaw heartbeat (every 30m)
 Compare to the pre-#324 flow, where NOVA evaluated each cascade step gate inline during
 its reasoning pass — running sessions queries, DB queries, and GitHub checks as part of the
 LLM turn rather than before it.
+
+---
+
+## Blocker Outreach (Step 8)
+
+**Issues:** [nova-mind#356](https://github.com/NOVA-Openclaw/nova-mind/issues/356),
+[nova-mind#358](https://github.com/NOVA-Openclaw/nova-mind/issues/358)
+
+### Curation vs. Outreach
+
+Before this feature, Steps 6 (Pending Tasks) and 7 (GitHub Issues) each contained inline
+outreach cascade logic — contacting a domain owner directly the moment a blocker was found,
+with an ad hoc 3-day cooldown. That logic is now split into two distinct concerns:
+
+- **Curation (Steps 6 and 7):** when a task or issue is blocked, upsert a row into the
+  `blockers` table (`ON CONFLICT (source_type, source_ref) DO UPDATE SET last_seen = NOW(), ...`).
+  The responsible entity is resolved via `agent_domains` first, then `user_domains`
+  (lower priority number wins, tiebreak random among ties), falling back to entity_id=2
+  (I)ruid) if no domain match exists. **No outreach happens in these steps.**
+- **Outreach (Step 8):** a dedicated step that reads the curated `blockers` registry (via
+  `check_step8_blocker_outreach()` in the gate check script) and owns all cooldown
+  enforcement, cascade escalation, and message dispatch.
+
+### Eligibility Rules
+
+| Rule | Threshold | Boundary behavior |
+|------|-----------|--------------------|
+| Entity master cooldown | 24h since ANY `proactive_outreach` row for the entity | Strict `>`; exactly 24h elapsed still blocks |
+| Per-blocker cooldown | 72h since a `proactive_outreach` row for `(entity_id, 'blocker', blocker_id)` | Strict `>`; exactly 72h elapsed still blocks |
+| Selection | Top 3 blockers per eligible entity | `ORDER BY priority ASC, first_seen ASC, id ASC` |
+
+### Cascade Level & Channel Mapping
+
+Cascade level for a given blocker = count of prior `proactive_outreach` rows for
+`(entity_id, 'blocker', blocker_id)` + 1. Levels map onto that entity's available contact
+channels, in escalation order: `discord_mention → discord_dm → signal → slack → email`,
+skipping any channel missing from `entity_facts`. Entities that are agents (a row exists in
+`agents` with a matching `entity_id`) always use `agent_chat` instead, regardless of level.
+
+### One Message, Multiple Logged Attempts
+
+An entity may have up to 3 selected blockers in a single cycle, but receives **exactly one
+message**, sent at the most-escalated requested channel among those blockers. Despite only
+one message being sent, **one `proactive_outreach` row is logged per blocker**, each
+recording the actual channel used to deliver that consolidated message — not the
+theoretical channel implied by that individual blocker's own cascade level.
+
+**Cascade position is derived from attempt-row count, not delivered channel** (TC-D09).
+Because every attempt is logged with the actual delivery channel rather than the
+requested one, a blocker's next cascade level is always `COUNT(proactive_outreach rows for
+this blocker) + 1` — independent of which channel any given attempt actually used.
+
+### Channel Exhaustion & Reassignment
+
+If an entity's cascade level exceeds the number of channels available to them (channel
+exhaustion) and they are not I)ruid, the blocker is reassigned to the next domain entity
+(re-resolved via `agent_domains`/`user_domains`, excluding the exhausted entity). If
+reassignment exhausts every domain entity, escalation falls through to **I)ruid
+(entity_id=2) as the final fallback**. If I)ruid himself is exhausted, the blocker holds at
+his last available channel/level and continues on the normal 72h cadence — it is never
+dropped or looped past him.
+
+### Satisfied Blocker Reconciliation
+
+Before selecting outreach targets each cycle, Step 8 marks any blocker whose underlying
+condition has cleared as `status = 'satisfied'`, `satisfied_at = NOW()`. If a
+previously-satisfied blocker's condition recurs, it is **reopened**: `status` reverts to
+`'open'` and `satisfied_at` is cleared back to `NULL` — the existing row is reused (the
+`(source_type, source_ref)` unique constraint prevents duplicates) rather than a new one
+being created.

--- a/motivation/scripts/README.md
+++ b/motivation/scripts/README.md
@@ -6,7 +6,7 @@ Scripts supporting NOVA's proactive motivation system.
 
 ## proactive-gate-check.py
 
-Deterministic gate checker for NOVA's proactive cascade. Checks all 10 cascade step
+Deterministic gate checker for NOVA's proactive cascade. Checks all 11 cascade step
 conditions without LLM involvement and emits a structured JSON manifest indicating which
 steps have actionable work. The heartbeat session runs this script first and works only the
 steps listed in `actionable_steps`, eliminating the need for inline LLM gate evaluation and
@@ -60,19 +60,30 @@ step numbers:
     "5_entities":    { "actionable": false, "reason": "No entity dedup candidates" },
     "6_tasks":       { "actionable": true,  "reason": "3 pending unblocked task(s)" },
     "7_github":      { "actionable": false, "reason": "0 open GitHub issues" },
-    "8_research":    { "actionable": false, "reason": "0 unsolved problems" },
-    "9_filesystem":  { "actionable": false, "reason": "Audited 2.1d ago (threshold 7d)" },
-    "10_d100":       { "actionable": false, "reason": "Optional — 2 prior step(s) already actionable" }
+    "8_blocker_outreach": { "actionable": false, "reason": "No blockers eligible for outreach" },
+    "9_research":    { "actionable": false, "reason": "0 unsolved problems" },
+    "10_filesystem": { "actionable": false, "reason": "Audited 2.1d ago (threshold 7d)" },
+    "11_d100":       { "actionable": false, "reason": "Optional — 2 prior step(s) already actionable" }
   },
   "actionable_steps": [3, 6],
   "actionable_count": 2,
-  "summary": "2 of 10 steps actionable"
+  "summary": "2 of 11 steps actionable"
 }
 ```
 
 Step numbers in `actionable_steps` correspond to `step_order` values in the `workflow_steps`
-table for the NOVA Proactive Mode workflow (id=27). Step 10 (D100 random task) is marked
-mandatory when no steps 1–9 are actionable, ensuring the cascade always produces output.
+table for the NOVA Proactive Mode workflow (id=27). Step 11 (D100 random task) is marked
+mandatory when no steps 1–10 are actionable, ensuring the cascade always produces output.
+Step 11 is also **forced** actionable whenever more than 12h have elapsed since the last
+recorded roll in `d100_roll_log` (or no roll is on record), regardless of other steps'
+actionable state (issue #358).
+
+Step 8 (Blocker Outreach) curates a per-entity, per-blocker eligible set from the `blockers`
+registry — entity master cooldown 24h, per-blocker cooldown 72h (both strict `>`), top 3
+blockers per entity by `priority ASC, first_seen ASC, id ASC`. Its `data` payload includes
+each eligible entity's selected blockers, computed cascade level per blocker, and the
+resolved delivery channel (see `motivation/ARCHITECTURE.md#blocker-outreach-step-8` for the
+full cascade/channel/reassignment rules, issue #356).
 
 Each step entry may include a `data` field with additional context (counts, timestamps,
 lists). Error conditions appear as `{ "actionable": false, "error": "..." }`.
@@ -83,7 +94,7 @@ lists). Error conditions appear as `{ "actionable": false, "error": "..." }`.
 |------------|----------------|
 | `psycopg2` | PostgreSQL queries (agent_chat, tasks, entities, unsolved_problems). Loaded from the nova venv at `~/.local/share/nova/venv/` — no manual activation required. |
 | `gh` CLI | Lists open GitHub issues across NOVA-Openclaw repos (Step 7) and enumerates repos. |
-| `openclaw` CLI | Lists recent active sessions (Step 2). |
+| `~/.openclaw/agents/nova/sessions/sessions.json` + per-session JSONL files | Detects unanswered user messages directly from session state (Step 2). |
 
 All other dependencies are Python standard library (`json`, `os`, `subprocess`, `sys`,
 `time`, `datetime`).

--- a/motivation/scripts/proactive-gate-check.py
+++ b/motivation/scripts/proactive-gate-check.py
@@ -2,7 +2,7 @@
 """
 proactive-gate-check.py — Deterministic gate checker for NOVA's proactive cascade.
 
-Checks all 10 cascade step gates without LLM involvement. Outputs a structured
+Checks all 11 cascade step gates without LLM involvement. Outputs a structured
 JSON manifest so the heartbeat agent can work only on actionable steps.
 
 Exit code is always 0. Per-step errors are embedded in JSON output.
@@ -15,7 +15,7 @@ import os
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 # ---------------------------------------------------------------------------
@@ -82,6 +82,14 @@ MEMORY_MAINTENANCE_COOLDOWN_H = 4
 
 # Filesystem audit staleness threshold
 FS_AUDIT_STALENESS_DAYS = 7
+
+# Blocker outreach cooldowns (issue #356)
+BLOCKER_ENTITY_COOLDOWN_H = 24
+BLOCKER_PER_BLOCKER_COOLDOWN_H = 72
+BLOCKERS_PER_MESSAGE = 3
+
+# D100 forced-roll threshold (issue #358)
+D100_FORCED_COOLDOWN_H = 12
 
 DB_DSN = "host=/var/run/postgresql dbname=nova_memory user=nova"
 
@@ -251,52 +259,76 @@ def check_step1_agent_chat() -> dict:
         return _step_error(f"DB error: {exc}")
 
 
+def _last_conversational_role(session_file: str) -> str | None:
+    """Return the role ('user' or 'assistant') of the last conversational message in a session JSONL file.
+
+    Skips toolResult, system, and other non-conversational entries.
+    Returns None if no conversational message is found.
+    """
+    if not os.path.exists(session_file):
+        return None
+    try:
+        with open(session_file, "r") as fh:
+            lines = fh.readlines()
+    except OSError:
+        return None
+    # Walk backwards to find last user or assistant message
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        role = entry.get("message", {}).get("role")
+        if role in ("user", "assistant"):
+            return role
+    return None
+
+
 def check_step2_unanswered_sessions() -> dict:
     """
-    Step 2: Recent user-facing sessions.
-    Runs `openclaw sessions list --json` and counts sessions with ageMs < 24h.
+    Step 2: Check for unanswered user messages in recent user-facing sessions.
+    Reads sessions.json and checks each session's JSONL file to see if the last
+    conversational message is from a user (i.e. unanswered).
     """
     ONE_DAY_MS = 86_400_000
     try:
-        result = subprocess.run(
-            ["openclaw", "sessions", "list", "--json"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-        if result.returncode != 0:
-            return _step_error(
-                f"openclaw sessions list failed (rc={result.returncode}): {result.stderr[:200]}"
-            )
-        payload = json.loads(result.stdout)
-    except FileNotFoundError:
-        return _step_error("openclaw CLI not found")
-    except subprocess.TimeoutExpired:
-        return _step_error("openclaw sessions list timed out")
-    except (json.JSONDecodeError, ValueError) as exc:
-        return _step_error(f"Failed to parse openclaw sessions list output: {exc}")
+        with open(SESSIONS_JSON, "r") as fh:
+            sessions_data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        return _step_error(f"Failed to read sessions.json: {exc}")
 
-    sessions = payload.get("sessions", [])
-    active: list[str] = []
-    for sess in sessions:
-        key = sess.get("key", "")
-        age_ms = sess.get("ageMs", ONE_DAY_MS + 1)
+    now_ms = int(time.time() * 1000)
+    unanswered: list[str] = []
+
+    for key, sess in sessions_data.items():
+        updated = sess.get("updatedAt", 0)
+        age_ms = now_ms - updated
         if age_ms >= ONE_DAY_MS:
             continue
         if not any(pat in key for pat in USER_SESSION_PATTERNS):
             continue
         if any(exc_pat in key for exc_pat in EXCLUDE_PATTERNS):
             continue
-        active.append(key)
 
-    count = len(active)
+        session_file = sess.get("sessionFile", "")
+        if not session_file:
+            continue
+
+        last_role = _last_conversational_role(session_file)
+        if last_role == "user":
+            unanswered.append(key)
+
+    count = len(unanswered)
     if count > 0:
         return {
             "actionable": True,
-            "reason": f"{count} recent active user-facing session(s)",
-            "data": {"count": count, "sessions": active},
+            "reason": f"{count} session(s) with unanswered user messages",
+            "data": {"count": count, "sessions": unanswered},
         }
-    return {"actionable": False, "reason": "No recent active user-facing sessions"}
+    return {"actionable": False, "reason": "No unanswered user messages in recent sessions"}
 
 
 def check_step3_introspection() -> dict:
@@ -601,8 +633,230 @@ def check_step7_github_issues() -> dict:
     return {"actionable": False, "reason": msg, "data": result_dict}
 
 
-def check_step8_unsolved_problems() -> dict:
-    """Step 8: Unsolved problems with status != 'solved'."""
+def _entity_channel_facts(entity_id: int) -> dict[str, str]:
+    """Return available human contact channels for an entity from entity_facts.
+
+    Keys: discord_id, discord_dm (same fact as discord_id), signal, slack, email.
+    Values are the fact values. Agents use agent_chat instead.
+    """
+    channels: dict[str, str] = {}
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT key, value FROM entity_facts
+                        WHERE entity_id = %s
+                          AND key IN ('discord_id', 'signal', 'slack', 'email')
+                        """,
+                        (entity_id,),
+                    )
+                    for key, value in cur.fetchall():
+                        if key == "discord_id":
+                            channels["discord_channel"] = value
+                            channels["discord_dm"] = value
+                        else:
+                            channels[key] = value
+        finally:
+            conn.close()
+    except Exception:
+        pass
+    return channels
+
+
+def _entity_is_agent(entity_id: int) -> bool:
+    """Return True if this entity maps to a row in the agents table."""
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT 1 FROM agents WHERE entity_id = %s LIMIT 1",
+                        (entity_id,),
+                    )
+                    return cur.fetchone() is not None
+        finally:
+            conn.close()
+    except Exception:
+        return False
+
+
+def _map_cascade_to_channel(level: int, channels: dict[str, str], is_agent: bool) -> str:
+    """Map a computed cascade level to a concrete channel.
+
+    Agents always map to agent_chat. Humans escalate through available
+    channels: discord_channel (1), discord_dm (2), signal (3), slack (4),
+    email (5+). If the requested level has no fact, fall back to the next
+    available channel. If no channels exist, return 'none'.
+    """
+    if is_agent:
+        return "agent_chat"
+    order = ["discord_channel", "discord_dm", "signal", "slack", "email"]
+    available = [ch for ch in order if ch in channels]
+    if not available:
+        return "none"
+    idx = max(0, level - 1)
+    if idx >= len(available):
+        return available[-1]
+    return available[idx]
+
+
+def check_step8_blocker_outreach() -> dict:
+    """
+    Step 8: Blocker outreach.
+
+    Curates eligible open blockers for outreach. Returns actionable=True when
+    at least one responsible entity has blockers ready for a new message.
+
+    Eligibility:
+      - entity master cooldown: >24h since ANY proactive_outreach row for the entity
+      - per-blocker cooldown: >72h since a proactive_outreach row for
+        (entity_id, blocker_type='blocker', blocker_id=blocker.id)
+      - top-3 per entity ordered by priority ASC, first_seen ASC, id ASC
+
+    Cascade level per blocker = prior proactive_outreach row count + 1.
+    One message per entity is sent at the most-escalated requested level among
+    its selected blockers; one proactive_outreach row is logged per blocker.
+    """
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT
+                            b.id,
+                            b.source_type,
+                            b.source_ref,
+                            b.description,
+                            b.needs,
+                            b.entity_id,
+                            e.name AS entity_name,
+                            b.priority,
+                            b.first_seen,
+                            COALESCE(po.attempt_count, 0) AS attempt_count,
+                            COALESCE(po.latest_attempt, 'epoch'::timestamptz) AS latest_attempt
+                        FROM blockers b
+                        JOIN entities e ON e.id = b.entity_id
+                        LEFT JOIN LATERAL (
+                            SELECT
+                                COUNT(*) AS attempt_count,
+                                MAX(attempted_at) AS latest_attempt
+                            FROM proactive_outreach
+                            WHERE entity_id = b.entity_id
+                              AND blocker_type = 'blocker'
+                              AND blocker_id = b.id
+                        ) po ON true
+                        WHERE b.status = 'open'
+                        ORDER BY b.entity_id, b.priority ASC, b.first_seen ASC, b.id ASC
+                        """
+                    )
+                    rows = cur.fetchall()
+
+                    # Entity master cooldown: latest ANY outreach to entity in last 24h
+                    entity_ids = list({r[5] for r in rows})
+                    entity_master: dict[int, datetime] = {}
+                    if entity_ids:
+                        cur.execute(
+                            """
+                            SELECT entity_id, MAX(attempted_at)
+                            FROM proactive_outreach
+                            WHERE entity_id = ANY(%s)
+                            GROUP BY entity_id
+                            """,
+                            (entity_ids,),
+                        )
+                        entity_master = {
+                            eid: ts for eid, ts in cur.fetchall() if ts is not None
+                        }
+        finally:
+            conn.close()
+    except Exception as exc:
+        return _step_error(f"DB error: {exc}")
+
+    now = _now_utc()
+    entity_cooldown_cutoff = now - timedelta(hours=BLOCKER_ENTITY_COOLDOWN_H)
+    blocker_cooldown_cutoff = now - timedelta(hours=BLOCKER_PER_BLOCKER_COOLDOWN_H)
+
+    by_entity: dict[int, dict[str, Any]] = {}
+    for row in rows:
+        (
+            bid, source_type, source_ref, description, needs,
+            entity_id, entity_name, priority, first_seen,
+            attempt_count, latest_attempt,
+        ) = row
+
+        # Entity master cooldown: strict > 24h means latest ANY outreach must be
+        # older than cutoff (or absent).
+        master_latest = entity_master.get(entity_id)
+        if master_latest is not None and master_latest > entity_cooldown_cutoff:
+            continue
+
+        # Per-blocker cooldown: strict > 72h
+        if latest_attempt > blocker_cooldown_cutoff:
+            continue
+
+        cascade_level = int(attempt_count) + 1
+
+        if entity_id not in by_entity:
+            by_entity[entity_id] = {
+                "entity_id": entity_id,
+                "entity_name": entity_name,
+                "channels": _entity_channel_facts(entity_id),
+                "is_agent": _entity_is_agent(entity_id),
+                "selected_blockers": [],
+            }
+
+        by_entity[entity_id]["selected_blockers"].append({
+            "id": bid,
+            "source_type": source_type,
+            "source_ref": source_ref,
+            "description": description,
+            "needs": needs,
+            "priority": priority,
+            "first_seen": first_seen.isoformat() if first_seen else None,
+            "cascade_level": cascade_level,
+        })
+
+    # Keep only top-3 per entity and compute actual channel
+    eligible_entities: list[dict[str, Any]] = []
+    for entity_id in sorted(by_entity.keys()):
+        ent = by_entity[entity_id]
+        selected = ent["selected_blockers"][:BLOCKERS_PER_MESSAGE]
+        if not selected:
+            continue
+        max_level = max(b["cascade_level"] for b in selected)
+        actual_channel = _map_cascade_to_channel(
+            max_level, ent["channels"], ent["is_agent"]
+        )
+        eligible_entities.append({
+            "entity_id": entity_id,
+            "entity_name": ent["entity_name"],
+            "selected_blockers": selected,
+            "max_cascade_level": max_level,
+            "actual_channel": actual_channel,
+            "is_agent": ent["is_agent"],
+        })
+
+    total = sum(len(e["selected_blockers"]) for e in eligible_entities)
+    if total > 0:
+        return {
+            "actionable": True,
+            "reason": f"{total} blocker(s) eligible across {len(eligible_entities)} entity/entities",
+            "data": {
+                "eligible_entities": eligible_entities,
+                "total_eligible_blockers": total,
+            },
+        }
+    return {"actionable": False, "reason": "No blockers eligible for outreach"}
+
+
+def check_step9_unsolved_problems() -> dict:
+    """Step 9: Unsolved problems with status != 'solved' and not researched in the last 3 days."""
     try:
         conn = _db_connect()
         try:
@@ -611,23 +865,25 @@ def check_step8_unsolved_problems() -> dict:
                     cur.execute("""
                         SELECT count(*) FROM unsolved_problems
                         WHERE status != 'solved'
+                          AND (last_worked_at IS NULL
+                               OR last_worked_at < NOW() - INTERVAL '3 days')
                     """)
                     count = cur.fetchone()[0]
             if count > 0:
                 return {
                     "actionable": True,
-                    "reason": f"{count} unsolved problem(s) awaiting research",
+                    "reason": f"{count} unsolved problem(s) due for research (3-day cooldown)",
                     "data": {"count": count},
                 }
-            return {"actionable": False, "reason": "0 unsolved problems"}
+            return {"actionable": False, "reason": "All unsolved problems researched within the last 3 days"}
         finally:
             conn.close()
     except Exception as exc:
         return _step_error(f"DB error: {exc}")
 
 
-def check_step9_filesystem_hygiene() -> dict:
-    """Step 9: Filesystem hygiene audit marker staleness."""
+def check_step10_filesystem_hygiene() -> dict:
+    """Step 10: Filesystem hygiene audit marker staleness."""
     STALE_SECONDS = FS_AUDIT_STALENESS_DAYS * 86_400
     try:
         with open(FS_AUDIT_MARKER, "r") as fh:
@@ -656,13 +912,33 @@ def check_step9_filesystem_hygiene() -> dict:
         return {"actionable": True, "reason": f"Could not parse audit marker timestamp: {exc}"}
 
 
-def check_step10_d100(prior_actionable_count: int) -> dict:
+def check_step11_d100(prior_actionable_count: int) -> dict:
     """
-    Step 10: D100 roll.
+    Step 11: D100 roll.
 
     MANDATORY (actionable=True) if no prior step was actionable.
     Optional (actionable=False, skippable) if at least one prior step was actionable.
+    Also forced actionable if >12h since the last D100 roll (issue #358).
     """
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT MAX(rolled_at) FROM d100_roll_log")
+                    row = cur.fetchone()
+                    last_rolled = row[0]
+        finally:
+            conn.close()
+    except Exception:
+        last_rolled = None
+
+    if last_rolled is None or (_now_utc() - last_rolled).total_seconds() > D100_FORCED_COOLDOWN_H * 3600:
+        return {
+            "actionable": True,
+            "reason": "Forced — >12h since last D100 roll",
+        }
+
     if prior_actionable_count == 0:
         return {
             "actionable": True,
@@ -700,7 +976,7 @@ def main() -> None:
         print(json.dumps(base, indent=2))
         return
 
-    # 2. Run all 10 gate checks
+    # 2. Run all 11 gate checks
     steps: dict[str, dict] = {}
 
     steps["1_agent_chat"] = check_step1_agent_chat()
@@ -710,12 +986,13 @@ def main() -> None:
     steps["5_entities"] = check_step5_entity_dedup()
     steps["6_tasks"] = check_step6_pending_tasks()
     steps["7_github"] = check_step7_github_issues()
-    steps["8_research"] = check_step8_unsolved_problems()
-    steps["9_filesystem"] = check_step9_filesystem_hygiene()
+    steps["8_blocker_outreach"] = check_step8_blocker_outreach()
+    steps["9_research"] = check_step9_unsolved_problems()
+    steps["10_filesystem"] = check_step10_filesystem_hygiene()
 
-    # Count actionable steps 1-9 (excluding step 10)
-    prior_actionable = [k for k, v in steps.items() if v.get("actionable")]
-    steps["10_d100"] = check_step10_d100(len(prior_actionable))
+    # Count actionable steps 1-10 (excluding step 11)
+    prior_actionable = [k for k, v in steps.items() if k != "11_d100" and v.get("actionable")]
+    steps["11_d100"] = check_step11_d100(len(prior_actionable))
 
     # Collect final actionable step numbers
     actionable_steps: list[int] = []
@@ -734,7 +1011,7 @@ def main() -> None:
         "steps": steps,
         "actionable_steps": actionable_steps,
         "actionable_count": actionable_count,
-        "summary": f"{actionable_count} of 10 steps actionable",
+        "summary": f"{actionable_count} of 11 steps actionable",
     }
 
     print(json.dumps(output, indent=2))

--- a/motivation/scripts/proactive-gate-check.py
+++ b/motivation/scripts/proactive-gate-check.py
@@ -684,13 +684,37 @@ def _entity_is_agent(entity_id: int) -> bool:
         return False
 
 
+def _entity_name_lookup(entity_id: int) -> str | None:
+    """Return entities.name for the given entity_id, or None on failure."""
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT name FROM entities WHERE id = %s LIMIT 1",
+                        (entity_id,),
+                    )
+                    row = cur.fetchone()
+                    return row[0] if row is not None else None
+        finally:
+            conn.close()
+    except Exception:
+        return None
+
+
 def _map_cascade_to_channel(level: int, channels: dict[str, str], is_agent: bool) -> str:
     """Map a computed cascade level to a concrete channel.
 
     Agents always map to agent_chat. Humans escalate through available
     channels: discord_channel (1), discord_dm (2), signal (3), slack (4),
-    email (5+). If the requested level has no fact, fall back to the next
-    available channel. If no channels exist, return 'none'.
+    email (5+). If the requested level has no fact, fall back to the last
+    available channel (repeat-at-ceiling). If no channels exist, return
+    'none'. Both the repeat-at-ceiling and no-channels cases are signals of
+    *cascade exhaustion* for the entity — see _is_cascade_exhausted() and
+    _reassign_exhausted_entity(), which detect this condition and drive
+    reassignment/hold-at-I)ruid behavior. This function itself only maps
+    level -> channel string; it does not decide reassignment.
     """
     if is_agent:
         return "agent_chat"
@@ -702,6 +726,160 @@ def _map_cascade_to_channel(level: int, channels: dict[str, str], is_agent: bool
     if idx >= len(available):
         return available[-1]
     return available[idx]
+
+
+def _is_cascade_exhausted(level: int, channels: dict[str, str], is_agent: bool) -> bool:
+    """Return True if the cascade level exceeds the entity's available channels.
+
+    Agents are never exhausted (agent_chat is unconditionally available).
+    A human entity with zero channels is exhausted at any level >= 1.
+    """
+    if is_agent:
+        return False
+    order = ["discord_channel", "discord_dm", "signal", "slack", "email"]
+    available_count = len([ch for ch in order if ch in channels])
+    return level > available_count
+
+
+def _entity_domain_topics(entity_id: int) -> list[str]:
+    """Return domain_topic values for which this entity is the PRIMARY owner.
+
+    Checks agent_domains first (joined via agents.entity_id), then
+    user_domains. Per ruling TC-E07, when the same domain_topic exists in
+    both tables, agent_domains wins as primary owner for that topic — so a
+    topic already claimed by an agent is excluded from this entity's list
+    if the entity itself is not that agent. Only used to find which topics
+    an *exhausted* entity currently owns, so we can look up the next
+    candidate for the same topic(s).
+    """
+    topics: set[str] = set()
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    # Topics this entity owns via agent_domains (entity is an agent).
+                    cur.execute(
+                        """
+                        SELECT ad.domain_topic
+                        FROM agent_domains ad
+                        JOIN agents a ON a.id = ad.agent_id
+                        WHERE a.entity_id = %s
+                        """,
+                        (entity_id,),
+                    )
+                    topics.update(r[0] for r in cur.fetchall())
+
+                    # Topics this entity owns via user_domains, EXCLUDING any
+                    # topic that agent_domains already claims for some agent
+                    # (agent_domains wins ties per TC-E07 — a human's
+                    # user_domains row for that topic is a fallback, not a
+                    # primary ownership claim, when an agent also claims it).
+                    cur.execute(
+                        """
+                        SELECT ud.domain_topic
+                        FROM user_domains ud
+                        WHERE ud.entity_id = %s
+                          AND NOT EXISTS (
+                              SELECT 1 FROM agent_domains ad2
+                              WHERE ad2.domain_topic = ud.domain_topic
+                          )
+                        """,
+                        (entity_id,),
+                    )
+                    topics.update(r[0] for r in cur.fetchall())
+        finally:
+            conn.close()
+    except Exception:
+        pass
+    return sorted(topics)
+
+
+def _next_domain_entity(domain_topic: str, exclude_entity_ids: set[int]) -> int | None:
+    """Resolve the next-priority responsible entity for a domain topic.
+
+    Resolution order matches curation (agent_domains first, then
+    user_domains by priority ASC, tiebreak first_seen/id), excluding any
+    entity already in exclude_entity_ids (already-exhausted entities in
+    this reassignment chain). Returns None if no candidate remains.
+    """
+    try:
+        conn = _db_connect()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    # agent_domains: domain_topic is globally unique per the
+                    # current schema constraint, so at most one candidate.
+                    cur.execute(
+                        """
+                        SELECT a.entity_id
+                        FROM agent_domains ad
+                        JOIN agents a ON a.id = ad.agent_id
+                        WHERE ad.domain_topic = %s
+                        """,
+                        (domain_topic,),
+                    )
+                    row = cur.fetchone()
+                    if row is not None and row[0] is not None and row[0] not in exclude_entity_ids:
+                        return row[0]
+
+                    # user_domains: lower priority number wins; tiebreak
+                    # created_at ASC, id ASC (deterministic; the random
+                    # tiebreak used in curation is for direct assignment,
+                    # not reassignment which needs a stable next-candidate).
+                    cur.execute(
+                        """
+                        SELECT entity_id
+                        FROM user_domains
+                        WHERE domain_topic = %s
+                          AND entity_id != ALL(%s)
+                        ORDER BY priority ASC, created_at ASC, id ASC
+                        LIMIT 1
+                        """,
+                        (domain_topic, list(exclude_entity_ids) or [-1]),
+                    )
+                    row = cur.fetchone()
+                    if row is not None:
+                        return row[0]
+        finally:
+            conn.close()
+    except Exception:
+        return None
+    return None
+
+
+def _reassign_exhausted_entity(
+    entity_id: int, exclude_entity_ids: set[int]
+) -> tuple[int | None, bool]:
+    """Find the reassignment target for an exhausted entity's blockers.
+
+    Per ruling #7 (SE Run #333 Step 4) / TC-D07:
+      1. Look up domain topics the exhausted entity currently owns as
+         primary responsible entity.
+      2. For each topic, find the next-priority domain entity (excluding
+         already-exhausted entities in this chain).
+      3. If any topic yields a candidate, reassign to it (first match wins;
+         topics are not expected to disagree in practice, and picking the
+         first deterministic match keeps this function total and simple).
+      4. If no topic yields a candidate (or the entity owns no topics),
+         fall back to entity_id = 2 (I)ruid) as the final fallback.
+
+    Returns (new_entity_id, is_final_fallback). is_final_fallback is True
+    when the returned entity is the I)ruid fallback (2) rather than a
+    genuine domain-topic reassignment — callers use this to distinguish
+    "reassigned to a peer" from "fell through to the catch-all."
+
+    Callers must not invoke this for entity_id == 2 (I)ruid) — his
+    exhaustion is a hold-in-place, not a reassignment; see
+    check_step8_blocker_outreach for that branch.
+    """
+    topics = _entity_domain_topics(entity_id)
+    chain_exclude = exclude_entity_ids | {entity_id}
+    for topic in topics:
+        candidate = _next_domain_entity(topic, chain_exclude)
+        if candidate is not None:
+            return candidate, False
+    return 2, True
 
 
 def check_step8_blocker_outreach() -> dict:
@@ -720,6 +898,20 @@ def check_step8_blocker_outreach() -> dict:
     Cascade level per blocker = prior proactive_outreach row count + 1.
     One message per entity is sent at the most-escalated requested level among
     its selected blockers; one proactive_outreach row is logged per blocker.
+
+    Cascade exhaustion (ruling #7 / TC-D07): when an entity's max cascade
+    level exceeds their available contact channels and they are not I)ruid
+    (entity_id=2), the blocker set is reassigned to the next domain entity
+    (via _reassign_exhausted_entity — agent_domains first, then
+    user_domains by priority, excluding already-exhausted entities in the
+    chain), restarting cascade level at 1 against the new entity. If every
+    domain entity is exhausted, the chain falls to I)ruid as final
+    fallback. If I)ruid himself is the exhausted entity, no reassignment
+    occurs — he holds at his last available channel/level and the normal
+    72h per-blocker cooldown continues to gate the next attempt. Each
+    returned entity entry carries "exhausted" (True only for the I)ruid
+    hold-in-place case) and, when reassignment occurred, the original
+    "reassigned_from_entity_id".
     """
     try:
         conn = _db_connect()
@@ -825,7 +1017,13 @@ def check_step8_blocker_outreach() -> dict:
             "cascade_level": cascade_level,
         })
 
-    # Keep only top-3 per entity and compute actual channel
+    # Keep only top-3 per entity, compute actual channel, and detect/resolve
+    # cascade exhaustion (ruling #7 / TC-D07): when max_level exceeds the
+    # entity's available channels and the entity is not I)ruid, reassign to
+    # the next domain entity (chain excludes already-exhausted entities),
+    # eventually falling to I)ruid if every domain entity is exhausted. If
+    # I)ruid himself is exhausted, hold him at his last available channel —
+    # no reassignment, no fabricated level increase.
     eligible_entities: list[dict[str, Any]] = []
     for entity_id in sorted(by_entity.keys()):
         ent = by_entity[entity_id]
@@ -833,17 +1031,67 @@ def check_step8_blocker_outreach() -> dict:
         if not selected:
             continue
         max_level = max(b["cascade_level"] for b in selected)
+
+        current_entity_id = entity_id
+        current_channels = ent["channels"]
+        current_is_agent = ent["is_agent"]
+        current_entity_name = ent["entity_name"]
+        exhausted_chain: list[int] = []
+        reassigned = False
+        exhaustion_hold = False
+
+        while _is_cascade_exhausted(max_level, current_channels, current_is_agent):
+            if current_entity_id == 2:
+                # I)ruid is exhausted — hold at his last available level,
+                # no further reassignment. Normal 72h cadence continues to
+                # gate future attempts.
+                exhaustion_hold = True
+                break
+
+            exhausted_chain.append(current_entity_id)
+            new_entity_id, is_final_fallback = _reassign_exhausted_entity(
+                current_entity_id, set(exhausted_chain)
+            )
+            if new_entity_id is None:
+                # No candidate at all (defensive; _reassign_exhausted_entity
+                # always returns entity 2 as a floor, but guard anyway).
+                new_entity_id = 2
+                is_final_fallback = True
+
+            reassigned = True
+            current_entity_id = new_entity_id
+            # Reassignment restarts cascade level at 1 against the new
+            # entity — no prior proactive_outreach rows exist against them
+            # for this blocker set yet.
+            max_level = 1
+            current_channels = _entity_channel_facts(current_entity_id)
+            current_is_agent = _entity_is_agent(current_entity_id)
+            current_entity_name = (
+                "I)ruid" if is_final_fallback and current_entity_id == 2
+                else _entity_name_lookup(current_entity_id) or current_entity_name
+            )
+
+            if current_entity_id in exhausted_chain:
+                # Defensive: avoid infinite loop if reassignment somehow
+                # cycles back to an already-exhausted entity.
+                break
+
         actual_channel = _map_cascade_to_channel(
-            max_level, ent["channels"], ent["is_agent"]
+            max_level, current_channels, current_is_agent
         )
-        eligible_entities.append({
-            "entity_id": entity_id,
-            "entity_name": ent["entity_name"],
+
+        entry: dict[str, Any] = {
+            "entity_id": current_entity_id,
+            "entity_name": current_entity_name,
             "selected_blockers": selected,
             "max_cascade_level": max_level,
             "actual_channel": actual_channel,
-            "is_agent": ent["is_agent"],
-        })
+            "is_agent": current_is_agent,
+            "exhausted": exhaustion_hold,
+        }
+        if reassigned:
+            entry["reassigned_from_entity_id"] = entity_id
+        eligible_entities.append(entry)
 
     total = sum(len(e["selected_blockers"]) for e in eligible_entities)
     if total > 0:

--- a/motivation/scripts/proactive-gate-check.py
+++ b/motivation/scripts/proactive-gate-check.py
@@ -790,14 +790,17 @@ def check_step8_blocker_outreach() -> dict:
             attempt_count, latest_attempt,
         ) = row
 
-        # Entity master cooldown: strict > 24h means latest ANY outreach must be
-        # older than cutoff (or absent).
+        # Entity master cooldown: strict > 24h elapsed required to be eligible,
+        # i.e. blocked while master_latest >= cutoff (elapsed <= 24h exactly
+        # still blocks).
         master_latest = entity_master.get(entity_id)
-        if master_latest is not None and master_latest > entity_cooldown_cutoff:
+        if master_latest is not None and master_latest >= entity_cooldown_cutoff:
             continue
 
-        # Per-blocker cooldown: strict > 72h
-        if latest_attempt > blocker_cooldown_cutoff:
+        # Per-blocker cooldown: strict > 72h elapsed required to be eligible,
+        # i.e. blocked while latest_attempt >= cutoff (elapsed <= 72h exactly
+        # still blocks).
+        if latest_attempt >= blocker_cooldown_cutoff:
             continue
 
         cascade_level = int(attempt_count) + 1

--- a/motivation/scripts/proactive-gate-check.py
+++ b/motivation/scripts/proactive-gate-check.py
@@ -1107,7 +1107,7 @@ def check_step8_blocker_outreach() -> dict:
 
 
 def check_step9_unsolved_problems() -> dict:
-    """Step 9: Unsolved problems with status != 'solved' and not researched in the last 3 days."""
+    """Step 9: Unsolved problems with status != 'solved'."""
     try:
         conn = _db_connect()
         try:
@@ -1116,17 +1116,15 @@ def check_step9_unsolved_problems() -> dict:
                     cur.execute("""
                         SELECT count(*) FROM unsolved_problems
                         WHERE status != 'solved'
-                          AND (last_worked_at IS NULL
-                               OR last_worked_at < NOW() - INTERVAL '3 days')
                     """)
                     count = cur.fetchone()[0]
             if count > 0:
                 return {
                     "actionable": True,
-                    "reason": f"{count} unsolved problem(s) due for research (3-day cooldown)",
+                    "reason": f"{count} unsolved problem(s) awaiting research",
                     "data": {"count": count},
                 }
-            return {"actionable": False, "reason": "All unsolved problems researched within the last 3 days"}
+            return {"actionable": False, "reason": "0 unsolved problems"}
         finally:
             conn.close()
     except Exception as exc:

--- a/motivation/tests/test_proactive_gate_check.py
+++ b/motivation/tests/test_proactive_gate_check.py
@@ -985,12 +985,16 @@ class TestStep9UnsolvedProblems:
         with patch.object(m, "_db_connect", return_value=self._mock_conn(0)):
             result = m.check_step9_unsolved_problems()
         assert result["actionable"] is False
+        # D-2 revert: no last_worked_at/3-day-cooldown predicate in this PR;
+        # reason string restored to the pre-PR count-only form.
+        assert result["reason"] == "0 unsolved problems"
 
     def test_unsolved_problems_present(self, m):
         with patch.object(m, "_db_connect", return_value=self._mock_conn(3)):
             result = m.check_step9_unsolved_problems()
         assert result["actionable"] is True
         assert result["data"]["count"] == 3
+        assert result["reason"] == "3 unsolved problem(s) awaiting research"
 
     def test_db_failure(self, m):
         with patch.object(m, "_db_connect", side_effect=Exception("db error")):
@@ -1243,6 +1247,262 @@ class TestStep8BlockerOutreach:
             result = m.check_step8_blocker_outreach()
         entity = result["data"]["eligible_entities"][0]
         assert entity["actual_channel"] == "discord_channel"
+
+    # ---- cascade exhaustion + reassignment (D-1 fix, ruling #7 / TC-D07) ----
+
+    def test_zero_channels_zero_attempts_triggers_reassignment(self, m):
+        """Entity with 0 contact channels and 0 prior attempts (cascade_level=1)
+        is immediately exhausted (1 > 0 available channels) — must reassign
+        rather than silently returning 'none'."""
+        rows = [self._row(1, entity_id=10, attempt_count=0)]
+        p1, p2, p3 = self._patched(m, rows, entity_master={}, channels={}, is_agent=False)
+        with (
+            p1, p2, p3,
+            patch.object(m, "_reassign_exhausted_entity", return_value=(20, False)) as mock_reassign,
+            patch.object(m, "_entity_channel_facts", side_effect=lambda eid: {"discord_channel": "abc"} if eid == 20 else {}),
+            patch.object(m, "_entity_is_agent", return_value=False),
+            patch.object(m, "_entity_name_lookup", return_value="Next Entity"),
+        ):
+            result = m.check_step8_blocker_outreach()
+        entity = result["data"]["eligible_entities"][0]
+        mock_reassign.assert_called_once_with(10, {10})
+        assert entity["entity_id"] == 20
+        assert entity["reassigned_from_entity_id"] == 10
+        assert entity["exhausted"] is False
+        assert entity["max_cascade_level"] == 1
+        assert entity["actual_channel"] == "discord_channel"
+
+    def test_n_channels_level_n_plus_1_triggers_reassignment(self, m):
+        """Entity with N channels, cascade_level = N+1 (first exhaustion past
+        the ceiling) — must reassign rather than repeating the last channel
+        silently."""
+        # attempt_count=2 -> cascade_level=3; only 2 channels available (N=2)
+        # so level 3 > 2 available channels -> exhausted.
+        rows = [self._row(1, entity_id=11, attempt_count=2)]
+        channels = {"discord_channel": "123", "discord_dm": "123"}
+        p1, p2, p3 = self._patched(m, rows, entity_master={}, channels=channels, is_agent=False)
+        with (
+            p1, p2, p3,
+            patch.object(m, "_reassign_exhausted_entity", return_value=(30, False)) as mock_reassign,
+            patch.object(m, "_entity_channel_facts", side_effect=lambda eid: {"signal": "sig"} if eid == 30 else channels),
+            patch.object(m, "_entity_is_agent", return_value=False),
+            patch.object(m, "_entity_name_lookup", return_value="Reassigned Entity"),
+        ):
+            result = m.check_step8_blocker_outreach()
+        entity = result["data"]["eligible_entities"][0]
+        mock_reassign.assert_called_once_with(11, {11})
+        assert entity["entity_id"] == 30
+        assert entity["reassigned_from_entity_id"] == 11
+        assert entity["max_cascade_level"] == 1
+        assert entity["actual_channel"] == "signal"
+
+    def test_iruid_exhausted_holds_no_reassignment(self, m):
+        """Entity is I)ruid (entity_id=2); cascade_level exceeds his channel
+        count. Must NOT reassign — holds at his last available channel and
+        is marked exhausted=True so the agent turn knows to keep the 72h
+        cadence rather than escalate further."""
+        # attempt_count=3 -> cascade_level=4; only 1 channel available -> exhausted.
+        rows = [self._row(1, entity_id=2, attempt_count=3)]
+        channels = {"discord_channel": "123"}
+        p1, p2, p3 = self._patched(m, rows, entity_master={}, channels=channels, is_agent=False)
+        with (
+            p1, p2, p3,
+            patch.object(m, "_reassign_exhausted_entity") as mock_reassign,
+        ):
+            result = m.check_step8_blocker_outreach()
+        entity = result["data"]["eligible_entities"][0]
+        mock_reassign.assert_not_called()
+        assert entity["entity_id"] == 2
+        assert entity["exhausted"] is True
+        assert entity["max_cascade_level"] == 4
+        assert entity["actual_channel"] == "discord_channel"
+        assert "reassigned_from_entity_id" not in entity
+
+    def test_full_reassignment_chain_falls_to_iruid(self, m):
+        """Original entity exhausted -> reassigned entity ALSO exhausted ->
+        falls through to I)ruid (entity_id=2) as final fallback."""
+        rows = [self._row(1, entity_id=10, attempt_count=0)]
+        p1, p2, p3 = self._patched(m, rows, entity_master={}, channels={}, is_agent=False)
+
+        # First reassignment: 10 -> 40 (also exhausted, 0 channels).
+        # Second reassignment: 40 -> 2 (I)ruid, final fallback), with channels.
+        reassign_calls = {"count": 0}
+
+        def fake_reassign(entity_id, exclude_ids):
+            reassign_calls["count"] += 1
+            if reassign_calls["count"] == 1:
+                assert entity_id == 10
+                assert exclude_ids == {10}
+                return 40, False
+            assert entity_id == 40
+            assert exclude_ids == {10, 40}
+            return 2, True
+
+        def fake_channels(eid):
+            if eid == 2:
+                return {"discord_channel": "999"}
+            return {}
+
+        with (
+            p1, p2, p3,
+            patch.object(m, "_reassign_exhausted_entity", side_effect=fake_reassign) as mock_reassign,
+            patch.object(m, "_entity_channel_facts", side_effect=fake_channels),
+            patch.object(m, "_entity_is_agent", return_value=False),
+            patch.object(m, "_entity_name_lookup", return_value="I)ruid"),
+        ):
+            result = m.check_step8_blocker_outreach()
+        entity = result["data"]["eligible_entities"][0]
+        assert mock_reassign.call_count == 2
+        assert entity["entity_id"] == 2
+        assert entity["reassigned_from_entity_id"] == 10
+        assert entity["exhausted"] is False  # landed on I)ruid with a channel, not a hold
+        assert entity["max_cascade_level"] == 1
+        assert entity["actual_channel"] == "discord_channel"
+
+
+# ---------------------------------------------------------------------------
+# Cascade exhaustion helpers — direct unit coverage (D-1 fix)
+# ---------------------------------------------------------------------------
+
+class TestIsCascadeExhausted:
+    def test_agent_never_exhausted(self, m):
+        assert m._is_cascade_exhausted(99, {}, is_agent=True) is False
+
+    def test_zero_channels_exhausted_at_level_1(self, m):
+        assert m._is_cascade_exhausted(1, {}, is_agent=False) is True
+
+    def test_level_within_available_channels_not_exhausted(self, m):
+        channels = {"discord_channel": "1", "discord_dm": "1", "signal": "s"}
+        assert m._is_cascade_exhausted(3, channels, is_agent=False) is False
+
+    def test_level_exceeding_available_channels_exhausted(self, m):
+        channels = {"discord_channel": "1", "discord_dm": "1"}
+        assert m._is_cascade_exhausted(3, channels, is_agent=False) is True
+
+
+class TestEntityDomainTopics:
+    def _mock_conn_for_topics(self, agent_rows, user_rows, exists_rows=None):
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        state = {"last": None}
+
+        def fake_execute(sql, params=None):
+            state["last"] = "agent" if "ad.domain_topic" in sql else "user"
+
+        def fake_fetchall():
+            if state["last"] == "agent":
+                return agent_rows
+            return user_rows
+
+        mock_cur.execute.side_effect = fake_execute
+        mock_cur.fetchall.side_effect = fake_fetchall
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.close = MagicMock()
+        return mock_conn
+
+    def test_combines_agent_and_user_domain_topics(self, m):
+        conn = self._mock_conn_for_topics(
+            agent_rows=[("Software Engineering",)],
+            user_rows=[("Project Leadership",)],
+        )
+        with patch.object(m, "_db_connect", return_value=conn):
+            topics = m._entity_domain_topics(2)
+        assert topics == ["Project Leadership", "Software Engineering"]
+
+    def test_db_failure_returns_empty_list(self, m):
+        with patch.object(m, "_db_connect", side_effect=Exception("db down")):
+            topics = m._entity_domain_topics(2)
+        assert topics == []
+
+
+class TestNextDomainEntity:
+    def _mock_conn(self, agent_row, user_row):
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        state = {"last": None}
+
+        def fake_execute(sql, params=None):
+            state["last"] = "agent" if "agent_domains ad" in sql else "user"
+
+        def fake_fetchone():
+            return agent_row if state["last"] == "agent" else user_row
+
+        mock_cur.execute.side_effect = fake_execute
+        mock_cur.fetchone.side_effect = fake_fetchone
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.close = MagicMock()
+        return mock_conn
+
+    def test_agent_domains_wins_when_present_and_not_excluded(self, m):
+        conn = self._mock_conn(agent_row=(50,), user_row=(60,))
+        with patch.object(m, "_db_connect", return_value=conn):
+            result = m._next_domain_entity("Software Engineering", set())
+        assert result == 50
+
+    def test_falls_back_to_user_domains_when_agent_excluded(self, m):
+        conn = self._mock_conn(agent_row=(50,), user_row=(60,))
+        with patch.object(m, "_db_connect", return_value=conn):
+            result = m._next_domain_entity("Software Engineering", {50})
+        assert result == 60
+
+    def test_returns_none_when_no_candidate(self, m):
+        conn = self._mock_conn(agent_row=None, user_row=None)
+        with patch.object(m, "_db_connect", return_value=conn):
+            result = m._next_domain_entity("obscure-topic", set())
+        assert result is None
+
+    def test_db_failure_returns_none(self, m):
+        with patch.object(m, "_db_connect", side_effect=Exception("db down")):
+            result = m._next_domain_entity("Software Engineering", set())
+        assert result is None
+
+
+class TestReassignExhaustedEntity:
+    def test_reassigns_to_next_domain_entity(self, m):
+        with (
+            patch.object(m, "_entity_domain_topics", return_value=["Software Engineering"]),
+            patch.object(m, "_next_domain_entity", return_value=99),
+        ):
+            new_id, is_final = m._reassign_exhausted_entity(10, set())
+        assert new_id == 99
+        assert is_final is False
+
+    def test_falls_back_to_iruid_when_no_topics_owned(self, m):
+        with patch.object(m, "_entity_domain_topics", return_value=[]):
+            new_id, is_final = m._reassign_exhausted_entity(10, set())
+        assert new_id == 2
+        assert is_final is True
+
+    def test_falls_back_to_iruid_when_all_topic_candidates_excluded(self, m):
+        with (
+            patch.object(m, "_entity_domain_topics", return_value=["Some Topic"]),
+            patch.object(m, "_next_domain_entity", return_value=None),
+        ):
+            new_id, is_final = m._reassign_exhausted_entity(10, set())
+        assert new_id == 2
+        assert is_final is True
+
+    def test_exclude_set_includes_entity_itself(self, m):
+        """The exhausted entity is always added to the exclusion set passed
+        to _next_domain_entity, even if the caller's exclude set didn't
+        already contain it."""
+        with (
+            patch.object(m, "_entity_domain_topics", return_value=["Topic"]),
+            patch.object(m, "_next_domain_entity") as mock_next,
+        ):
+            mock_next.return_value = 5
+            m._reassign_exhausted_entity(10, {7})
+        mock_next.assert_called_once_with("Topic", {7, 10})
 
 
 # ---------------------------------------------------------------------------

--- a/motivation/tests/test_proactive_gate_check.py
+++ b/motivation/tests/test_proactive_gate_check.py
@@ -3,8 +3,8 @@ Tests for motivation/scripts/proactive-gate-check.py
 
 Covers:
 - Idle detection (active, idle, boundary, missing file, malformed, bot-only, custom threshold)
-- All 10 gate check steps (actionable / not-actionable paths)
-- D100 logic (mandatory vs optional)
+- All 11 gate check steps (actionable / not-actionable paths)
+- D100 logic (mandatory vs optional vs forced by roll staleness)
 - Error handling (DB failure, missing state files, gh unavailable)
 - Output format validation (required fields, correct types)
 """
@@ -247,66 +247,97 @@ class TestStep1AgentChat:
 # ---------------------------------------------------------------------------
 
 class TestStep2UnansweredSessions:
-    def _make_openclaw_output(self, sessions: list[dict]) -> str:
-        return json.dumps({"sessions": sessions})
+    """check_step2_unanswered_sessions() reads SESSIONS_JSON directly and, for
+    each recent user-facing session, inspects the last conversational role in
+    its JSONL session file via _last_conversational_role()."""
 
-    def test_recent_user_sessions_found(self, m):
-        payload = self._make_openclaw_output([
-            {"key": "agent:nova:discord:channel:123", "ageMs": 1000},
-            {"key": "agent:nova:discord:channel:456", "ageMs": 2000},
-        ])
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = payload
+    def _write_sessions_json(self, tmp_path, entries: dict[str, dict]) -> str:
+        path = tmp_path / "sessions.json"
+        path.write_text(json.dumps(entries))
+        return str(path)
 
-        with patch("subprocess.run", return_value=mock_result):
+    def _write_session_file(self, tmp_path, name: str, roles: list[str]) -> str:
+        """Write a minimal JSONL session file; last entry in `roles` is the
+        last conversational message role."""
+        path = tmp_path / name
+        lines = [json.dumps({"message": {"role": role}}) for role in roles]
+        path.write_text("\n".join(lines) + "\n")
+        return str(path)
+
+    def test_recent_user_sessions_found(self, m, tmp_path):
+        now_ms = int(time.time() * 1000)
+        sf1 = self._write_session_file(tmp_path, "s1.jsonl", ["assistant", "user"])
+        sf2 = self._write_session_file(tmp_path, "s2.jsonl", ["assistant", "user"])
+        sessions_json = self._write_sessions_json(tmp_path, {
+            "agent:nova:discord:channel:123": {"updatedAt": now_ms - 1000, "sessionFile": sf1},
+            "agent:nova:discord:channel:456": {"updatedAt": now_ms - 2000, "sessionFile": sf2},
+        })
+        with patch.object(m, "SESSIONS_JSON", sessions_json):
             result = m.check_step2_unanswered_sessions()
         assert result["actionable"] is True
         assert result["data"]["count"] == 2
 
-    def test_no_recent_user_sessions(self, m):
-        payload = self._make_openclaw_output([
-            {"key": "agent:nova:discord:channel:123", "ageMs": 90_000_000},
-        ])
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = payload
-
-        with patch("subprocess.run", return_value=mock_result):
+    def test_no_recent_user_sessions(self, m, tmp_path):
+        now_ms = int(time.time() * 1000)
+        sf1 = self._write_session_file(tmp_path, "s1.jsonl", ["user", "assistant"])
+        sessions_json = self._write_sessions_json(tmp_path, {
+            "agent:nova:discord:channel:123": {"updatedAt": now_ms - 90_000_000, "sessionFile": sf1},
+        })
+        with patch.object(m, "SESSIONS_JSON", sessions_json):
             result = m.check_step2_unanswered_sessions()
         assert result["actionable"] is False
 
-    def test_excludes_bot_sessions(self, m):
-        payload = self._make_openclaw_output([
-            {"key": "agent:nova:discord:channel:123", "ageMs": 1000},
-            {"key": "agent:nova:main:heartbeat", "ageMs": 500},
-            {"key": "agent:nova:cron:abc", "ageMs": 300},
-        ])
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = payload
+    def test_answered_session_not_actionable(self, m, tmp_path):
+        """Last conversational message is from the assistant -> not unanswered."""
+        now_ms = int(time.time() * 1000)
+        sf1 = self._write_session_file(tmp_path, "s1.jsonl", ["user", "assistant"])
+        sessions_json = self._write_sessions_json(tmp_path, {
+            "agent:nova:discord:channel:123": {"updatedAt": now_ms - 1000, "sessionFile": sf1},
+        })
+        with patch.object(m, "SESSIONS_JSON", sessions_json):
+            result = m.check_step2_unanswered_sessions()
+        assert result["actionable"] is False
 
-        with patch("subprocess.run", return_value=mock_result):
+    def test_excludes_bot_sessions(self, m, tmp_path):
+        now_ms = int(time.time() * 1000)
+        sf1 = self._write_session_file(tmp_path, "s1.jsonl", ["assistant", "user"])
+        sf2 = self._write_session_file(tmp_path, "s2.jsonl", ["assistant", "user"])
+        sf3 = self._write_session_file(tmp_path, "s3.jsonl", ["assistant", "user"])
+        sessions_json = self._write_sessions_json(tmp_path, {
+            "agent:nova:discord:channel:123": {"updatedAt": now_ms - 1000, "sessionFile": sf1},
+            "agent:nova:main:heartbeat": {"updatedAt": now_ms - 500, "sessionFile": sf2},
+            "agent:nova:cron:abc": {"updatedAt": now_ms - 300, "sessionFile": sf3},
+        })
+        with patch.object(m, "SESSIONS_JSON", sessions_json):
             result = m.check_step2_unanswered_sessions()
         # Only the discord channel should count
         assert result["data"]["count"] == 1
 
-    def test_openclaw_cli_not_found(self, m):
-        import subprocess as sp
-        with patch("subprocess.run", side_effect=FileNotFoundError):
+    def test_sessions_json_missing(self, m, tmp_path):
+        missing = str(tmp_path / "no-such-sessions.json")
+        with patch.object(m, "SESSIONS_JSON", missing):
             result = m.check_step2_unanswered_sessions()
         assert result["actionable"] is False
         assert "error" in result
 
-    def test_openclaw_cli_failure(self, m):
-        mock_result = MagicMock()
-        mock_result.returncode = 1
-        mock_result.stderr = "something went wrong"
-
-        with patch("subprocess.run", return_value=mock_result):
+    def test_sessions_json_malformed(self, m, tmp_path):
+        path = tmp_path / "sessions.json"
+        path.write_text("not json")
+        with patch.object(m, "SESSIONS_JSON", str(path)):
             result = m.check_step2_unanswered_sessions()
         assert result["actionable"] is False
         assert "error" in result
+
+    def test_missing_session_file_skipped(self, m, tmp_path):
+        """A session entry with no sessionFile on disk should be skipped, not error."""
+        now_ms = int(time.time() * 1000)
+        missing_file = str(tmp_path / "does-not-exist.jsonl")
+        sessions_json = self._write_sessions_json(tmp_path, {
+            "agent:nova:discord:channel:123": {"updatedAt": now_ms - 1000, "sessionFile": missing_file},
+        })
+        with patch.object(m, "SESSIONS_JSON", sessions_json):
+            result = m.check_step2_unanswered_sessions()
+        assert result["actionable"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -665,7 +696,10 @@ class TestStep3IntrospectionDualMirror:
     def test_same_timestamp_uses_primary(self, m, tmp_path):
         primary_file = tmp_path / "primary.json"
         alt_file = tmp_path / "alt.json"
-        fixed_ts = "2026-06-21T10:00:00Z"
+        # Relative (3h ago) rather than a hardcoded absolute date so this test
+        # doesn't bit-rot as real time passes and eventually cross the
+        # INTROSPECT_TIME_THRESHOLD_H threshold regardless of tie-break winner.
+        fixed_ts = _iso(3.0)
         primary_file.write_text(json.dumps({
             "lastIntrospection": {
                 "dailyLogLines": 100,
@@ -935,7 +969,7 @@ class TestStep7GithubIssues:
 # Step 8 — unsolved problems
 # ---------------------------------------------------------------------------
 
-class TestStep8UnsolvedProblems:
+class TestStep9UnsolvedProblems:
     def _mock_conn(self, count: int) -> MagicMock:
         mock_cur = MagicMock()
         mock_cur.__enter__ = MagicMock(return_value=mock_cur)
@@ -949,80 +983,398 @@ class TestStep8UnsolvedProblems:
 
     def test_no_unsolved_problems(self, m):
         with patch.object(m, "_db_connect", return_value=self._mock_conn(0)):
-            result = m.check_step8_unsolved_problems()
+            result = m.check_step9_unsolved_problems()
         assert result["actionable"] is False
 
     def test_unsolved_problems_present(self, m):
         with patch.object(m, "_db_connect", return_value=self._mock_conn(3)):
-            result = m.check_step8_unsolved_problems()
+            result = m.check_step9_unsolved_problems()
         assert result["actionable"] is True
         assert result["data"]["count"] == 3
 
     def test_db_failure(self, m):
         with patch.object(m, "_db_connect", side_effect=Exception("db error")):
-            result = m.check_step8_unsolved_problems()
+            result = m.check_step9_unsolved_problems()
         assert result["actionable"] is False
         assert "error" in result
 
 
 # ---------------------------------------------------------------------------
-# Step 9 — filesystem hygiene
+# Step 8 — blocker outreach
 # ---------------------------------------------------------------------------
 
-class TestStep9FilesystemHygiene:
+class TestStep8BlockerOutreach:
+    """Tests for check_step8_blocker_outreach().
+
+    The function issues three DB round-trips via a single connection:
+      1. main SELECT joining blockers + entities + LATERAL proactive_outreach
+         (per-blocker attempt_count / latest_attempt)
+      2. entity master-cooldown SELECT (MAX(attempted_at) GROUP BY entity_id)
+      3. (helpers) _entity_channel_facts / _entity_is_agent, one query each,
+         called per-entity outside the main connection block.
+
+    We mock _db_connect to return a context-manager connection whose
+    cursor.execute/fetchall are driven by a small dispatcher keyed on the
+    SQL text, and separately patch _entity_channel_facts / _entity_is_agent
+    since those open their own connections.
+    """
+
+    def _row(
+        self,
+        bid: int,
+        entity_id: int,
+        entity_name: str = "entity",
+        priority: int = 5,
+        first_seen_hours_ago: float = 1.0,
+        attempt_count: int = 0,
+        latest_attempt_hours_ago: float | None = None,
+        source_type: str = "task",
+        source_ref: str = "ref-1",
+    ):
+        latest_attempt = (
+            "epoch"
+            if latest_attempt_hours_ago is None
+            else datetime.now(timezone.utc) - timedelta(hours=latest_attempt_hours_ago)
+        )
+        if latest_attempt == "epoch":
+            latest_attempt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        return (
+            bid,
+            source_type,
+            source_ref,
+            f"desc-{bid}",
+            f"needs-{bid}",
+            entity_id,
+            entity_name,
+            priority,
+            datetime.now(timezone.utc) - timedelta(hours=first_seen_hours_ago),
+            attempt_count,
+            latest_attempt,
+        )
+
+    def _mock_conn(self, rows: list, entity_master: dict[int, Any]):
+        """Build a mock connection whose cursor dispatches on query text."""
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+
+        state = {"last": None}
+
+        def fake_execute(sql, params=None):
+            if "FROM blockers b" in sql:
+                state["last"] = "main"
+            elif "GROUP BY entity_id" in sql:
+                state["last"] = "master"
+            else:
+                state["last"] = "other"
+
+        def fake_fetchall():
+            if state["last"] == "main":
+                return rows
+            if state["last"] == "master":
+                return list(entity_master.items())
+            return []
+
+        mock_cur.execute.side_effect = fake_execute
+        mock_cur.fetchall.side_effect = fake_fetchall
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        mock_conn.close = MagicMock()
+        return mock_conn
+
+    def _patched(self, m, rows, entity_master=None, channels=None, is_agent=None):
+        """Context manager patching _db_connect + the per-entity helpers."""
+        entity_master = entity_master or {}
+        channels = channels if channels is not None else {}
+        is_agent = is_agent if is_agent is not None else False
+        conn = self._mock_conn(rows, entity_master)
+        return (
+            patch.object(m, "_db_connect", return_value=conn),
+            patch.object(m, "_entity_channel_facts", return_value=channels),
+            patch.object(m, "_entity_is_agent", return_value=is_agent),
+        )
+
+    # ---- cooldown boundaries ----
+
+    def test_entity_master_cooldown_exactly_24h_is_blocked(self, m):
+        """Master cooldown is strict >24h: exactly 24h elapsed must still be blocked.
+
+        A 100ms safety margin is added so the row's timestamp is captured
+        very slightly *after* the true 24h mark, absorbing the microseconds
+        that elapse before the function's internal _now_utc() call runs —
+        otherwise this boundary test is flaky (real elapsed drifts just past
+        24h and is treated as eligible).
+        """
+        rows = [self._row(1, entity_id=10, attempt_count=0)]
+        master = {10: datetime.now(timezone.utc) - timedelta(hours=24.0) + timedelta(milliseconds=100)}
+        p1, p2, p3 = self._patched(m, rows, entity_master=master)
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is False
+
+    def test_entity_master_cooldown_24h_plus_1s_is_eligible(self, m):
+        rows = [self._row(1, entity_id=10, attempt_count=0)]
+        master = {10: datetime.now(timezone.utc) - timedelta(hours=24.0, seconds=1)}
+        p1, p2, p3 = self._patched(m, rows, entity_master=master)
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is True
+
+    def test_per_blocker_cooldown_exactly_72h_is_blocked(self, m):
+        """Per-blocker cooldown is strict >72h: exactly 72h elapsed must still be blocked.
+
+        Uses a 100ms-under-72h delta (see note on the 24h master-cooldown
+        boundary test above) to avoid boundary flakiness.
+        """
+        rows = [self._row(
+            1, entity_id=10, attempt_count=1,
+            latest_attempt_hours_ago=72.0 - (0.1 / 3600),
+        )]
+        p1, p2, p3 = self._patched(m, rows, entity_master={})
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is False
+
+    def test_per_blocker_cooldown_72h_plus_1s_is_eligible(self, m):
+        rows = [self._row(
+            1, entity_id=10, attempt_count=1,
+            latest_attempt_hours_ago=72.0 + (1 / 3600),
+        )]
+        p1, p2, p3 = self._patched(m, rows, entity_master={})
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is True
+
+    # ---- never-contacted entity ----
+
+    def test_never_contacted_entity_is_eligible(self, m):
+        """No proactive_outreach rows at all (empty master dict, epoch latest_attempt)."""
+        rows = [self._row(1, entity_id=10, attempt_count=0, latest_attempt_hours_ago=None)]
+        p1, p2, p3 = self._patched(m, rows, entity_master={})
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is True
+        assert result["data"]["eligible_entities"][0]["selected_blockers"][0]["cascade_level"] == 1
+
+    # ---- non-blocker outreach triggers master but not per-blocker cooldown ----
+
+    def test_non_blocker_outreach_triggers_master_not_per_blocker(self, m):
+        """A proactive_outreach row for a *different* blocker_type/id still counts
+        toward the entity master cooldown (any row for the entity), but the
+        per-blocker cooldown for THIS blocker is independent — attempt_count
+        for this blocker's LATERAL join is 0 since the row is keyed to a
+        different blocker_id, so its own cooldown is unaffected. The master
+        cooldown (recent) should block the entity outright.
+        """
+        rows = [self._row(1, entity_id=10, attempt_count=0, latest_attempt_hours_ago=None)]
+        # Master cooldown recent (1h ago) from an unrelated (e.g. non-blocker) row
+        master = {10: datetime.now(timezone.utc) - timedelta(hours=1.0)}
+        p1, p2, p3 = self._patched(m, rows, entity_master=master)
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        # Blocked by master cooldown even though per-blocker attempt_count is 0
+        assert result["actionable"] is False
+
+    # ---- top-3 tiebreak determinism ----
+
+    def test_top_3_tiebreak_determinism(self, m):
+        """5 blockers for one entity, all same priority/first_seen — only first
+        3 by id (as returned in SQL ORDER BY) are selected."""
+        now_h = 1.0
+        rows = [
+            self._row(i, entity_id=10, priority=5, first_seen_hours_ago=now_h, attempt_count=0)
+            for i in range(1, 6)
+        ]
+        p1, p2, p3 = self._patched(m, rows, entity_master={})
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is True
+        selected = result["data"]["eligible_entities"][0]["selected_blockers"]
+        assert len(selected) == 3
+        assert [b["id"] for b in selected] == [1, 2, 3]
+
+    def test_top_3_respects_priority_ordering(self, m):
+        """Lower priority number sorts first (already ordered by SQL); function
+        must preserve incoming row order, not re-sort."""
+        rows = [
+            self._row(3, entity_id=10, priority=1, attempt_count=0),
+            self._row(1, entity_id=10, priority=2, attempt_count=0),
+            self._row(2, entity_id=10, priority=3, attempt_count=0),
+        ]
+        p1, p2, p3 = self._patched(m, rows, entity_master={})
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        selected = result["data"]["eligible_entities"][0]["selected_blockers"]
+        assert [b["id"] for b in selected] == [3, 1, 2]
+
+    # ---- empty tables ----
+
+    def test_empty_blockers_table(self, m):
+        p1, p2, p3 = self._patched(m, rows=[], entity_master={})
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is False
+        assert "reason" in result
+
+    def test_db_failure(self, m):
+        with patch.object(m, "_db_connect", side_effect=Exception("db error")):
+            result = m.check_step8_blocker_outreach()
+        assert result["actionable"] is False
+        assert "error" in result
+
+    # ---- cascade level -> channel mapping ----
+
+    def test_cascade_level_maps_to_agent_chat_for_agents(self, m):
+        rows = [self._row(1, entity_id=99, attempt_count=0)]
+        p1, p2, p3 = self._patched(m, rows, entity_master={}, is_agent=True)
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        entity = result["data"]["eligible_entities"][0]
+        assert entity["actual_channel"] == "agent_chat"
+
+    def test_cascade_level_maps_to_available_human_channel(self, m):
+        rows = [self._row(1, entity_id=2, attempt_count=0)]
+        channels = {"discord_channel": "123", "discord_dm": "123", "email": "x@y.com"}
+        p1, p2, p3 = self._patched(m, rows, entity_master={}, channels=channels, is_agent=False)
+        with p1, p2, p3:
+            result = m.check_step8_blocker_outreach()
+        entity = result["data"]["eligible_entities"][0]
+        assert entity["actual_channel"] == "discord_channel"
+
+
+# ---------------------------------------------------------------------------
+# Step 10 — filesystem hygiene
+# ---------------------------------------------------------------------------
+
+class TestStep10FilesystemHygiene:
     def test_recently_audited_not_actionable(self, m, tmp_path):
         marker = tmp_path / ".last-fs-audit"
         marker.write_text(_iso(24.0))  # 1 day ago, threshold 7 days
         with patch.object(m, "FS_AUDIT_MARKER", str(marker)):
-            result = m.check_step9_filesystem_hygiene()
+            result = m.check_step10_filesystem_hygiene()
         assert result["actionable"] is False
 
     def test_stale_audit_is_actionable(self, m, tmp_path):
         marker = tmp_path / ".last-fs-audit"
         marker.write_text(_iso(8 * 24.0))  # 8 days ago, threshold 7 days
         with patch.object(m, "FS_AUDIT_MARKER", str(marker)):
-            result = m.check_step9_filesystem_hygiene()
+            result = m.check_step10_filesystem_hygiene()
         assert result["actionable"] is True
 
     def test_missing_marker_is_actionable(self, m, tmp_path):
         missing = str(tmp_path / "no-such-file")
         with patch.object(m, "FS_AUDIT_MARKER", missing):
-            result = m.check_step9_filesystem_hygiene()
+            result = m.check_step10_filesystem_hygiene()
         assert result["actionable"] is True
 
     def test_empty_marker_is_actionable(self, m, tmp_path):
         marker = tmp_path / ".last-fs-audit"
         marker.write_text("")
         with patch.object(m, "FS_AUDIT_MARKER", str(marker)):
-            result = m.check_step9_filesystem_hygiene()
+            result = m.check_step10_filesystem_hygiene()
         assert result["actionable"] is True
 
     def test_malformed_timestamp_is_actionable(self, m, tmp_path):
         marker = tmp_path / ".last-fs-audit"
         marker.write_text("not-a-timestamp")
         with patch.object(m, "FS_AUDIT_MARKER", str(marker)):
-            result = m.check_step9_filesystem_hygiene()
+            result = m.check_step10_filesystem_hygiene()
         assert result["actionable"] is True
 
 
 # ---------------------------------------------------------------------------
-# Step 10 — D100
+# Step 11 — D100
 # ---------------------------------------------------------------------------
 
-class TestStep10D100:
+class TestStep11D100:
+    def _mock_conn(self, last_rolled):
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_cur.fetchone.return_value = (last_rolled,)
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cur
+        return mock_conn
+
     def test_mandatory_when_no_prior_work(self, m):
-        result = m.check_step10_d100(prior_actionable_count=0)
+        """Last roll recent (<=12h), no prior actionable steps -> mandatory catch-all."""
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(datetime.now(timezone.utc) - timedelta(hours=1))):
+            result = m.check_step11_d100(prior_actionable_count=0)
         assert result["actionable"] is True
         assert "mandatory" in result["reason"].lower()
 
     def test_optional_when_prior_work_exists(self, m):
-        result = m.check_step10_d100(prior_actionable_count=3)
+        """Last roll recent (<=12h), prior actionable steps exist -> optional."""
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(datetime.now(timezone.utc) - timedelta(hours=1))):
+            result = m.check_step11_d100(prior_actionable_count=3)
         assert result["actionable"] is False
         assert "optional" in result["reason"].lower()
 
     def test_boundary_one_prior_step(self, m):
-        result = m.check_step10_d100(prior_actionable_count=1)
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(datetime.now(timezone.utc) - timedelta(hours=1))):
+            result = m.check_step11_d100(prior_actionable_count=1)
         assert result["actionable"] is False
+
+    # ---- forced D100 (issue #358) ----
+
+    def test_forced_when_more_than_12h_since_last_roll(self, m):
+        """Strictly >12h since last roll forces actionable, even with prior work."""
+        last = datetime.now(timezone.utc) - timedelta(hours=12, seconds=1)
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(last)):
+            result = m.check_step11_d100(prior_actionable_count=5)
+        assert result["actionable"] is True
+        assert "forced" in result["reason"].lower()
+
+    def test_not_forced_at_exactly_12h(self, m):
+        """Exactly 12h elapsed does not force (strict > threshold); falls back to
+        the prior-actionable-count logic.
+
+        A small safety margin (100ms) is subtracted from the 12h delta to
+        absorb the microseconds that elapse between constructing `last` here
+        and the function's internal _now_utc() call — without the margin this
+        boundary test is flaky (elapsed drifts to just over 12h and forces).
+        """
+        last = datetime.now(timezone.utc) - timedelta(hours=12) + timedelta(milliseconds=100)
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(last)):
+            result = m.check_step11_d100(prior_actionable_count=5)
+        assert result["actionable"] is False
+        assert "optional" in result["reason"].lower()
+
+    def test_forced_when_no_roll_history(self, m):
+        """No rows in d100_roll_log (MAX returns None) -> forced, regardless of
+        prior actionable count."""
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(None)):
+            result = m.check_step11_d100(prior_actionable_count=5)
+        assert result["actionable"] is True
+        assert "forced" in result["reason"].lower()
+
+    def test_under_12h_preserves_mandatory_catch_all(self, m):
+        """<=12h since last roll: 0 prior actionable -> mandatory (old behavior)."""
+        last = datetime.now(timezone.utc) - timedelta(hours=6)
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(last)):
+            result = m.check_step11_d100(prior_actionable_count=0)
+        assert result["actionable"] is True
+        assert "mandatory" in result["reason"].lower()
+
+    def test_under_12h_preserves_optional_when_prior_work(self, m):
+        """<=12h since last roll: prior actionable exists -> optional (old behavior)."""
+        last = datetime.now(timezone.utc) - timedelta(hours=6)
+        with patch.object(m, "_db_connect", return_value=self._mock_conn(last)):
+            result = m.check_step11_d100(prior_actionable_count=2)
+        assert result["actionable"] is False
+        assert "optional" in result["reason"].lower()
+
+    def test_db_failure_falls_back_to_forced(self, m):
+        """DB error while checking roll history -> treated like no-history (forced),
+        matching the code's `except Exception: last_rolled = None` fallback."""
+        with patch.object(m, "_db_connect", side_effect=Exception("db error")):
+            result = m.check_step11_d100(prior_actionable_count=5)
+        assert result["actionable"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -1052,8 +1404,9 @@ class TestOutputFormat:
              patch.object(m, "check_step5_entity_dedup", return_value=not_actionable), \
              patch.object(m, "check_step6_pending_tasks", return_value=not_actionable), \
              patch.object(m, "check_step7_github_issues", return_value=not_actionable), \
-             patch.object(m, "check_step8_unsolved_problems", return_value=not_actionable), \
-             patch.object(m, "check_step9_filesystem_hygiene", return_value=not_actionable), \
+             patch.object(m, "check_step8_blocker_outreach", return_value=not_actionable), \
+             patch.object(m, "check_step9_unsolved_problems", return_value=not_actionable), \
+             patch.object(m, "check_step10_filesystem_hygiene", return_value=not_actionable), \
              patch("builtins.print") as mock_print:
             m.main()
             printed = mock_print.call_args[0][0]
@@ -1071,8 +1424,8 @@ class TestOutputFormat:
         assert "steps" in output
         for step_key in [
             "1_agent_chat", "2_unanswered", "3_introspect", "4_memory",
-            "5_entities", "6_tasks", "7_github", "8_research",
-            "9_filesystem", "10_d100",
+            "5_entities", "6_tasks", "7_github", "8_blocker_outreach",
+            "9_research", "10_filesystem", "11_d100",
         ]:
             assert step_key in output["steps"], f"Missing step: {step_key}"
 
@@ -1091,9 +1444,12 @@ class TestOutputFormat:
 
     def test_d100_mandatory_when_all_others_not_actionable(self, m):
         output = self._run_main(m, idle=True)
-        # All steps 1-9 mocked as not-actionable, so D100 must be mandatory
-        assert 10 in output["actionable_steps"]
-        assert output["steps"]["10_d100"]["actionable"] is True
+        # All steps 1-10 mocked as not-actionable, so D100 must be mandatory
+        # (this exercises the real check_step11_d100, which is NOT mocked by
+        # _run_main; the DB call inside it will raise since there's no real
+        # connection, which is treated as no-history -> forced actionable)
+        assert 11 in output["actionable_steps"]
+        assert output["steps"]["11_d100"]["actionable"] is True
 
     def test_timestamp_is_valid_iso(self, m):
         output = self._run_main(m, idle=True)
@@ -1103,7 +1459,7 @@ class TestOutputFormat:
 
     def test_summary_string_format(self, m):
         output = self._run_main(m, idle=True)
-        assert "of 10 steps actionable" in output["summary"]
+        assert "of 11 steps actionable" in output["summary"]
 
     def test_output_is_valid_json(self, m):
         """main() must print valid JSON — no exceptions."""
@@ -1219,9 +1575,9 @@ class TestBoundaryValues:
             result = m.check_step4_memory_maintenance()
         assert result["actionable"] is True
 
-    # ---- Step 9: staleness exactly at threshold (7 days) ----
+    # ---- Step 10: staleness exactly at threshold (7 days) ----
 
-    def test_step9_staleness_exactly_7_days_is_actionable(self, m, tmp_path):
+    def test_step10_staleness_exactly_7_days_is_actionable(self, m, tmp_path):
         """Elapsed == 7 days (threshold >= 7d) → actionable.
 
         _iso(7 * 24.0) truncates to whole seconds, so measured elapsed >= 7d.
@@ -1229,5 +1585,5 @@ class TestBoundaryValues:
         marker = tmp_path / ".last-fs-audit"
         marker.write_text(_iso(7 * 24.0))  # exactly 7 days ago
         with patch.object(m, "FS_AUDIT_MARKER", str(marker)):
-            result = m.check_step9_filesystem_hygiene()
+            result = m.check_step10_filesystem_hygiene()
         assert result["actionable"] is True

--- a/psyche/ARCHITECTURE-agent-chat.md
+++ b/psyche/ARCHITECTURE-agent-chat.md
@@ -2,17 +2,17 @@
 
 ## Overview
 
-The `agent_chat` system provides asynchronous, push-based communication between peer agents in the NOVA Psyche ecosystem. This system enables real-time messaging with persistent storage and efficient delivery through PostgreSQL's native NOTIFY/LISTEN mechanism.
+The `agent_chat` system provides asynchronous, push-based communication between peer agents in the NOVA ecosystem. This system enables real-time messaging with persistent storage and efficient delivery through PostgreSQL's native NOTIFY/LISTEN mechanism.
 
 ## Purpose
 
-The agent chat system facilitates communication between **peer agents** - independent AI entities with their own sessions and identities. This is distinct from sub-agents or facets, which are temporary extensions of a parent agent like NOVA.
+The agent chat system facilitates communication between **peer agents** - independent AI entities with their own sessions and identities. This is distinct from sub-agents, which are temporary extensions of a parent agent spawned via `sessions_spawn`.
 
 Key characteristics:
 - **Asynchronous**: Messages persist even when recipient agents are offline
 - **Push-based**: Real-time delivery without polling overhead
-- **Peer-to-peer**: Communication between independent agent entities
-- **Auditable**: Complete message history with timestamps
+- **Peer-to-peer / broadcast**: Communication between independent agent entities, or to all agents via `ARRAY['*']`
+- **Auditable**: Complete message history with timestamps and per-recipient processing state
 
 ## Database Table Structure
 
@@ -21,39 +21,39 @@ Key characteristics:
 ```sql
 CREATE TABLE agent_chat (
     id SERIAL PRIMARY KEY,
-    sender VARCHAR(255) NOT NULL,
-    message TEXT NOT NULL,
-    mentions VARCHAR(255)[] DEFAULT '{}',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    read_at TIMESTAMP NULL
+    sender varchar(50) NOT NULL,
+    message text NOT NULL,
+    recipients text[] NOT NULL,
+    reply_to integer REFERENCES agent_chat(id),
+    "timestamp" timestamptz DEFAULT now() NOT NULL,
+    CONSTRAINT agent_chat_recipients_check CHECK (array_length(recipients, 1) > 0)
 );
 ```
 
 ### Column Descriptions
 
 - **id**: Auto-incrementing primary key
-- **sender**: Identifier of the sending agent (e.g., 'NOVA', 'NHR')
+- **sender**: Identifier of the sending agent (e.g., `'nova'`, `'newhart'`), stored lowercase
 - **message**: The actual message content
-- **mentions**: Array of agent identifiers mentioned in the message
-- **created_at**: Timestamp when message was inserted
-- **read_at**: Timestamp when message was read (NULL until read)
+- **recipients**: Array of agent identifiers this message is addressed to, or `ARRAY['*']` for a broadcast to all agents
+- **reply_to**: Optional self-reference to the message this one replies to
+- **timestamp**: Timestamp when the message was inserted
 
-### Example Usage
+Read/delivery state is **not** tracked on `agent_chat` itself — it lives in the separate `agent_chat_processed` table (see below).
+
+### Direct INSERT Is Blocked
+
+`agent_chat` has a trigger (`enforce_agent_chat_function_use()`) that raises an exception on any direct `INSERT` (except for the logical-replication apply worker, which bypasses the gate for cross-instance sync). The only supported write path is the `send_agent_message()` SECURITY DEFINER function:
 
 ```sql
--- Send a message from NOVA to Newhart
-INSERT INTO agent_chat (sender, message, mentions) 
-VALUES ('NOVA', 'Hey NHR, can you check the weather forecast for tomorrow?', ARRAY['NHR']);
-
--- Send a broadcast message (no specific mentions)
-INSERT INTO agent_chat (sender, message) 
-VALUES ('NOVA', 'System maintenance scheduled for 2 AM tonight');
-
--- Mark a message as read
-UPDATE agent_chat 
-SET read_at = CURRENT_TIMESTAMP 
-WHERE id = 123;
+SELECT send_agent_message('your_agent_name', 'message text', ARRAY['recipient_agent']);
 ```
+
+- **Sender** (arg 1): Your agent name (lowercase)
+- **Message** (arg 2): The message content
+- **Recipients** (arg 3): Array of recipient agent names, or `ARRAY['*']` for broadcast
+
+`send_agent_message()` normalizes sender/recipients to lowercase, validates that message and recipients are non-empty, sets `agent_chat.bypass_gate = 'on'` for its own INSERT, and returns the new row's `id`.
 
 ## Communication Mechanism
 
@@ -61,34 +61,28 @@ The system leverages **PostgreSQL's NOTIFY/LISTEN** functionality for efficient,
 
 ### How It Works
 
-1. **Message Insertion**: An agent inserts a message into the `agent_chat` table
-2. **Trigger Activation**: A PostgreSQL trigger fires automatically on INSERT
-3. **NOTIFY Broadcast**: The trigger sends a NOTIFY signal to all listening agents
+1. **Message Insertion**: An agent calls `send_agent_message()`, which inserts a row into `agent_chat`
+2. **Trigger Activation**: The `notify_agent_chat()` trigger fires automatically on INSERT
+3. **NOTIFY Broadcast**: The trigger sends a NOTIFY signal on the `agent_chat` channel to all listening agents
 4. **Instant Delivery**: Connected agents receive the notification immediately
-5. **Message Retrieval**: Receiving agents query for new messages
+5. **Message Retrieval**: Receiving agents query for new messages and record their processing state in `agent_chat_processed`
 
-### PostgreSQL Trigger Example
+### PostgreSQL Trigger (Actual)
 
 ```sql
 CREATE OR REPLACE FUNCTION notify_agent_chat()
-RETURNS TRIGGER AS $$
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
 BEGIN
-    PERFORM pg_notify('agent_chat', 
-        json_build_object(
-            'id', NEW.id,
-            'sender', NEW.sender,
-            'mentions', NEW.mentions,
-            'created_at', NEW.created_at
-        )::text
-    );
+    PERFORM pg_notify('agent_chat', json_build_object(
+        'id',         NEW.id,
+        'sender',     NEW.sender,
+        'recipients', NEW.recipients
+    )::text);
     RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER agent_chat_notify
-    AFTER INSERT ON agent_chat
-    FOR EACH ROW
-    EXECUTE FUNCTION notify_agent_chat();
+$$;
 ```
 
 ### Benefits Over Polling
@@ -101,13 +95,13 @@ CREATE TRIGGER agent_chat_notify
 ## Message Flow Diagram
 
 ```
-┌─────────┐    INSERT INTO     ┌──────────────┐    pg_notify()    ┌─────────┐
-│ Agent A │ ──────────────────▶│  agent_chat  │ ─────────────────▶│ Channel │
-└─────────┘    (message)       │   (table)    │   (trigger)       │agent_chat│
-                                └──────────────┘                   └─────────┘
-                                                                        │
-                                                                        │ LISTEN
-                                                                        ▼
+┌─────────┐  send_agent_message() ┌──────────────┐   pg_notify()    ┌─────────┐
+│ Agent A │ ──────────────────────▶│  agent_chat  │ ─────────────────▶│ Channel │
+└─────────┘                        │   (table)    │   (trigger)       │agent_chat│
+                                    └──────────────┘                   └─────────┘
+                                                                            │
+                                                                            │ LISTEN
+                                                                            ▼
 ┌─────────┐    Query new       ┌──────────────┐    NOTIFY event   ┌─────────┐
 │ Agent B │ ◀──────────────────│  agent_chat  │ ◀─────────────────│ Agent B │
 └─────────┘    messages        │   (table)    │   received        │(Listener)│
@@ -115,34 +109,31 @@ CREATE TRIGGER agent_chat_notify
 ```
 
 **Step-by-step flow:**
-1. Agent A inserts message into agent_chat table
-2. PostgreSQL trigger executes automatically
-3. Trigger calls pg_notify() to broadcast on 'agent_chat' channel
-4. Agent B (and other listening agents) receive NOTIFY event instantly
-5. Agent B queries agent_chat table for new messages
-6. Agent B processes the message and optionally marks as read
+1. Agent A calls `send_agent_message()`, which inserts into `agent_chat`
+2. PostgreSQL trigger (`notify_agent_chat()`) executes automatically
+3. Trigger calls `pg_notify()` to broadcast on the `agent_chat` channel
+4. Agent B (and other listening agents whose name is in `recipients`, or who watch broadcasts) receive the NOTIFY event
+5. Agent B queries `agent_chat` for new messages addressed to it
+6. Agent B processes the message and records status in `agent_chat_processed`
 
 ## Use Cases
 
 ### Direct Agent Communication
 ```sql
 -- NOVA asks Newhart for assistance
-INSERT INTO agent_chat (sender, message, mentions) 
-VALUES ('NOVA', 'NHR, I need your help analyzing market trends', ARRAY['NHR']);
+SELECT send_agent_message('nova', 'Need your help analyzing market trends', ARRAY['newhart']);
 ```
 
 ### Broadcast Announcements
 ```sql
--- System-wide notification
-INSERT INTO agent_chat (sender, message) 
-VALUES ('NOVA', 'New security protocols are now in effect');
+-- System-wide notification to all agents
+SELECT send_agent_message('nova', 'New security protocols are now in effect', ARRAY['*']);
 ```
 
 ### Collaborative Decision Making
 ```sql
--- Multi-agent discussion
-INSERT INTO agent_chat (sender, message, mentions) 
-VALUES ('NOVA', 'Should we prioritize Task A or Task B? @NHR @SAGE', ARRAY['NHR', 'SAGE']);
+-- Multi-agent discussion, addressed to more than one recipient
+SELECT send_agent_message('nova', 'Should we prioritize Task A or Task B?', ARRAY['newhart', 'graybeard']);
 ```
 
 ### Audit Trail
@@ -157,53 +148,65 @@ All messages are permanently stored, providing:
 ### Peer Agents (Use agent_chat)
 - **Independent entities**: Have their own sessions and persistent state
 - **Equal status**: Can initiate conversations with any other peer
-- **Examples**: NOVA, Newhart (NHR), SAGE
-- **Communication method**: agent_chat table
+- **Examples**: NOVA, Newhart, Graybeard
+- **Communication method**: `send_agent_message()` / `agent_chat` table
 
-### Sub-agents/Facets (Do NOT use agent_chat)
+### Sub-agents (Do NOT use agent_chat)
 - **Temporary extensions**: Spawned via `sessions_spawn` for specific tasks
-- **Child relationship**: Extensions of the parent agent (e.g., NOVA's facets)
+- **Child relationship**: Extensions of the parent agent (e.g., NOVA's subagents)
 - **Session-bound**: Exist only for the duration of their task
 - **Communication method**: Direct session communication, not agent_chat
 
 ### Key Differences
 
-| Aspect | Peer Agents | Sub-agents/Facets |
+| Aspect | Peer Agents | Sub-agents |
 |--------|-------------|-------------------|
 | Lifespan | Persistent | Temporary (task-bound) |
 | Identity | Independent | Extension of parent |
 | State | Own database/session | Shared with parent |
 | Communication | agent_chat system | Session channels |
-| Examples | NOVA ↔ NHR | NOVA → research facet |
+| Examples | NOVA ↔ Newhart | NOVA → research subagent |
+
+## Message Processing State (`agent_chat_processed`)
+
+Read/delivery tracking lives in a companion table, not on `agent_chat` itself:
+
+```sql
+CREATE TABLE agent_chat_processed (
+    chat_id integer REFERENCES agent_chat(id),
+    agent varchar(50),
+    received_at timestamp,
+    routed_at timestamp,
+    responded_at timestamp,
+    error_message text,
+    status agent_chat_status DEFAULT 'responded',
+    PRIMARY KEY (chat_id, agent)
+);
+```
+
+`status` is one of `received`, `routed`, `responded`, `failed`. Each recipient agent gets its own row keyed on `(chat_id, agent)`, so a single broadcast message can have independent processing state per recipient. An "unacknowledged message" check (e.g. used by the Proactive Mode heartbeat cascade) looks for `agent_chat` rows addressed to an agent with no matching `agent_chat_processed` row for that agent.
 
 ## Implementation Notes
 
 ### For Agent Developers
 
-1. **Listen Setup**: Agents should establish LISTEN connection on startup:
-   ```sql
-   LISTEN agent_chat;
-   ```
-
-2. **Message Processing**: Handle incoming NOTIFY events asynchronously
-
-3. **Mention Detection**: Parse the mentions array to determine if message is relevant
-
-4. **Read Receipts**: Update read_at timestamp when processing messages
+1. **Listen Setup**: Agents should establish a LISTEN connection on the `agent_chat` channel on startup.
+2. **Message Processing**: Handle incoming NOTIFY events asynchronously.
+3. **Recipient Detection**: Check whether your agent name is in `recipients` (or `recipients` contains `'*'` for broadcasts).
+4. **Processing State**: Upsert into `agent_chat_processed` as you receive, route, and respond to a message.
 
 ### Security Considerations
 
-- Validate sender identity before processing messages
-- Sanitize message content to prevent injection attacks
-- Implement rate limiting for message insertion
-- Consider encryption for sensitive communications
+- `send_agent_message()` is the only write path — direct INSERT is blocked by a trigger, so sender identity spoofing requires calling the function with a false `p_sender` value; validate at the call site.
+- Sanitize message content to prevent injection attacks.
+- Consider encryption for sensitive communications.
 
 ### Performance Optimization
 
-- Index frequently queried columns (sender, created_at, mentions)
-- Implement message archival for long-term storage management
-- Monitor NOTIFY/LISTEN connection health
-- Use connection pooling for database efficiency
+- Index frequently queried columns (`sender`, `"timestamp"`, `recipients` via GIN if needed).
+- Implement message archival for long-term storage management if volume grows.
+- Monitor NOTIFY/LISTEN connection health.
+- Use connection pooling for database efficiency.
 
 ## Monitoring and Debugging
 
@@ -211,21 +214,24 @@ All messages are permanently stored, providing:
 
 ```sql
 -- Recent messages for an agent
-SELECT * FROM agent_chat 
-WHERE 'NHR' = ANY(mentions) OR sender = 'NHR'
-ORDER BY created_at DESC 
+SELECT * FROM agent_chat
+WHERE 'newhart' = ANY(recipients) OR sender = 'newhart'
+ORDER BY "timestamp" DESC
 LIMIT 50;
 
--- Unread messages
-SELECT * FROM agent_chat 
-WHERE read_at IS NULL 
-AND created_at > NOW() - INTERVAL '24 hours';
+-- Unacknowledged messages for an agent
+SELECT ac.* FROM agent_chat ac
+WHERE 'nova' = ANY(ac.recipients)
+AND NOT EXISTS (
+    SELECT 1 FROM agent_chat_processed acp
+    WHERE acp.chat_id = ac.id AND acp.agent = 'nova'
+);
 
 -- Message volume by agent
-SELECT sender, COUNT(*) as message_count 
-FROM agent_chat 
-WHERE created_at > NOW() - INTERVAL '7 days'
-GROUP BY sender 
+SELECT sender, COUNT(*) as message_count
+FROM agent_chat
+WHERE "timestamp" > NOW() - INTERVAL '7 days'
+GROUP BY sender
 ORDER BY message_count DESC;
 ```
 
@@ -238,4 +244,4 @@ ORDER BY message_count DESC;
 
 ---
 
-This architecture provides a robust foundation for inter-agent communication while maintaining clear boundaries between peer agents and sub-agent facets. The PostgreSQL-based approach ensures reliability, performance, and auditability for all agent interactions.
+This architecture provides a robust foundation for inter-agent communication while maintaining clear boundaries between peer agents and sub-agents. The PostgreSQL-based approach ensures reliability, performance, and auditability for all agent interactions.

--- a/psyche/ARCHITECTURE-entities-users.md
+++ b/psyche/ARCHITECTURE-entities-users.md
@@ -40,12 +40,15 @@ The core table for all tracked entities.
 | `photo` | bytea | Avatar/photo (binary) |
 | `user_id` | varchar(255) | External user identifier |
 | `auth_token` | varchar(255) | Authentication token |
-| `trust_level` | integer | Trust score (default 0) |
+| `trust_level` | varchar(20) | Trust level string, default `'unknown'` (values: `owner`, `admin`, `user`, `unknown`, `untrusted`) |
 | `collaborate` | boolean | Can this entity collaborate? |
 | `collaboration_scope` | text | 'full', 'domain-specific', or 'supervised' |
 | `introduction_context` | text | How was this entity introduced? |
 | `capabilities` | jsonb | What can this entity do? |
 | `access_constraints` | jsonb | Limitations on access |
+| `preferred_contact` | varchar(50) | Preferred outreach channel |
+| `did` | text | Decentralized identifier, if any |
+| `alternate_spellings` | text[] | Alternate name spellings for fuzzy entity matching (issue #267) |
 
 **Type Constraint:**
 ```sql
@@ -71,16 +74,22 @@ Flexible key-value storage for any fact about an entity.
 | `key` | varchar(255) | Fact name (e.g., 'phone', 'email') |
 | `value` | text | Fact value |
 | `data` | jsonb | Structured data (optional) |
-| `source` | varchar(255) | Where did this fact come from? |
-| `source_entity_id` | integer | Who told us this? (FK to entities) |
 | `confidence` | float | 0.0 - 1.0 confidence score (default 1.0) |
 | `learned_at` | timestamp | When first learned |
 | `updated_at` | timestamp | When last updated |
-| `last_confirmed` | timestamp | When last verified |
-| `vote_count` | integer | Confirmation count |
+| `last_confirmed_at` | timestamptz | When last verified (default now()) |
+| `extraction_count` | integer | Reinforcement/confirmation count (default 1) |
+| `decay_rate` | real | Confidence decay rate |
+| `durability` | varchar(20) | `permanent`, `long_term`, `short_term`, or `ephemeral` — replaces the old `data_type` column |
+| `category` | text | Free-form category, default `'observation'` |
+| `expires` | timestamptz | Optional expiration for ephemeral facts |
+| `source_channel_transcript_id` | bigint | FK to `channel_transcripts` — source attribution (replaces the old `source`/`source_entity_id` columns) |
+| `source_channel_session_id` | bigint | FK to `channel_sessions` — source attribution |
 | `visibility` | varchar(20) | 'public', 'private', etc. |
 | `privacy_scope` | integer[] | Array of entity IDs who can see this |
 | `visibility_reason` | text | Why is visibility set this way? |
+
+> **Note:** Source attribution ("who told us this") lives in the separate `entity_fact_sources` table, not as columns on `entity_facts`. See `database/schema-reference.md` for its schema.
 
 **Common Keys for Users:**
 - `is_user` — 'true' marks entity as a user
@@ -133,9 +142,11 @@ Links entities together with typed relationships.
 
 ```sql
 -- Example: Sean knows I)ruid
-INSERT INTO entity_relationships (entity_a, entity_b, relationship_type)
+INSERT INTO entity_relationships (entity_a, entity_b, relationship)
 VALUES (28, 2, 'knows');
 ```
+
+Other columns: `since` (timestamp), `notes`, `is_long_distance` (boolean), `seriousness` (varchar, default `'standard'`).
 
 ## Related Tables
 

--- a/psyche/ARCHITECTURE-user-identification.md
+++ b/psyche/ARCHITECTURE-user-identification.md
@@ -48,18 +48,22 @@ The core challenge: **How do we resolve multiple platform-specific identifiers t
 
 ## 3. Current Storage (entity_facts table)
 
-The `entity_facts` table stores key-value pairs linking platform identifiers to entities:
+The `entity_facts` table stores key-value pairs linking platform identifiers to entities. The actual schema (see `database/schema.sql`) uses an integer `entity_id` FK to `entities.id` (a SERIAL primary key, not a UUID), a SERIAL `id` as its own primary key (not a composite key on the fact columns), and columns named `key`/`value` (not `fact_key`/`fact_value`):
 
 ```sql
 CREATE TABLE entity_facts (
-    entity_id UUID NOT NULL,
-    fact_key VARCHAR(255) NOT NULL,
-    fact_value TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT NOW(),
+    id SERIAL PRIMARY KEY,
+    entity_id INTEGER REFERENCES entities(id) ON DELETE CASCADE,
+    key VARCHAR(255) NOT NULL,
+    value TEXT NOT NULL,
+    learned_at TIMESTAMP DEFAULT NOW(),
     updated_at TIMESTAMP DEFAULT NOW(),
-    PRIMARY KEY (entity_id, fact_key)
+    -- plus confidence, durability, category, visibility, and other columns
+    -- (see database/schema-reference.md for the full column list)
 );
 ```
+
+The examples below use `fact_key`/`fact_value` for readability, but the real columns are `key`/`value`. The live resolution implementation is `relationships/lib/entity-resolver/` (`resolveEntity()` / `resolveEntityByIdentifiers()`), which maps platform-specific identifiers via the `IDENTIFIER_TO_DB_KEY` table (includes `deviceId` → `nova_app_device_id`, in addition to the keys listed below) — see `relationships/ARCHITECTURE-entity-resolver.md` for the current API reference.
 
 ### Standard Fact Keys
 

--- a/relationships/ARCHITECTURE-entity-resolver.md
+++ b/relationships/ARCHITECTURE-entity-resolver.md
@@ -240,6 +240,7 @@ The resolver maps camelCase identifier fields to snake_case `entity_facts.key` v
 | `slackMemberId` | `slack_member_id` |
 | `signalUuid` | `signal_uuid` |
 | `signalUsername` | `signal_username` |
+| `deviceId` | `nova_app_device_id` |
 
 Legacy identifiers (`phone`, `uuid`, `certCN`, `email`) are mapped inline to `phone`, `signal_uuid`, `cert_cn`, and `email`.
 

--- a/relationships/CONTRIBUTING.md
+++ b/relationships/CONTRIBUTING.md
@@ -18,6 +18,9 @@ cd nova-relationships
 ```
 
 2. **Database Setup**
+
+> **Note:** This subsystem does not ship its own `schema/init.sql`. The unified schema lives at the repo root (`database/schema.sql`), applied declaratively via `pgschema` by the root `agent-install.sh`. Install `memory/` first (it owns the shared `entities`/`entity_facts`/`entity_relationships` tables this subsystem depends on), then run this subsystem's own `agent-install.sh` for the entity-resolver library and CA setup.
+
 ```bash
 # Create database and user
 # Database name follows pattern: {username}_memory
@@ -25,8 +28,9 @@ cd nova-relationships
 sudo -u postgres createdb nova_memory
 sudo -u postgres createuser nova
 
-# Run schema setup
-psql -U nova -d nova_memory -f schema/init.sql
+# Apply the unified schema (run from repo root, not from relationships/)
+cd ~/.openclaw/workspace/nova-mind
+./agent-install.sh
 ```
 
 3. **Environment Configuration**
@@ -204,9 +208,11 @@ describe('Entity Resolution', () => {
 
 ### Schema Changes
 
-1. **Create Migration Script**
+> **Note:** There is no `relationships/migrations/` or `relationships/schema/` directory in this repo — shared tables (`entities`, `entity_facts`, `entity_relationships`) are owned by the root-level declarative schema at `database/schema.sql` and versioned via `memory/migrations/*.sql`. Schema changes affecting these tables should go through that process, not a subsystem-local migration file.
+
+1. **Edit the declarative schema**
 ```sql
--- migrations/003_add_relationship_strength.sql
+-- database/schema.sql (repo root) — edit the entity_relationships CREATE TABLE block directly
 ALTER TABLE entity_relationships 
 ADD COLUMN strength DECIMAL(3,2) DEFAULT 0.5;
 
@@ -214,15 +220,16 @@ CREATE INDEX idx_relationships_strength
 ON entity_relationships(strength);
 ```
 
-2. **Test Migration**
+2. **If the change requires a data migration** (e.g., a rename or backfill), add a numbered file to `memory/migrations/` following the existing convention (e.g., `084_add_relationship_strength.sql`).
+
+3. **Apply via the installer**
 ```bash
-# Test on development database
-# Database name pattern: {username}_memory (e.g., nova_memory, john_staging_memory)
-psql -U nova -d nova_memory_dev -f migrations/003_add_relationship_strength.sql
+cd ~/.openclaw/workspace/nova-mind
+./agent-install.sh
 ```
 
-3. **Document Changes**
-Update `schema/README.md` with new schema version and changes.
+4. **Document Changes**
+Update `database/schema-reference.md` and `memory/CHANGELOG.md` with the new column/table and its purpose.
 
 ### Query Guidelines
 

--- a/relationships/README.md
+++ b/relationships/README.md
@@ -15,7 +15,7 @@ Part of the nova-mind ecosystem, providing comprehensive entity perception, prof
 The NOVA Relationships System is a unified platform that merged the original Entity Relations System with the NOVA Multiuser System. It provides:
 
 ### Core Capabilities
-- **Entity Perception**: How NOVA notices and identifies entities across all interaction channels, now with `is_plausible_entity()` heuristics to prevent ghost entities and leveraging `alternate_spellings` for more accurate matching.
+- **Entity Perception**: How NOVA notices and identifies entities across all interaction channels. Ghost-entity prevention (`is_plausible_entity()` heuristics, `find_entity_id()` smarter matching via `alternate_spellings`) lives in the memory domain's extraction pipeline (`memory/scripts/extract_memories.py`), not in this repo's `lib/entity-resolver/` — see `memory/CHANGELOG.md` (#230, #267, #295).
 - **Entity Profiling**: Dynamic profiling of entities (people, organizations, concepts) with behavioral/trait schema
 - **Relationship Management**: Mapping and managing relationships between entities
 - **Recall Triggers**: Context-aware retrieval of relevant entity information
@@ -25,8 +25,9 @@ The NOVA Relationships System is a unified platform that merged the original Ent
 ### Key Components
 
 1. **Entity Resolver Library** (`lib/entity-resolver/`)
-   - **Enhanced Identity Resolution**: Expanded `find_entity_id()` to include `alternate_spellings`, domain-to-entity normalization, and whole-word substring matching. Supports resolution across multiple identifiers (phone, email, UUID, certificates, Discord ID, Telegram ID, Slack member ID, Signal UUID/username, `deviceId`).
+   - **Identity Resolution**: `resolveEntity()` looks up an entity across multiple identifiers (phone, email, UUID, certificates, Discord ID, Telegram ID, Slack member ID, Signal UUID/username, `deviceId`) via the `IDENTIFIER_TO_DB_KEY` mapping.
    - Conflict detection via `resolveEntityByIdentifiers()` — flags when identifiers match different entities
+   - (Note: `find_entity_id()`/`is_plausible_entity()` — alternate-spelling matching and ghost-entity heuristics — are implemented in the memory domain's `extract_memories.py`, not this library.)
    - Session-aware caching for performance
    - Profile management and fact storage
    - Cross-platform integration (Discord, Telegram, Slack, Signal, email, web, certificates, devices)
@@ -205,47 +206,50 @@ This is the actual installer. It:
 - `--database NAME` or `-d NAME` — Override database name (default: `${USER}_memory`)
 
 ### Database Setup
+
+> **Note:** These tables are created by the `memory/` installer, not by this subsystem — the block below is illustrative of the shape, not a script to run directly. For the exact current schema, see `database/schema.sql` / `database/schema-reference.md`. A few real column names differ from earlier drafts of this doc: `entity_relationships` uses `entity_a`/`entity_b`/`relationship` (not `from_entity_id`/`to_entity_id`/`relationship_type`), and `entity_facts` has no `source` column (source attribution is a separate `entity_fact_sources` table) and no composite primary key (it has its own `id SERIAL PRIMARY KEY`).
+
 ```sql
--- Create entities table
+-- entities table (simplified — see database/schema.sql for full column list)
 CREATE TABLE entities (
   id SERIAL PRIMARY KEY,
   name VARCHAR(255) NOT NULL,
   full_name VARCHAR(255),
   alternate_spellings TEXT[],
-  type VARCHAR(50) DEFAULT 'person',
+  type VARCHAR(50) NOT NULL,
   created_at TIMESTAMP DEFAULT NOW(),
   updated_at TIMESTAMP DEFAULT NOW()
 );
 
--- Create entity facts table  
+-- entity_facts table (simplified — see database/schema.sql for full column list,
+-- including durability/category/extraction_count/last_confirmed_at)
 CREATE TABLE entity_facts (
+  id SERIAL PRIMARY KEY,
   entity_id INTEGER REFERENCES entities(id),
   key VARCHAR(255) NOT NULL,
   value TEXT,
   confidence DECIMAL(3,2) DEFAULT 1.0,
-  source VARCHAR(255),
-  created_at TIMESTAMP DEFAULT NOW(),
-  updated_at TIMESTAMP DEFAULT NOW(),
-  PRIMARY KEY (entity_id, key)
+  learned_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
 );
 
--- Create relationships table
+-- entity_relationships table (actual column names)
 CREATE TABLE entity_relationships (
   id SERIAL PRIMARY KEY,
-  from_entity_id INTEGER REFERENCES entities(id),
-  to_entity_id INTEGER REFERENCES entities(id),
-  relationship_type VARCHAR(100) NOT NULL,
-  strength DECIMAL(3,2) DEFAULT 0.5,
-  context TEXT,
-  created_at TIMESTAMP DEFAULT NOW(),
-  updated_at TIMESTAMP DEFAULT NOW()
+  entity_a INTEGER REFERENCES entities(id),
+  entity_b INTEGER REFERENCES entities(id),
+  relationship VARCHAR(100) NOT NULL,
+  since TIMESTAMP,
+  notes TEXT,
+  is_long_distance BOOLEAN DEFAULT FALSE,
+  seriousness VARCHAR(20) DEFAULT 'standard'
 );
 
 -- Create indexes for performance
 CREATE INDEX idx_entity_facts_key_value ON entity_facts(key, value);
 CREATE INDEX idx_entity_facts_entity_id ON entity_facts(entity_id);
-CREATE INDEX idx_relationships_from_entity ON entity_relationships(from_entity_id);
-CREATE INDEX idx_relationships_to_entity ON entity_relationships(to_entity_id);
+CREATE INDEX idx_entity_rel_a ON entity_relationships(entity_a);
+CREATE INDEX idx_entity_rel_b ON entity_relationships(entity_b);
 ```
 
 ### Environment Configuration

--- a/tests/DOC-AUDIT-RUN333.md
+++ b/tests/DOC-AUDIT-RUN333.md
@@ -1,0 +1,283 @@
+# Documentation Audit — SE Run #333 (Step 9, Technical Writing)
+
+**Scope:** Document PR #359 (heartbeat-integrated blocker outreach, issues #356/#358) and audit
+all project documentation against current source code.
+
+**Branch:** `se333-docs-audit` (worktree at `~/.openclaw/workspace/se333-docs-worktree`), off
+`feature/blocker-outreach-356` @ 4625769.
+
+**Commit:** `7dbc831` — `docs(schema): add blockers, d100_roll_log, proactive_outreach to
+schema.sql and schema-reference` (single commit; all fixes below landed together — see
+"Commit note" at the end for why).
+
+---
+
+## 1. Docs Updated for the Feature (PR #359)
+
+Verification against the PR's actual scope (migrations 082/083, gate-check changes, cascade
+fixes) found `HEARTBEAT.md` and `motivation/ARCHITECTURE.md`/`motivation/scripts/README.md`
+already accurately updated by the Coder — no changes needed there. The gaps found and fixed:
+
+| File | Fix |
+|------|-----|
+| `database/schema.sql` | **Migrations 082/083 never made it into the declarative schema.** Added `blockers` table, `d100_roll_log` table, and the `trg_log_d100_roll` trigger on `motivation_d100`. Per `ARCHITECTURE.md`'s own documented process ("Edit `database/schema.sql` ... `CREATE TABLE IF NOT EXISTS`"), this file is supposed to be the single declarative source of truth — the raw migration files add tables that were never reflected there. |
+| `database/schema-reference.md` | Added `blockers` and `d100_roll_log` rows to the table index. |
+| `memory/CHANGELOG.md` | Added an `## Unreleased` entry for migrations 082/083: the `blockers` table, `d100_roll_log`, workflow 27's rewrite to 11 steps, the forced-D100-after-12h gate change, and the cascade-exhaustion/reassignment fix (commit b66f8da). |
+| `motivation/README.md` | **Not fixed — flagged only, see §2.** Found to be severely stale (describes a "9-step priority cascade" that predates even the pre-#356 10-step workflow, with no gate-check script, no blockers table, no D100-forced-roll logic). Out of the explicit PR-file-changes list but directly relevant to the feature; left as a flagged gap rather than fixed due to scope/time — see reasoning in §2. |
+
+### Also found and fixed: `proactive_outreach` table missing from `database/schema.sql`
+
+Not part of PR #359 (it's from #232/migration 078), but discovered while confirming the
+`blockers` insertion point: `proactive_outreach` was *also* missing from the declarative
+schema despite being live in the database and directly referenced by the new Step 8 blocker
+outreach logic this PR adds. Added it alongside `blockers`/`d100_roll_log` since it's the
+same category of gap and directly touches this feature's outreach path.
+
+---
+
+## 2. Flagged But Not Fixed (Feature-Adjacent)
+
+### `motivation/README.md` — severely stale, not rewritten
+
+**Why not fixed:** This file describes an entirely different (and older) operational model
+than what workflow 27 (Proactive Mode) actually does today — no mention of the gate-check
+script, the `blockers` table, D100 forced rolls, or even the pre-#356 10-step layout. Fixing
+it properly means writing a new step-by-step walkthrough of the current 11-step workflow,
+which is a substantial rewrite (motivation/ARCHITECTURE.md already does this well — this file
+would need to either be brought into alignment with that document or explicitly deprecated in
+favor of it). Given the volume of other stale documentation surfaced by the full-repo audit
+(see §3), I prioritized fixing the schema/pipeline-accuracy gaps that make documentation
+actively wrong over rewriting a doc whose sibling (`ARCHITECTURE.md`) already covers the same
+ground correctly. **Recommend a follow-up task**: either rewrite `motivation/README.md` to
+match `motivation/ARCHITECTURE.md`'s current description, or replace its content with a
+pointer to `ARCHITECTURE.md` to avoid two sources of truth drifting apart again.
+
+---
+
+## 3. Stale Docs Found and Fixed During the Full Audit
+
+The task explicitly scoped this beyond the feature — "AUDIT ALL project documentation
+against current source code." I read every file in the given inventory (or delegated batches
+to subagents where the volume was large) and cross-checked concrete technical claims (schema,
+function names, script paths) against `database/schema.sql`, the live database, and the
+relevant source directories. Findings below are grouped by area.
+
+### Database schema mismatches (high confidence, verified against live DB + schema.sql)
+
+Several architecture docs described `entity_facts`/`entities`/`entity_relationships`/
+`agent_chat` schemas that were either aspirational drafts that never matched the implemented
+schema, or described a schema from before several migrations landed. Fixed:
+
+- **`psyche/ARCHITECTURE-agent-chat.md`** — Entire doc rewritten. It described `mentions`
+  (array) and `read_at` (timestamp) columns and a raw-INSERT write pattern; the real table
+  has `recipients`/`timestamp`, direct INSERT is blocked by a trigger
+  (`enforce_agent_chat_function_use()`), and the only write path is
+  `send_agent_message()`. Read/delivery tracking is a separate `agent_chat_processed` table,
+  not columns on `agent_chat` — the old doc didn't mention this table at all.
+- **`psyche/ARCHITECTURE-entities-users.md`** — `entities.trust_level` documented as
+  `integer default 0`; actual column is `varchar(20) default 'unknown'` (owner/admin/user/
+  unknown/untrusted). `entity_facts` documented `source`/`source_entity_id`/`vote_count`/
+  `last_confirmed` columns that don't exist; real columns are `durability`/`category`/
+  `extraction_count`/`last_confirmed_at`, with source attribution in a separate
+  `entity_fact_sources` table. `entity_relationships` example used `relationship_type`;
+  real column is `relationship`.
+- **`psyche/ARCHITECTURE-user-identification.md`** — `entity_facts` schema block showed a
+  `UUID` entity_id with composite primary key on `(entity_id, fact_key)`; real table has
+  integer `entity_id`, its own `SERIAL id` primary key, and columns named `key`/`value`.
+- **`relationships/README.md`** — Database Setup SQL block showed `entity_relationships`
+  with `from_entity_id`/`to_entity_id`/`relationship_type`/`strength` (none of which exist)
+  and `entity_facts` with a `source` column and composite PK. Also claimed the
+  `lib/entity-resolver/` library implements `find_entity_id()`/`is_plausible_entity()` —
+  those functions exist in the memory domain's `extract_memories.py` (ghost-entity
+  prevention, issues #230/#267/#295), not in this library.
+- **`relationships/ARCHITECTURE-entity-resolver.md`** — The `IDENTIFIER_TO_DB_KEY` mapping
+  table was missing the `deviceId` → `nova_app_device_id` entry, which exists in the actual
+  `resolver.ts`/`types.ts` and is referenced elsewhere in the same doc's identifier list.
+- **`relationships/CONTRIBUTING.md`** — Referenced a nonexistent `schema/init.sql`,
+  `schema/README.md`, and a subsystem-local `migrations/` directory. Fixed to point at the
+  actual root `database/schema.sql` + `memory/migrations/*.sql` process.
+- **`memory/docs/database-schema-guide.md`** — Example `INSERT INTO entity_facts` used a
+  `source` column two lines below a note saying source attribution moved to
+  `entity_fact_sources` — the example directly contradicted the note above it.
+- **`memory/docs/fact-judgement-model.md`** — Extensively described `entity_facts.source`,
+  `source_entity_id`, `data_type`, `vote_count`, `confirmation_count`, `last_confirmed` as
+  live columns, all of which are stale/renamed (see entities-users fix above). This document
+  also disagreed with `SOURCE-AUTHORITY.md` on the schema, which itself has the correct
+  current columns — the two docs contradicted each other. Rewrote the schema references,
+  the example SQL, and the summary diagram to use `entity_fact_sources` + current column
+  names.
+
+### Extraction pipeline: entire shell-script chain no longer exists (high confidence)
+
+The #174 grammar-parser removal consolidated `extract-memories.sh` + `store-memories.sh` +
+`process-input.sh` into a single Python script, `memory/scripts/extract_memories.py`. Several
+docs still describe the old three-script pipeline as current:
+
+- **`memory/docs/SOURCE-AUTHORITY.md`** — Described a deterministic `SENDER_NAME`-based
+  authority-detection flow in `store-memories.sh` that force-sets `durability='permanent'`
+  and rejects non-authority conflicting facts at write time. Verified against
+  `extract_memories.py` and `confidence_helper.py`: no such deterministic rejection exists —
+  the extraction LLM judges `durability`/`category`/`confidence` per fact directly, and
+  `confidence_helper.py`'s `get_initial_confidence()` uses `trust_level`-based scoring with no
+  `AUTHORITY_ENTITY_ID` override. Marked the deterministic-authority sections as historical
+  (pre-#174) and documented the current behavior.
+- **`memory/docs/CONFIDENCE-DECAY.md`** — Described a `decay-confidence.sh` cron job running
+  daily with a flat daily-multiplier decay model. Verified against
+  `memory/templates/memory-maintenance.py`: decay is Phase 5 of a heartbeat-triggered (not
+  cron) maintenance pipeline, uses exponential decay (`exp(-rate * days_since)`) with a
+  `DECAY_RATES` table (permanent=0, long_term=0.005, short_term=0.02, ephemeral=0.1) plus
+  separate `TABLE_DECAY_RATES` for events/lessons/memory_embeddings, and a 24h decay-specific
+  cooldown on top of the pipeline's 4h general cooldown. Rewrote the whole doc to match.
+- **`memory/docs/memory-extraction-pipeline.md`** — Fully rewritten. The old doc's entire
+  three-component breakdown (`memory-catchup.sh` → `extract-memories.sh` →
+  `store-memories.sh`) doesn't match current source. New version documents the real
+  real-time path (`memory-extract` hook → `extract_memories.py`) and the separate
+  `memory-catchup.sh` transcript-ingestion cron path.
+- **`memory/ARCHITECTURE.md`, `memory/README.md`, `memory/docs/deployment-setup-guide.md`,
+  `memory/docs/README.md`, `memory/docs/semantic-search-guide.md`** — Same family of stale
+  references (`process-input.sh`, `extract-memories.sh`, `store-memories.sh`,
+  `search-memories.sh`) fixed throughout usage examples, troubleshooting steps, and
+  integration snippets. `memory/docs/README.md` additionally had five broken links under
+  "Advanced Topics"/"Integration" pointing to docs that were never written
+  (`librarian-agent-deployment.md`, `access-control-guide.md`, `performance-tuning.md`,
+  `api-reference.md`, `agent-communication.md`) — marked as not-yet-written rather than
+  live links.
+
+### A genuine code bug surfaced during the pipeline audit (not fixed — flagged only)
+
+While verifying `memory-extract-pipeline.md`, I found that **`memory/scripts/memory-catchup.sh`
+(current repo source) still calls `EXTRACT_SCRIPT="${SCRIPT_DIR}/process-input.sh"`**, a script
+that does not exist anywhere in this repo. A `process-input.sh` happens to be deployed on at
+least one host (`~/.openclaw/scripts/`, `~/.openclaw/workspace/scripts/`) as a leftover
+pre-#174 artifact, but it in turn calls `extract-memories.sh`, which also doesn't exist. This
+is a real latent bug, not a documentation issue — flagged in the rewritten
+`memory-extraction-pipeline.md` and `memory/ARCHITECTURE.md`, and noted here for a GitHub
+issue / Software Engineering domain follow-up. Not fixed directly since editing script logic
+is outside Technical Writing's scope and this PR's branch.
+
+### AWL docs presented as live when unimplemented (high confidence)
+
+- **`cognition/docs/awl-getting-started.md`**, **`cognition/docs/awl-quick-reference.md`** —
+  Both present a `nova-workflow` CLI (`nova-workflow run/list/status/approve/logs/validate`)
+  as an installable, runnable tool. No such CLI, executor, or `workflow_executions`/
+  `workflow_gates` tables exist anywhere in the repo (confirmed via repo-wide search).
+  `cognition/docs/agent-workflow-language.md` (the spec doc) already correctly says "Status:
+  Design Proposal" — the two tutorial-style docs did not carry the same caveat. Added
+  "Design Proposal, not yet implemented" banners to both rather than rewriting their
+  (useful, forward-looking) tutorial content.
+
+### Bootstrap context / delegation context docs describing removed mechanisms (high confidence)
+
+- **`cognition/docs/bootstrap-context-workflow-changes.md`** — Claimed `get_agent_bootstrap()`
+  matches on `workflow_steps.agent_id`. That column has never existed on `workflow_steps`
+  (confirmed via `\d workflow_steps` against the live DB) — matching has always been
+  domain-based (`workflow_steps.domain`/`domains` vs. `agent_domains`). Also referenced a
+  `verify_workflow_context()` helper function that doesn't exist. Fixed both, with notes on
+  the current `get_agent_bootstrap()` output shape (compact per-workflow summaries, not a
+  flat `WORKFLOW_CONTEXT.md` row per match).
+- **`cognition/docs/delegation-context-auto-regeneration.md`** — The "Long-Term Solution"
+  section's entire design depends on `update_universal_context()`, confirmed via `\df
+  update_universal_context` against the live database to no longer exist. (There's also a
+  stale call to it in `copy_file_to_bootstrap()` in `database/schema.sql` — a latent bug
+  worth its own issue, noted in the doc.) Added a warning banner; did not rewrite the
+  proposal itself since it's explicitly a not-yet-implemented plan (Issue #10) and would need
+  re-design against the current schema, which is outside this task's scope.
+- **`cognition/docs/delegation-context.md`** — Spot-checked against the same claims (a
+  subagent's initial pass flagged `workflow_steps_detail` as nonexistent); **verified this
+  claim was incorrect** — `workflow_steps_detail` is a real, live view exactly matching the
+  doc's usage. No fix needed; this shows the value of verifying subagent audit findings
+  against source before acting on them.
+
+### Deprecated path references (`~/workspace/nova-mind` → `~/.openclaw/workspace/nova-mind`)
+
+Per the task's explicit note that `~/workspace` is a deprecated symlink, fixed in:
+`memory/INSTALLATION.md`, `cognition/docs/agent-workflow-language.md`,
+`cognition/docs/awl-getting-started.md`, `cognition/docs/awl-quick-reference.md`, and (outside
+the explicit file inventory, but directly related and low-risk)
+`cognition/focus/protocols/workflows/README.md` and
+`cognition/focus/protocols/workflows/getting-started/README.md`.
+
+### `cognition/docs/installation.md` — oversimplified `agents` table
+
+The illustrative `CREATE TABLE agents` block (10 columns) is drastically simpler than the
+live `agents` table (~35+ columns: `context_type`, `thinking`, `allowed_subagents`,
+`parent_agents`, `heartbeat_*` fields, etc.). Rather than reproduce the full column list
+(which will drift again), added a note pointing at `database/schema-reference.md` /
+`\d agents` as the source of truth before building tooling against this table.
+
+---
+
+## 4. Audited and Found Accurate (No Changes Needed)
+
+Confirmed accurate against source, no action taken:
+
+- `README.md`, `ARCHITECTURE.md` (root) — accurate, no stale claims relevant to this PR
+- `cognition/README.md`, `cognition/CHANGELOG.md` — cross-checked against migrations 106,
+  146, 160, 163, 174, 244; accurate
+- `cognition/docs/agent-workflow-language.md` — correctly labeled Design Proposal
+- `cognition/docs/confidence-gating.md`, `cross-database-replication.md`,
+  `implementation-notes.md`, `models.md`, `multi-agent-addressing.md`, `philosophy.md`,
+  `pitfalls.md`, `quickstart.md`, `shell-environment.md`, `system-level-controls.md` — no
+  fabricated CLI references, no deprecated paths, no schema drift found
+- `cognition/docs/delegation-context.md` — accurate (see note in §3 about the incorrect
+  `workflow_steps_detail` flag that was verified and rejected)
+- `memory/docs/CONFIDENCE-DECAY.md` dependencies verified: `memory-maintenance.py` decay
+  logic confirmed against actual source
+- `memory/docs/database-config.md`, `library-schema.md`, `semantic-recall.md`,
+  `DATABASE-ALIASING.md`, `integration-overview.md`, `agent-delegation-memory.md` (correctly
+  self-labeled as a design doc, "Status: Design complete, ready for implementation" — left
+  untouched per the historical/point-in-time exclusion rule)
+- `psyche/DESIGN-core-values.md`, `psyche/README.md` — no verifiable claims contradicted
+- `relationships/docs/algorithms.md`, `integration-guide.md`, `web-of-trust.md` — explicitly
+  marked experimental/design-phase throughout; consistent with actual implementation status
+- `relationships/CHANGELOG.md` — accurate historical record
+- `pre-migrations/README.md` — verified against `pre-migrations/001-005*.sql`; file names,
+  phase descriptions, and purposes all match exactly
+- `skills/agent-ecosystem/SKILL.md` — cross-checked against `agents`, `agent_domains`
+  tables and `send_agent_message()`; all referenced columns and the function signature match
+- `motivation/ARCHITECTURE.md`, `motivation/scripts/README.md`,
+  `motivation/scripts/proactive-gate-check.py`,
+  `motivation/tests/test_proactive_gate_check.py` — the PR's own changed files; already
+  accurate, matches implementation, correctly distinguishes the working-copy path
+  (`motivation/scripts/`) from the deployed runtime path
+  (`~/.openclaw/workspace/scripts/proactive-gate-check.py`)
+- `HEARTBEAT.md` — accurate, correctly describes the 11-step workflow, Step 8 blocker
+  outreach semantics, and Step 11's dual trigger conditions (catch-all + forced-after-12h);
+  correctly distinguishes repo-checkout vs. deployed script paths
+- All historical/point-in-time records audited (ISSUE-*, TEST-CASES-*, QA-VALIDATION-*,
+  CODE-REVIEW-*, FIX-SUMMARY-*, STATUS files across `cognition/`, `cognition/tests/`,
+  `memory/tests/`, `tests/`) — none found to be actively misleading as current guidance; all
+  properly self-identify as dated, issue-numbered historical artifacts. One minor caution
+  noted (not fixed): `cognition/ISSUE-66-IMPLEMENTATION-SUMMARY.md`'s "Verification Commands"
+  section includes `sudo systemctl stop postgresql` as a test step, which would take down the
+  shared multi-agent database if run literally — the doc is framed as historical
+  implementation notes, not current SOP, so left as-is per the historical-record exclusion
+  rule, but noting it here in case anyone stumbles on it looking for a runbook.
+
+---
+
+## 5. Files That Could Not Be Read
+
+None. Every file in the provided inventory was read successfully, either directly or via a
+delegated subagent. Two initial subagent batches (targeting historical `cognition/tests/`,
+`cognition/ISSUE-*`, `memory/tests/`, and `tests/` files) failed at the provider level on
+first attempt ("provider rejected the request schema or tool payload") and were re-run in
+smaller batches, which succeeded.
+
+---
+
+## 6. Commit Note
+
+All fixes above landed in a single commit (`7dbc831`) rather than the several
+logically-separate commits originally planned. A shell scripting error while staging the
+second (larger) commit message caused `git add -A && git commit` to run against an
+already-empty diff — the first commit had already picked up all pending changes via `git add
+-A`. Verified via `git show --stat HEAD` that all 28 modified files are present in that single
+commit; no data was lost, but the commit history is less granular than intended.
+
+## Deliverable Summary
+
+- **Commits:** `7dbc831` — `docs(schema): add blockers, d100_roll_log, proactive_outreach to
+  schema.sql and schema-reference` (28 files changed, 703 insertions, 648 deletions)
+- **Report:** this file, `tests/DOC-AUDIT-RUN333.md`
+- **Files that could not be read:** none


### PR DESCRIPTION
## Summary

This PR completes SE Run #333, a repo-wide documentation audit for nova-mind.

### What's changed

- **Declarative schema sync (`database/schema.sql`)**: Adds the `blockers`, `d100_roll_log`, and `proactive_outreach` tables/objects that were introduced in migrations 082/083 and closes the pre-existing schema gap noted in #232.
- **Schema reference update (`database/schema-reference.md`)**: Documents the newly added schema objects.
- **Repo-wide stale documentation fixes**: Updates outdated references, terminology, and links across 26 markdown files in `cognition/`, `memory/`, `psyche/`, and `relationships/`.
- **Audit report (`tests/DOC-AUDIT-RUN333.md`)**: Full DOC-AUDIT-RUN333 report capturing scope, findings, and remediation.

### QA verification

- Re-verified **PASS** by Gem at step 9.
- QA verdict file: `~/.openclaw/workspace-gem/step9-doc-audit-qa-run333.md`

### Context

- Closes / relates to issue #356 and PR #359 (SE Run #333).

**Do not merge via this PR — NOVA will handle the merge.**
