### PR TITLE
fix(agent_chat): declare openclaw dependency and install before build

### DIFF
--- a/agent-install.sh
+++ b/agent-install.sh
@@ -1482,10 +1482,24 @@ if [ -d "$EXTENSION_SOURCE" ]; then
         fi
     fi
 
+    # Install extension dependencies
+    echo ""
+    echo "  Installing agent_chat extension dependencies..."
+    cd "$EXTENSION_TARGET"
+
+    NPM_INSTALL_LOG="${TMPDIR:-/tmp}/npm-install-agent-chat-$$.log"
+    if npm install >"$NPM_INSTALL_LOG" 2>&1; then
+        echo -e "  ${CHECK_MARK} Extension dependencies installed"
+        rm -f "$NPM_INSTALL_LOG"
+    else
+        echo -e "  ${CROSS_MARK} npm install failed for agent_chat"
+        tail -20 "$NPM_INSTALL_LOG"
+        exit 1
+    fi
+
     # Build TypeScript
     echo ""
     echo "  Building agent_chat TypeScript..."
-    cd "$EXTENSION_TARGET"
 
     NPM_BUILD_LOG="${TMPDIR:-/tmp}/npm-build-agent-chat-$$.log"
     if npm run build >"$NPM_BUILD_LOG" 2>&1; then

--- a/cognition/focus/agent_chat/package.json
+++ b/cognition/focus/agent_chat/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@types/node": "^22.0.0",
     "@types/pg": "^8.11.0",
+    "openclaw": "2026.2.9",
     "pg": "^8.11.3",
     "typescript": "^5.6.0",
     "zod": "^3.23.0"


### PR DESCRIPTION
Fixes #333

## Changes
- Add `openclaw` to `cognition/focus/agent_chat/package.json` so `openclaw/plugin-sdk` resolves during the TypeScript build.
- Update `agent-install.sh` to run `npm install` in the agent_chat extension target directory before `npm run build`.

## Verification
From a fresh scratch clone with no pre-existing `node_modules`:

```bash
cd cognition/focus/agent_chat
rm -rf node_modules package-lock.json dist
npm install
npm run build
```

Output:
```
> @nova-cognition/agent_chat@2.0.0 build
> tsc
```

Build completes with no errors.