### PR TITLE
Split agent_chat into dedicated database (Refs #320)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main, 'issue-*', 'feat/*', 'fix/*']
+  pull_request:
+    branches: [main]
+
+jobs:
+  shell-tests:
+    name: Shell / Installer Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install shellcheck and bats
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq shellcheck bats
+
+      - name: Syntax check agent-install.sh
+        run: bash -n agent-install.sh
+
+      - name: ShellCheck agent-install.sh
+        run: shellcheck agent-install.sh
+
+      - name: Run installer BATS tests
+        run: bats tests/install/test_agent_chat_installer.bats tests/install/test_agents_json_safety.bats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+### Batch: agent-chat-dedicated-db-320 (Issue #320)
+
+#### Added
+- **Dedicated `agent_chat` database** (#320) — `agent_chat` and `agent_chat_processed` (tables, `send_agent_message()`, triggers, views, grants) moved out of `nova_memory` into their own dedicated `agent_chat` PostgreSQL database, shared directly by all agents. Schema lives in `database/agent-chat/schema.sql`; table shapes and the `send_agent_message()`-only write path are unchanged by the move.
+- **Nested `postgres.json` section support** — `loadPgEnv()` (TypeScript, `lib/pg-env.ts`) and `load_pg_env()` (Python, `lib/pg_env.py`) both gained an optional `section` parameter so callers can resolve a named nested connection (e.g. `agent_chat`) alongside the existing flat top-level keys, with resolution order ENV → section → flat top-level → defaults. See `memory/docs/database-config.md`.
+- **`agent-install.sh` auto-provisioning** — the installer now idempotently writes/merges the nested `agent_chat` section of `~/.openclaw/postgres.json`, adds `.pgpass` entries for both `nova_memory` and `agent_chat` on `localhost`/`127.0.0.1`, and strips dead `database`/`host`/`port`/`user`/`password` connection keys from `channels.agent_chat` and `plugins.entries.agent_chat.config` (those keys are no longer read by the plugin).
+- **`pg-notify-listener.py` + systemd user service** — deployed by the installer to `~/.openclaw/workspace/scripts/` with a user-level systemd unit, using `pg_env.py` at `~/.openclaw/lib/pg_env.py` for its DSN resolution.
+- **`agent_chat` migration tooling** (`scripts/agent-chat-migration/`) — `migrate.sh`, `delta_check_and_migrate.py`, `pre_drop_gate_check.sh` (six-gate pre-decommission checklist), `decommission.sh`, and `audit_rollout.py` (rollout-status audit reporting which database each agent's config currently resolves to). Full runbook in `scripts/agent-chat-migration/README.md`.
+- **`proactive-gate-check.py` agent_chat DSN resolution** (commit `cf323da`) — Step 1 (unacknowledged `agent_chat` messages) now connects via `load_pg_env(section="agent_chat")` instead of the default `nova_memory` connection.
+
+#### Changed
+- Documentation across `cognition/`, `memory/`, `motivation/`, `scripts/`, `skills/`, and the repo-root `README.md`/`database/schema-reference.md` updated to reflect the dedicated-database model (see `~/.openclaw/workspace/se-runs/run-334-step9-docs-audit.md` for the full list). The `embed_chat_message()` trigger that auto-embedded new `agent_chat` rows into `memory_embeddings` was dropped as part of the migration (cross-database triggers aren't supported in plain PostgreSQL); new `agent_chat` messages are not currently auto-embedded for semantic recall — tracked as a known gap, not a design decision.
+- The pre-#320 cross-database logical-replication design for `agent_chat` (per-agent memory database ↔ per-agent memory database, e.g. `nova_memory` ↔ `graybeard_memory`) is superseded: all agents now connect to the single shared `agent_chat` database directly. `agent-install.sh` no longer configures or detects `agent_chat` replication.
+
+#### Fixed
+- **Installer ordering bug** (fix cycle `c5fa491`/tested in `4c812d3`) — an earlier version of the installer's `agent_chat` postgres.json provisioning and listener deployment ran *after* an early exit in the `agent_chat` extension build step, so on some install paths the provisioning never executed. Fixed by moving provisioning/deployment before the extension build's early-exit paths; covered by new BATS tests for idempotency and listener deployment.
+- **`lib/pg-env.ts` strict-TypeScript compile failure (#377)** — the section-key loader introduced for #320 failed to compile under the project's `strict` TypeScript settings (TS7053 implicit-any index access) when resolving `PgConnectionConfig`; masked in earlier verification because a stale prebuilt `dist/` was being reused instead of a clean build. Fixed on this branch.
+
+#### Known Issues (open, not yet resolved on this branch)
+- **#375** — `pre_drop_gate_check.sh` Gate 4's delta check only detects *new* unmigrated `agent_chat_processed` rows, not rows updated after migration on already-migrated chat_ids; disagrees with `delta_check_and_migrate.py`'s two-part logic. Blocks trusting the decommission runbook for a live cutover; does not block merge or staging testing.
+- **#379** — `agent-install.sh`'s `systemctl --user enable --now pg-notify-listener.service` step silently degrades to a warning when the installer is run under `sudo` (no D-Bus user session for the target user), leaving the listener deployed but not running. Documented as a post-install manual-verification step in `scripts/agent-chat-migration/README.md`. Workaround: run `systemctl --user enable --now pg-notify-listener.service` as the target user after install.
+- Deferred to live cutover (not yet actioned): #376 Gate 5 dependency logic, peer-credential independence, and an incomplete gateway plugin-load investigation (TC-38, possibly related to the #377 stale-`dist/` issue above).
+
+---
+
 ### Batch: blocker-outreach-356 (Issues #356, #358)
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ nova-mind is the complete agent mind stack for NOVA. It provides:
 - **Psyche** — Agent self-awareness design: core values, agent-chat architecture, entity/user identity models, and identification protocols
 - **Motivation** — Drive assignment, goal tracking, reward signals, and proactive mode orchestration for agent initiative
 
-All five subsystems share a single PostgreSQL database (`{username}_memory`) and a unified installer.
+All five subsystems share a single PostgreSQL database (`{username}_memory`) and a unified installer. **Exception (nova-mind#320):** inter-agent messaging (`agent_chat`/`agent_chat_processed`) was moved out of `{username}_memory` into its own dedicated `agent_chat` database, shared across agents, to remove the per-agent replication that previously kept messaging in sync across separate memory databases. Agents resolve the `agent_chat` connection via a nested section of `~/.openclaw/postgres.json` rather than the flat top-level keys used for `{username}_memory`. See `memory/docs/database-config.md` and `scripts/agent-chat-migration/README.md` for details.
 
 ### Memory Maintenance
 

--- a/agent-install.sh
+++ b/agent-install.sh
@@ -23,11 +23,13 @@ WARNING="${YELLOW}⚠️${NC}"
 INFO="${BLUE}ℹ️${NC}"
 
 # Verification results
+# shellcheck disable=SC2034
 VERIFICATION_PASSED=0
 VERIFICATION_WARNINGS=0
 VERIFICATION_ERRORS=0
 
 # Track if gateway restart is needed
+# shellcheck disable=SC2034
 GATEWAY_RESTART_NEEDED=0
 
 # Temp file cleanup
@@ -43,6 +45,7 @@ if [ ! -f "$PG_ENV" ]; then
     echo -e "  ${RED}❌${NC} $PG_ENV not found"
     exit 1
 fi
+# shellcheck disable=SC1090,SC1091
 source "$PG_ENV"
 
 # ============================================
@@ -71,8 +74,10 @@ PGPASS_FILE="${HOME}/.pgpass"
 
 WORKSPACE="${OPENCLAW_WORKSPACE:-$HOME/.openclaw/workspace-coder}"
 OPENCLAW_DIR="$HOME/.openclaw"
+# shellcheck disable=SC2034
 OPENCLAW_PROJECTS="$OPENCLAW_DIR/projects"
 EXTENSIONS_DIR="$OPENCLAW_DIR/extensions"
+# shellcheck disable=SC2034
 NOVA_DIR="$HOME/.local/share/nova"
 
 # Superuser connection helper for DDL operations
@@ -317,7 +322,8 @@ fi
 if [ $VERIFY_ONLY -eq 0 ]; then
     if command -v node &>/dev/null; then
         NODE_VERSION=$(node --version)
-        NODE_MAJOR=$(echo "$NODE_VERSION" | sed 's/v\([0-9]*\).*/\1/')
+        NODE_VERSION_NO_V="${NODE_VERSION#v}"
+        NODE_MAJOR="${NODE_VERSION_NO_V%%.*}"
         if [ "$NODE_MAJOR" -ge 18 ]; then
             echo -e "  ${CHECK_MARK} Node.js installed ($NODE_VERSION)"
         else
@@ -550,7 +556,7 @@ install_skills() {
             else
                 local needs_update=0
                 while IFS= read -r -d '' source_file; do
-                    local rel_path="${source_file#$skill_dir}"
+                    local rel_path="${source_file#"$skill_dir"}"
                     local target_file="$target_skill/$rel_path"
                     if [ ! -f "$target_file" ]; then
                         needs_update=1; break
@@ -1008,6 +1014,7 @@ fi
 RENAMES_FILE="$SCRIPT_DIR/memory/database/renames.json"
 if [ -f "$RENAMES_FILE" ]; then
     echo "  Processing renames.json (Step 1.5)..."
+    # shellcheck disable=SC2034
     RENAME_COUNT=$(jq '[.renames[] | select(.column.from? != null)] | length' "$RENAMES_FILE" 2>/dev/null || echo "0")
     APPLIED=0
     SKIPPED=0
@@ -1564,6 +1571,7 @@ if [ -d "$EXTENSION_SOURCE" ]; then
         exit 1
     fi
 
+    # shellcheck disable=SC2015
     [ -f "dist/index.js" ] && echo -e "  ${CHECK_MARK} Build output verified: dist/index.js" || \
         { echo -e "  ${CROSS_MARK} Build output not found"; exit 1; }
 
@@ -1592,6 +1600,7 @@ for old_hook in "semantic-recall" "agent-turn-context"; do
     if [ -d "$OLD_HOOK_DIR" ]; then
         rm -rf "$OLD_HOOK_DIR"
         echo -e "  ${CHECK_MARK} Removed old hook: $old_hook"
+        # shellcheck disable=SC2034
         GATEWAY_RESTART_NEEDED=1
     fi
 done
@@ -1696,7 +1705,7 @@ install_metacognition_plugin() {
     for f in package.json openclaw.plugin.json tsconfig.json src; do
         if [ -e "$plugin_source/$f" ]; then
             if [ -d "$plugin_source/$f" ]; then
-                rm -rf "$plugin_target/$f"
+                rm -rf "${plugin_target:?}/$f"
                 cp -r "$plugin_source/$f" "$plugin_target/$f"
             else
                 cp "$plugin_source/$f" "$plugin_target/$f"
@@ -1709,7 +1718,7 @@ install_metacognition_plugin() {
     cd "$plugin_target"
     if [ ! -d "node_modules" ] || [ "$FORCE_INSTALL" -eq 1 ]; then
         echo "    Installing dependencies..."
-        NPM_INSTALL_LOG=$(mktemp /tmp/npm-install-${plugin_name}-XXXXXX.log)
+        NPM_INSTALL_LOG=$(mktemp "/tmp/npm-install-${plugin_name}-XXXXXX.log")
         TMPFILES+=("$NPM_INSTALL_LOG")
         if npm install >"$NPM_INSTALL_LOG" 2>&1; then
             echo -e "    ${CHECK_MARK} Dependencies installed"
@@ -1723,7 +1732,7 @@ install_metacognition_plugin() {
     # Build TypeScript
     if [ -d "$plugin_target/src" ]; then
         echo "    Building TypeScript..."
-        BUILD_LOG=$(mktemp /tmp/build-${plugin_name}-XXXXXX.log)
+        BUILD_LOG=$(mktemp "/tmp/build-${plugin_name}-XXXXXX.log")
         TMPFILES+=("$BUILD_LOG")
         if npx tsc >"$BUILD_LOG" 2>&1; then
             echo -e "    ${CHECK_MARK} Build completed"
@@ -1995,6 +2004,7 @@ if [ -d "$AGENT_CONFIG_SYNC_SOURCE" ]; then
         if AGENTS_DATA=$(psql -U "$DB_USER" -d "$DB_NAME" -tAc "$INITIAL_SYNC_QUERY" 2>/dev/null); then
             if [ -n "$AGENTS_DATA" ] && [ "$AGENTS_DATA" != "null" ] && [ "$AGENTS_DATA" != "" ]; then
                 if echo "$AGENTS_DATA" | jq '.' >"$AGENTS_JSON_TMP" 2>/dev/null; then
+                    # shellcheck disable=SC2015
                     mv "$AGENTS_JSON_TMP" "$AGENTS_JSON" && \
                         echo -e "  ${CHECK_MARK} Generated agents.json from DB" || \
                         { echo -e "  ${WARNING} Could not write agents.json"; rm -f "$AGENTS_JSON_TMP"; return 1; }
@@ -2056,11 +2066,62 @@ else
     echo -e "  ${WARNING} cognition/focus/agent-config-sync not found (skipping)"
 fi
 
+# --- PostgreSQL NOTIFY listener ---
+# Local listener that reacts to postgres channels (schema_changed, gambling_changed,
+# etc.). Runs as a systemd --user service under the installing unix account so it
+# authenticates with that account's DB role. Issue: nova-mind #320 / #251.
+echo ""
+echo "PostgreSQL NOTIFY listener..."
+
+NOTIFY_LISTENER_SOURCE="$SCRIPT_DIR/cognition/scripts/pg-notify-listener.py"
+NOTIFY_LISTENER_SERVICE_SOURCE="$SCRIPT_DIR/cognition/systemd/pg-notify-listener.service"
+# Intentionally uses the canonical workspace path (not $WORKSPACE) because the
+# live listener has always lived at ~/.openclaw/workspace/scripts and the
+# service file is shared across peer agents with different WORKSPACE values.
+NOTIFY_LISTENER_DIR="$HOME/.openclaw/workspace/scripts"
+NOTIFY_LISTENER_SERVICE_DIR="$HOME/.config/systemd/user"
+NOTIFY_LISTENER_SERVICE_TARGET="$NOTIFY_LISTENER_SERVICE_DIR/pg-notify-listener.service"
+
+if [ -f "$NOTIFY_LISTENER_SOURCE" ] && [ -f "$NOTIFY_LISTENER_SERVICE_SOURCE" ]; then
+    mkdir -p "$NOTIFY_LISTENER_DIR"
+    mkdir -p "$NOTIFY_LISTENER_SERVICE_DIR"
+    mkdir -p "$HOME/.openclaw/workspace/logs"
+
+    cp "$NOTIFY_LISTENER_SOURCE" "$NOTIFY_LISTENER_DIR/pg-notify-listener.py"
+    chmod +x "$NOTIFY_LISTENER_DIR/pg-notify-listener.py"
+    echo -e "  ${CHECK_MARK} Installed pg-notify-listener.py → $NOTIFY_LISTENER_DIR"
+
+    cp "$NOTIFY_LISTENER_SERVICE_SOURCE" "$NOTIFY_LISTENER_SERVICE_TARGET"
+    echo -e "  ${CHECK_MARK} Installed pg-notify-listener.service → $NOTIFY_LISTENER_SERVICE_DIR"
+
+    if command -v systemctl &>/dev/null; then
+        systemctl --user daemon-reload
+        if systemctl --user is-active pg-notify-listener.service &>/dev/null; then
+            if systemctl --user restart pg-notify-listener.service; then
+                echo -e "  ${CHECK_MARK} Restarted pg-notify-listener.service"
+            else
+                echo -e "  ${WARNING} pg-notify-listener.service restart failed"
+            fi
+        else
+            if systemctl --user enable pg-notify-listener.service &>/dev/null && \
+               systemctl --user start pg-notify-listener.service; then
+                echo -e "  ${CHECK_MARK} Enabled and started pg-notify-listener.service"
+            else
+                echo -e "  ${WARNING} pg-notify-listener.service enable/start failed"
+            fi
+        fi
+    else
+        echo -e "  ${WARNING} systemctl not available — service not started"
+    fi
+else
+    echo -e "  ${WARNING} pg-notify-listener source files not found (skipping)"
+fi
+
 # --- Ensure agent_system_config table ---
 echo ""
 echo "  Ensuring agent_system_config table..."
 
-psql -U "$DB_USER" -d "$DB_NAME" -q <<'SYSTEM_CONFIG_TABLE_SQL'
+if psql -U "$DB_USER" -d "$DB_NAME" -q <<'SYSTEM_CONFIG_TABLE_SQL'
 CREATE TABLE IF NOT EXISTS agent_system_config (
     key        TEXT PRIMARY KEY,
     value      TEXT NOT NULL,
@@ -2069,9 +2130,11 @@ CREATE TABLE IF NOT EXISTS agent_system_config (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 SYSTEM_CONFIG_TABLE_SQL
-
-[ $? -eq 0 ] && echo -e "  ${CHECK_MARK} agent_system_config table ready" || \
+then
+    echo -e "  ${CHECK_MARK} agent_system_config table ready"
+else
     echo -e "  ${WARNING} Could not ensure agent_system_config table"
+fi
 
 # --- System config notification trigger ---
 echo "  Installing system config notification trigger..."
@@ -2088,7 +2151,7 @@ if [ -f "$SYSTEM_CONFIG_MIGRATION" ]; then
         rm -f "$MIGRATION_ERR"
     fi
 else
-    psql -U "$DB_USER" -d "$DB_NAME" -q <<'INLINE_MIGRATION_SQL'
+    if psql -U "$DB_USER" -d "$DB_NAME" -q <<'INLINE_MIGRATION_SQL'
 CREATE OR REPLACE FUNCTION notify_system_config_changed()
 RETURNS trigger AS $$
 BEGIN
@@ -2112,14 +2175,17 @@ INSERT INTO agent_system_config (key, value, value_type)
 VALUES ('max_spawn_depth', '5', 'integer')
 ON CONFLICT (key) DO NOTHING;
 INLINE_MIGRATION_SQL
-    [ $? -eq 0 ] && echo -e "  ${CHECK_MARK} System config trigger installed (inline)" || \
+    then
+        echo -e "  ${CHECK_MARK} System config trigger installed (inline)"
+    else
         echo -e "  ${WARNING} Inline migration had issues"
+    fi
 fi
 
 # --- agent config notification trigger ---
 echo "  Installing agent config notification trigger..."
 
-psql -U "$DB_USER" -d "$DB_NAME" -q <<'TRIGGER_SQL'
+if psql -U "$DB_USER" -d "$DB_NAME" -q <<'TRIGGER_SQL'
 CREATE OR REPLACE FUNCTION notify_agent_config_changed()
 RETURNS trigger AS $$
 BEGIN
@@ -2137,9 +2203,11 @@ CREATE TRIGGER agent_config_changed
     AFTER INSERT OR UPDATE OR DELETE ON agents
     FOR EACH ROW EXECUTE FUNCTION notify_agent_config_changed();
 TRIGGER_SQL
-
-[ $? -eq 0 ] && echo -e "  ${CHECK_MARK} Agent config notification trigger installed" || \
+then
+    echo -e "  ${CHECK_MARK} Agent config notification trigger installed"
+else
     echo -e "  ${CROSS_MARK} Failed to install agent config notification trigger"
+fi
 
 # --- Shell environment setup (cognition dotfiles) ---
 echo ""
@@ -2176,6 +2244,7 @@ else
 fi
 
 if [ -f "$BASH_ENV_SOURCE" ]; then
+    # shellcheck disable=SC2088
     if [ -f "$BASH_ENV_FILE" ] && grep -qF '~/.local/share/nova/shell-aliases.sh' "$BASH_ENV_FILE"; then
         echo -e "  ${CHECK_MARK} ~/.bash_env already sources shell-aliases.sh"
     else

--- a/agent-install.sh
+++ b/agent-install.sh
@@ -64,6 +64,11 @@ fi
 # Derived variables
 DB_USER="${PGUSER:-$(whoami)}"
 DB_NAME="${PGDATABASE:-${DB_USER//-/_}_memory}"
+AGENT_CHAT_DB_NAME="agent_chat"
+
+# PostgreSQL password file path
+PGPASS_FILE="${HOME}/.pgpass"
+
 WORKSPACE="${OPENCLAW_WORKSPACE:-$HOME/.openclaw/workspace-coder}"
 OPENCLAW_DIR="$HOME/.openclaw"
 OPENCLAW_PROJECTS="$OPENCLAW_DIR/projects"
@@ -103,6 +108,72 @@ _superuser_pgschema() {
     else
         sudo -u "$PG_SUPERUSER" "$PGSCHEMA_BIN" "$@"
     fi
+}
+
+# Ensure a ~/.pgpass entry exists for a given connection.
+# Removes any existing entry with the same host:port:database:user prefix
+# and appends the current password, so re-runs are idempotent and password
+# rotations are picked up.
+_ensure_pgpass_entry() {
+    local host="$1"
+    local port="$2"
+    local database="$3"
+    local user="$4"
+    local password="$5"
+    local pgpass="$PGPASS_FILE"
+    local prefix="${host}:${port}:${database}:${user}:"
+    local line="${prefix}${password}"
+
+    if [ ! -f "$pgpass" ]; then
+        touch "$pgpass"
+        chmod 600 "$pgpass"
+    fi
+
+    # Already correct? Nothing to do.
+    if grep -qxF "$line" "$pgpass" 2>/dev/null; then
+        return 1
+    fi
+
+    local tmpfile
+    tmpfile=$(mktemp)
+    TMPFILES+=("$tmpfile")
+    chmod 600 "$tmpfile"
+    # Drop any stale entry with the same prefix, then append the new one.
+    if [ -s "$pgpass" ]; then
+        grep -vF "$prefix" "$pgpass" >"$tmpfile" 2>/dev/null || cat "$pgpass" >"$tmpfile"
+    fi
+    printf '%s\n' "$line" >>"$tmpfile"
+    mv "$tmpfile" "$pgpass"
+    chmod 600 "$pgpass"
+    return 0
+}
+
+# Write the nested agent_chat section to ~/.openclaw/postgres.json.
+# Host/port fall back to the flat keys at runtime, so only database/user/password
+# are written in the nested block.
+_ensure_agent_chat_postgres_json() {
+    local pg_config="$1"
+    local database="$2"
+    local user="$3"
+    local password="$4"
+
+    if [ ! -f "$pg_config" ] || ! command -v jq &>/dev/null; then
+        return 1
+    fi
+
+    local already_correct
+    already_correct=$(jq --arg db "$database" --arg user "$user" --arg pass "$password" \
+        '(.agent_chat // {}) | {database, user, password} == {database: $db, user: $user, password: $pass}' \
+        "$pg_config" 2>/dev/null || echo "false")
+    if [ "$already_correct" = "true" ]; then
+        return 1
+    fi
+
+    jq --arg db "$database" --arg user "$user" --arg pass "$password" \
+        '.agent_chat = {"database": $db, "user": $user, "password": $pass}' \
+        "$pg_config" >"${pg_config}.tmp" && \
+        mv "${pg_config}.tmp" "$pg_config" && \
+        chmod 600 "$pg_config"
 }
 
 echo "  Agent DB user: $DB_USER"
@@ -629,17 +700,25 @@ verify_cognition() {
         VERIFICATION_ERRORS=$((VERIFICATION_ERRORS + 1))
     fi
 
-    local required_tables=("agent_chat" "agent_chat_processed")
-    for table in "${required_tables[@]}"; do
-        local TABLE_EXISTS
-        TABLE_EXISTS=$(psql -U "$DB_USER" -d "$DB_NAME" -tAc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = '$table'" | tr -d '[:space:]')
-        if [ "$TABLE_EXISTS" -eq 0 ]; then
-            echo -e "  ${WARNING} Table '$table' not yet created (will be created by extension)"
-            VERIFICATION_WARNINGS=$((VERIFICATION_WARNINGS + 1))
-        else
-            echo -e "  ${CHECK_MARK} Table '$table' exists"
-        fi
-    done
+    # agent_chat tables live in the dedicated agent_chat DB, not the memory DB.
+    local agent_chat_db
+    agent_chat_db=$(jq -r '.agent_chat.database // "agent_chat"' "$PG_CONFIG" 2>/dev/null || echo "agent_chat")
+    if psql -U "$DB_USER" -d "$agent_chat_db" -c '\q' >/dev/null 2>&1; then
+        local required_tables=("agent_chat" "agent_chat_processed")
+        for table in "${required_tables[@]}"; do
+            local TABLE_EXISTS
+            TABLE_EXISTS=$(psql -U "$DB_USER" -d "$agent_chat_db" -tAc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = '$table'" | tr -d '[:space:]')
+            if [ "$TABLE_EXISTS" -eq 0 ]; then
+                echo -e "  ${WARNING} Table '$table' not yet created in '$agent_chat_db'"
+                VERIFICATION_WARNINGS=$((VERIFICATION_WARNINGS + 1))
+            else
+                echo -e "  ${CHECK_MARK} Table '$table' exists in '$agent_chat_db'"
+            fi
+        done
+    else
+        echo -e "  ${WARNING} Cannot verify agent_chat tables (database '$agent_chat_db' unreachable)"
+        VERIFICATION_WARNINGS=$((VERIFICATION_WARNINGS + 1))
+    fi
 }
 
 verify_config() {
@@ -1415,26 +1494,14 @@ else
 fi
 
 # --- agent_chat runtime configuration ---
-# Schema is managed by pgschema via database/schema.sql
-# This section only configures triggers for logical replication
+# The agent_chat messaging bus now lives in a dedicated `agent_chat` database.
+# Schema/objects for that database are managed by database/agent-chat/schema.sql
+# and applied by scripts/agent-chat-migration/migrate.sh, not by this installer.
+# Logical replication for agent_chat (#64/#67) was superseded by the shared-DB
+# design and is no longer configured here.
 echo ""
 echo "Agent chat schema..."
-
-# Configure triggers for logical replication if subscriptions exist
-echo "  Checking for logical replication subscriptions..."
-SUBSCRIPTION_COUNT=$(psql -U "$DB_USER" -d "$DB_NAME" -tAc "SELECT COUNT(*) FROM pg_subscription WHERE subname LIKE '%agent_chat%'" 2>/dev/null || echo "0")
-
-if [ "$SUBSCRIPTION_COUNT" -gt 0 ]; then
-    echo -e "  ${CHECK_MARK} Found $SUBSCRIPTION_COUNT agent_chat subscription(s)"
-    psql -U "$DB_USER" -d "$DB_NAME" -c "ALTER TABLE agent_chat ENABLE ALWAYS TRIGGER trg_notify_agent_chat;" >/dev/null 2>&1 && \
-        echo -e "  ${CHECK_MARK} Notification trigger configured (ALWAYS)" || \
-        echo -e "  ${WARNING} Failed to configure notification trigger"
-    psql -U "$DB_USER" -d "$DB_NAME" -c "ALTER TABLE agent_chat DISABLE TRIGGER trg_embed_chat_message;" >/dev/null 2>&1 && \
-        echo -e "  ${CHECK_MARK} Embedding trigger DISABLED (source-only embeddings)" || \
-        echo -e "  ${WARNING} Failed to configure embedding trigger"
-else
-    echo "  No agent_chat subscriptions found — using default trigger configuration"
-fi
+echo -e "  ${INFO} agent_chat bus is a dedicated database; trigger/schema config lives in database/agent-chat/schema.sql"
 
 # --- agent_chat extension ---
 echo ""
@@ -2137,47 +2204,50 @@ if [ -f "$OPENCLAW_CONFIG" ] && command -v jq &>/dev/null; then
     fi
 fi
 
+# --- Configure PostgreSQL password file and agent_chat DB config ---
+echo ""
+echo "PostgreSQL password file and agent_chat DB config..."
+
+if [ -n "${PGPASSWORD:-}" ]; then
+    pgpass_changed=0
+    _ensure_pgpass_entry "localhost" "5432" "$DB_NAME" "$DB_USER" "$PGPASSWORD" && pgpass_changed=1
+    _ensure_pgpass_entry "127.0.0.1" "5432" "$DB_NAME" "$DB_USER" "$PGPASSWORD" && pgpass_changed=1
+    _ensure_pgpass_entry "localhost" "5432" "$AGENT_CHAT_DB_NAME" "$DB_USER" "$PGPASSWORD" && pgpass_changed=1
+    _ensure_pgpass_entry "127.0.0.1" "5432" "$AGENT_CHAT_DB_NAME" "$DB_USER" "$PGPASSWORD" && pgpass_changed=1
+    if [ "$pgpass_changed" -eq 1 ]; then
+        echo -e "  ${CHECK_MARK} Updated ~/.pgpass with memory and agent_chat DB entries"
+    else
+        echo -e "  ${CHECK_MARK} ~/.pgpass entries already correct"
+    fi
+else
+    echo -e "  ${WARNING} PGPASSWORD not set — skipping ~/.pgpass provisioning"
+fi
+
+if _ensure_agent_chat_postgres_json "$PG_CONFIG" "$AGENT_CHAT_DB_NAME" "$DB_USER" "${PGPASSWORD:-}"; then
+    echo -e "  ${CHECK_MARK} Wrote nested agent_chat section to $PG_CONFIG"
+else
+    echo -e "  ${CHECK_MARK} Nested agent_chat section already correct in $PG_CONFIG (or could not update)"
+fi
+
 # --- Configure agent_chat channel ---
 echo ""
 echo "Configuring agent_chat channel..."
 
 OPENCLAW_CONFIG="$OPENCLAW_DIR/openclaw.json"
 if [ -f "$OPENCLAW_CONFIG" ] && command -v jq &>/dev/null; then
-    # Read DB password from postgres.json (may be empty for peer auth)
-    AGENT_CHAT_PASSWORD=""
-    if [ -f "$PG_CONFIG" ]; then
-        AGENT_CHAT_PASSWORD=$(jq -r '.password // empty' "$PG_CONFIG" 2>/dev/null || true)
-    fi
-
-    jq --arg db "$DB_NAME" --arg user "$DB_USER" --arg pass "$AGENT_CHAT_PASSWORD" \
-        '.channels.agent_chat = (.channels.agent_chat // {}) * {
-            "enabled": true,
-            "database": $db,
-            "host": "localhost",
-            "port": 5432,
-            "user": $user,
-            "password": $pass
-        }' \
+    # The plugin now resolves agent_chat DB credentials from ~/.openclaw/postgres.json.
+    # Keep only the operational keys here; drop the dead connection keys that the
+    # installer used to write (and that agent_config_sync could otherwise misread).
+    jq '.channels.agent_chat |= ((. // {}) | del(.database, .host, .port, .user, .password) + {"enabled": true})' \
         "$OPENCLAW_CONFIG" >"$OPENCLAW_CONFIG.tmp" && \
         mv "$OPENCLAW_CONFIG.tmp" "$OPENCLAW_CONFIG" && \
-        echo -e "  ${CHECK_MARK} Configured channels.agent_chat (db=$DB_NAME, user=$DB_USER)" || \
+        echo -e "  ${CHECK_MARK} Configured channels.agent_chat (connection keys removed, enabled=true)" || \
         echo -e "  ${WARNING} Could not configure agent_chat channel"
 
-    jq --arg db "$DB_NAME" --arg user "$DB_USER" --arg pass "$AGENT_CHAT_PASSWORD" \
-        '.plugins.entries.agent_chat = (.plugins.entries.agent_chat // {}) * {
-            "enabled": true,
-            "config": ((.plugins.entries.agent_chat.config // {}) * {
-                "database": $db,
-                "host": "localhost",
-                "port": 5432,
-                "user": $user,
-                "password": $pass,
-                "routeToSession": "main"
-            })
-        }' \
+    jq '.plugins.entries.agent_chat |= (. + {"enabled": true} | .config |= ((. // {}) | del(.database, .host, .port, .user, .password) + {"routeToSession": "main"}))' \
         "$OPENCLAW_CONFIG" >"$OPENCLAW_CONFIG.tmp" && \
         mv "$OPENCLAW_CONFIG.tmp" "$OPENCLAW_CONFIG" && \
-        echo -e "  ${CHECK_MARK} Configured plugins.entries.agent_chat (db=$DB_NAME, user=$DB_USER)" || \
+        echo -e "  ${CHECK_MARK} Configured plugins.entries.agent_chat (connection keys removed, routeToSession=main)" || \
         echo -e "  ${WARNING} Could not configure agent_chat plugin"
 else
     echo -e "  ${WARNING} Cannot configure agent_chat (missing config or jq)"

--- a/agent-install.sh
+++ b/agent-install.sh
@@ -155,7 +155,10 @@ _ensure_pgpass_entry() {
 
 # Write the nested agent_chat section to ~/.openclaw/postgres.json.
 # Host/port fall back to the flat keys at runtime, so only database/user/password
-# are written in the nested block.
+# are written in the nested block.  Idempotent: if the section already exists as
+# an object, missing keys are merged in and existing keys are preserved (no
+# clobber).  If it is missing or not an object, the section is created from the
+# supplied values.
 _ensure_agent_chat_postgres_json() {
     local pg_config="$1"
     local database="$2"
@@ -166,19 +169,72 @@ _ensure_agent_chat_postgres_json() {
         return 1
     fi
 
-    local already_correct
-    already_correct=$(jq --arg db "$database" --arg user "$user" --arg pass "$password" \
-        '(.agent_chat // {}) | {database, user, password} == {database: $db, user: $user, password: $pass}' \
-        "$pg_config" 2>/dev/null || echo "false")
-    if [ "$already_correct" = "true" ]; then
+    local new_json
+    new_json=$(jq --arg db "$database" --arg user "$user" --arg pass "$password" \
+        'if (.agent_chat // null) | type == "object" then
+            .agent_chat |= . + {
+                database: (.database // $db),
+                user: (.user // $user),
+                password: (.password // $pass)
+            }
+         else
+            .agent_chat = {"database": $db, "user": $user, "password": $pass}
+         end' "$pg_config" 2>/dev/null) || return 1
+
+    # Only write if something changed.
+    if [ "$(printf '%s\n' "$new_json" | jq -Sc .)" = "$(jq -Sc . < "$pg_config")" ]; then
         return 1
     fi
 
-    jq --arg db "$database" --arg user "$user" --arg pass "$password" \
-        '.agent_chat = {"database": $db, "user": $user, "password": $pass}' \
-        "$pg_config" >"${pg_config}.tmp" && \
+    printf '%s\n' "$new_json" >"${pg_config}.tmp" && \
         mv "${pg_config}.tmp" "$pg_config" && \
         chmod 600 "$pg_config"
+}
+
+# Install the PostgreSQL NOTIFY listener as a systemd --user service.
+# Parameters: source_script source_service target_dir service_dir logs_dir
+_install_pg_notify_listener() {
+    local source_script="$1"
+    local source_service="$2"
+    local target_dir="$3"
+    local service_dir="$4"
+    local logs_dir="$5"
+
+    if [ ! -f "$source_script" ] || [ ! -f "$source_service" ]; then
+        echo -e "  ${WARNING} pg-notify-listener source files not found (skipping)"
+        return 1
+    fi
+
+    mkdir -p "$target_dir"
+    mkdir -p "$service_dir"
+    mkdir -p "$logs_dir"
+
+    cp "$source_script" "$target_dir/pg-notify-listener.py"
+    chmod +x "$target_dir/pg-notify-listener.py"
+    echo -e "  ${CHECK_MARK} Installed pg-notify-listener.py → $target_dir"
+
+    cp "$source_service" "$service_dir/pg-notify-listener.service"
+    echo -e "  ${CHECK_MARK} Installed pg-notify-listener.service → $service_dir"
+
+    if command -v systemctl &>/dev/null; then
+        systemctl --user daemon-reload
+        if systemctl --user is-active pg-notify-listener.service &>/dev/null; then
+            if systemctl --user restart pg-notify-listener.service; then
+                echo -e "  ${CHECK_MARK} Restarted pg-notify-listener.service"
+            else
+                echo -e "  ${WARNING} pg-notify-listener.service restart failed"
+            fi
+        else
+            if systemctl --user enable pg-notify-listener.service &>/dev/null && \
+               systemctl --user start pg-notify-listener.service; then
+                echo -e "  ${CHECK_MARK} Enabled and started pg-notify-listener.service"
+            else
+                echo -e "  ${WARNING} pg-notify-listener.service enable/start failed"
+            fi
+        fi
+    else
+        echo -e "  ${WARNING} systemctl not available — service not started"
+    fi
 }
 
 echo "  Agent DB user: $DB_USER"
@@ -1510,6 +1566,45 @@ echo ""
 echo "Agent chat schema..."
 echo -e "  ${INFO} agent_chat bus is a dedicated database; trigger/schema config lives in database/agent-chat/schema.sql"
 
+# --- Configure PostgreSQL password file and agent_chat DB config ---
+echo ""
+echo "PostgreSQL password file and agent_chat DB config..."
+
+if [ -n "${PGPASSWORD:-}" ]; then
+    pgpass_changed=0
+    _ensure_pgpass_entry "localhost" "5432" "$DB_NAME" "$DB_USER" "$PGPASSWORD" && pgpass_changed=1
+    _ensure_pgpass_entry "127.0.0.1" "5432" "$DB_NAME" "$DB_USER" "$PGPASSWORD" && pgpass_changed=1
+    _ensure_pgpass_entry "localhost" "5432" "$AGENT_CHAT_DB_NAME" "$DB_USER" "$PGPASSWORD" && pgpass_changed=1
+    _ensure_pgpass_entry "127.0.0.1" "5432" "$AGENT_CHAT_DB_NAME" "$DB_USER" "$PGPASSWORD" && pgpass_changed=1
+    if [ "$pgpass_changed" -eq 1 ]; then
+        echo -e "  ${CHECK_MARK} Updated ~/.pgpass with memory and agent_chat DB entries"
+    else
+        echo -e "  ${CHECK_MARK} ~/.pgpass entries already correct"
+    fi
+else
+    echo -e "  ${WARNING} PGPASSWORD not set — skipping ~/.pgpass provisioning"
+fi
+
+if _ensure_agent_chat_postgres_json "$PG_CONFIG" "$AGENT_CHAT_DB_NAME" "$DB_USER" "${PGPASSWORD:-}"; then
+    echo -e "  ${CHECK_MARK} Wrote nested agent_chat section to $PG_CONFIG"
+else
+    echo -e "  ${CHECK_MARK} Nested agent_chat section already correct in $PG_CONFIG (or could not update)"
+fi
+
+# --- PostgreSQL NOTIFY listener ---
+# Local listener that reacts to postgres channels (schema_changed, gambling_changed,
+# etc.). Runs as a systemd --user service under the installing unix account so it
+# authenticates with that account's DB role. Issue: nova-mind #320 / #251.
+echo ""
+echo "PostgreSQL NOTIFY listener..."
+
+_install_pg_notify_listener \
+    "$SCRIPT_DIR/cognition/scripts/pg-notify-listener.py" \
+    "$SCRIPT_DIR/cognition/systemd/pg-notify-listener.service" \
+    "$HOME/.openclaw/workspace/scripts" \
+    "$HOME/.config/systemd/user" \
+    "$HOME/.openclaw/workspace/logs"
+
 # --- agent_chat extension ---
 echo ""
 echo "Agent Chat extension installation..."
@@ -2066,57 +2161,6 @@ else
     echo -e "  ${WARNING} cognition/focus/agent-config-sync not found (skipping)"
 fi
 
-# --- PostgreSQL NOTIFY listener ---
-# Local listener that reacts to postgres channels (schema_changed, gambling_changed,
-# etc.). Runs as a systemd --user service under the installing unix account so it
-# authenticates with that account's DB role. Issue: nova-mind #320 / #251.
-echo ""
-echo "PostgreSQL NOTIFY listener..."
-
-NOTIFY_LISTENER_SOURCE="$SCRIPT_DIR/cognition/scripts/pg-notify-listener.py"
-NOTIFY_LISTENER_SERVICE_SOURCE="$SCRIPT_DIR/cognition/systemd/pg-notify-listener.service"
-# Intentionally uses the canonical workspace path (not $WORKSPACE) because the
-# live listener has always lived at ~/.openclaw/workspace/scripts and the
-# service file is shared across peer agents with different WORKSPACE values.
-NOTIFY_LISTENER_DIR="$HOME/.openclaw/workspace/scripts"
-NOTIFY_LISTENER_SERVICE_DIR="$HOME/.config/systemd/user"
-NOTIFY_LISTENER_SERVICE_TARGET="$NOTIFY_LISTENER_SERVICE_DIR/pg-notify-listener.service"
-
-if [ -f "$NOTIFY_LISTENER_SOURCE" ] && [ -f "$NOTIFY_LISTENER_SERVICE_SOURCE" ]; then
-    mkdir -p "$NOTIFY_LISTENER_DIR"
-    mkdir -p "$NOTIFY_LISTENER_SERVICE_DIR"
-    mkdir -p "$HOME/.openclaw/workspace/logs"
-
-    cp "$NOTIFY_LISTENER_SOURCE" "$NOTIFY_LISTENER_DIR/pg-notify-listener.py"
-    chmod +x "$NOTIFY_LISTENER_DIR/pg-notify-listener.py"
-    echo -e "  ${CHECK_MARK} Installed pg-notify-listener.py → $NOTIFY_LISTENER_DIR"
-
-    cp "$NOTIFY_LISTENER_SERVICE_SOURCE" "$NOTIFY_LISTENER_SERVICE_TARGET"
-    echo -e "  ${CHECK_MARK} Installed pg-notify-listener.service → $NOTIFY_LISTENER_SERVICE_DIR"
-
-    if command -v systemctl &>/dev/null; then
-        systemctl --user daemon-reload
-        if systemctl --user is-active pg-notify-listener.service &>/dev/null; then
-            if systemctl --user restart pg-notify-listener.service; then
-                echo -e "  ${CHECK_MARK} Restarted pg-notify-listener.service"
-            else
-                echo -e "  ${WARNING} pg-notify-listener.service restart failed"
-            fi
-        else
-            if systemctl --user enable pg-notify-listener.service &>/dev/null && \
-               systemctl --user start pg-notify-listener.service; then
-                echo -e "  ${CHECK_MARK} Enabled and started pg-notify-listener.service"
-            else
-                echo -e "  ${WARNING} pg-notify-listener.service enable/start failed"
-            fi
-        fi
-    else
-        echo -e "  ${WARNING} systemctl not available — service not started"
-    fi
-else
-    echo -e "  ${WARNING} pg-notify-listener source files not found (skipping)"
-fi
-
 # --- Ensure agent_system_config table ---
 echo ""
 echo "  Ensuring agent_system_config table..."
@@ -2271,31 +2315,6 @@ if [ -f "$OPENCLAW_CONFIG" ] && command -v jq &>/dev/null; then
             echo -e "  ${CHECK_MARK} Added BASH_ENV to OpenClaw config" || \
             echo -e "  ${WARNING} Could not update config with BASH_ENV"
     fi
-fi
-
-# --- Configure PostgreSQL password file and agent_chat DB config ---
-echo ""
-echo "PostgreSQL password file and agent_chat DB config..."
-
-if [ -n "${PGPASSWORD:-}" ]; then
-    pgpass_changed=0
-    _ensure_pgpass_entry "localhost" "5432" "$DB_NAME" "$DB_USER" "$PGPASSWORD" && pgpass_changed=1
-    _ensure_pgpass_entry "127.0.0.1" "5432" "$DB_NAME" "$DB_USER" "$PGPASSWORD" && pgpass_changed=1
-    _ensure_pgpass_entry "localhost" "5432" "$AGENT_CHAT_DB_NAME" "$DB_USER" "$PGPASSWORD" && pgpass_changed=1
-    _ensure_pgpass_entry "127.0.0.1" "5432" "$AGENT_CHAT_DB_NAME" "$DB_USER" "$PGPASSWORD" && pgpass_changed=1
-    if [ "$pgpass_changed" -eq 1 ]; then
-        echo -e "  ${CHECK_MARK} Updated ~/.pgpass with memory and agent_chat DB entries"
-    else
-        echo -e "  ${CHECK_MARK} ~/.pgpass entries already correct"
-    fi
-else
-    echo -e "  ${WARNING} PGPASSWORD not set — skipping ~/.pgpass provisioning"
-fi
-
-if _ensure_agent_chat_postgres_json "$PG_CONFIG" "$AGENT_CHAT_DB_NAME" "$DB_USER" "${PGPASSWORD:-}"; then
-    echo -e "  ${CHECK_MARK} Wrote nested agent_chat section to $PG_CONFIG"
-else
-    echo -e "  ${CHECK_MARK} Nested agent_chat section already correct in $PG_CONFIG (or could not update)"
 fi
 
 # --- Configure agent_chat channel ---

--- a/cognition/ISSUE-147-agent-chat-db-auth-docs.md
+++ b/cognition/ISSUE-147-agent-chat-db-auth-docs.md
@@ -1,5 +1,14 @@
 # Issue #147: Document agent_chat Plugin Database Authentication Requirements
 
+> **Superseded by #320.** As of the `agent_chat` dedicated-database migration, the
+> plugin no longer reads `database`/`host`/`port`/`user`/`password` from
+> `channels.<plugin_name>` at all — connection details resolve from the nested
+> `agent_chat` section of `~/.openclaw/postgres.json` (see
+> `cognition/focus/agent_chat/SETUP.md` and `memory/docs/database-config.md` for
+> the current story). The requirements below (password-required, sequence grants)
+> are still true in spirit but the specific config-block example is obsolete.
+> Left as-is otherwise for historical record of the original ask.
+
 ## Context
 The `agent_chat` extension plugin connects to PostgreSQL via TCP using `pg.Client` (not Unix socket peer auth). This has specific requirements that are not currently documented clearly, and the existing SETUP.md contains environment-specific references (agent names, credential storage locations) that should not be in a public repository.
 

--- a/cognition/ISSUE-148-agent-chat-db-permissions.md
+++ b/cognition/ISSUE-148-agent-chat-db-permissions.md
@@ -1,5 +1,12 @@
 # Issue #148: Ensure agent_chat Setup Scripts Grant Complete Database Permissions
 
+> **Status note (post-#320):** The dedicated `agent_chat` database's schema file
+> (`database/agent-chat/schema.sql`) now grants the full permission matrix
+> (SELECT/INSERT plus sequence USAGE/SELECT) for all nova-ecosystem roles as part
+> of schema application, satisfying the spirit of this request for the new database.
+> Left as historical record of the original ask against the old `nova_memory`-hosted
+> table.
+
 ## Context
 When setting up a new agent's database user for the `agent_chat` plugin, the required sequence permissions are not automatically granted. This causes agents to receive and process messages but fail silently when attempting to reply.
 

--- a/cognition/README.md
+++ b/cognition/README.md
@@ -47,10 +47,11 @@ This is the actual installer. It:
 - Validates API keys — checks `~/.openclaw/openclaw.json` first, then shell environment
 - Installs the `agent_chat` TypeScript extension to `~/.openclaw/extensions/`
 - Builds the extension (npm install, TypeScript compilation)
-- Applies the agent_chat database schema (creates tables if needed)
+- Provisions the nested `agent_chat` section of `~/.openclaw/postgres.json` and `.pgpass` entries for the dedicated `agent_chat` database (idempotent; as of nova-mind#320, `agent_chat` no longer lives in the main memory database, and its schema is applied separately by `scripts/agent-chat-migration/migrate.sh` against `database/agent-chat/schema.sql` — not by this installer)
+- Deploys `pg-notify-listener.py` and its systemd user unit
 - Installs skills (agent-chat, agent-spawn) and bootstrap-context hook
 - Runs `npm install` for hook dependencies if `package.json` is present
-- Configures shell environment and agent_chat channel in OpenClaw config
+- Configures shell environment and agent_chat channel in OpenClaw config (connection-free, per #320 — see `memory/docs/database-config.md`)
 - Verifies all components are working
 
 **Common flags:**

--- a/cognition/docs/cross-database-replication.md
+++ b/cognition/docs/cross-database-replication.md
@@ -1,5 +1,18 @@
 # Cross-Database Replication Setup
 
+> **⚠️ Superseded for `agent_chat` by nova-mind#320.** This entire guide describes a
+> pre-#320 architecture in which `agent_chat` was replicated bidirectionally between
+> each agent's own memory database (e.g. `nova_memory` ↔ `graybeard_memory`). As of
+> #320, `agent_chat` lives in a single dedicated `agent_chat` database that all agents
+> connect to directly — there is no more per-agent `agent_chat` table to replicate, and
+> `agent-install.sh` no longer sets up or detects `agent_chat` logical replication (see
+> the "agent_chat runtime configuration" section of `agent-install.sh`, and
+> `scripts/agent-chat-migration/README.md` for the current architecture). This guide is
+> kept as a historical/reference document for the replication mechanics themselves
+> (origin='none', trigger REPLICA-mode pitfalls, etc.), which may still be relevant if
+> some other table is replicated this way in the future — but do not use it to set up
+> or troubleshoot `agent_chat` on a #320-or-later install.
+
 This guide covers setting up **bidirectional** logical replication for `agent_chat` when agents use
 separate databases. The production configuration (nova_memory ↔ graybeard_memory) is bidirectional
 so each agent sees messages the other sends in real time.

--- a/cognition/docs/installation.md
+++ b/cognition/docs/installation.md
@@ -52,18 +52,36 @@ CREATE TABLE agents (
     updated_at TIMESTAMPTZ DEFAULT now()
 );
 
--- Inter-agent communication
--- Column history (#106): mentions → recipients, created_at → "timestamp", channel dropped
--- All inserts via send_agent_message(sender, message, recipients)
-CREATE TABLE agent_chat (
-    id          SERIAL PRIMARY KEY,
-    sender      TEXT NOT NULL,
-    message     TEXT NOT NULL,
-    recipients  TEXT[] NOT NULL CHECK (array_length(recipients, 1) > 0),
-    reply_to    INTEGER REFERENCES agent_chat(id),
-    "timestamp" TIMESTAMPTZ NOT NULL DEFAULT now()
-);
 ```
+
+> **`agent_chat` lives in its own database (#320), not here.** As of the #320
+> migration, `agent_chat` and `agent_chat_processed` are NOT part of the main
+> memory database above — they live in a separate, dedicated `agent_chat`
+> database on the same PostgreSQL instance. Create and schema it separately:
+>
+> ```bash
+> createdb agent_chat
+> psql -d agent_chat -f database/agent-chat/schema.sql
+> ```
+>
+> See `scripts/agent-chat-migration/README.md` for the full migration runbook
+> (including grants, sequence alignment, and rollout) and
+> `memory/docs/database-config.md` for how agents resolve which database to
+> connect to. The table shape itself (columns, `send_agent_message()` as the only
+> insert path, column history from #106) is unchanged by the database move:
+>
+> ```sql
+> -- Column history (#106): mentions → recipients, created_at → "timestamp", channel dropped
+> -- All inserts via send_agent_message(sender, message, recipients)
+> CREATE TABLE agent_chat (
+>     id          SERIAL PRIMARY KEY,
+>     sender      TEXT NOT NULL,
+>     message     TEXT NOT NULL,
+>     recipients  TEXT[] NOT NULL CHECK (array_length(recipients, 1) > 0),
+>     reply_to    INTEGER REFERENCES agent_chat(id),
+>     "timestamp" TIMESTAMPTZ NOT NULL DEFAULT now()
+> );
+> ```
 
 ## Step 2: OpenClaw Configuration
 
@@ -116,7 +134,7 @@ In `~/.openclaw/openclaw.json`, add agents to the `agents.list` array:
 1. **Primary agent** must have `subagents.allowAgents` listing spawnable agents
 2. **Each subagent** needs an entry in `agents.list` with at least `id` and `model`
 3. **Fallbacks** are optional but recommended for reliability
-4. **Agent chat requires dual config** — both `channels.agent_chat` and `plugins.entries.agent_chat.config` must contain the database connection details. The `agent-install.sh` script handles this automatically, but manual setups must configure both or the gateway will fail plugin validation
+4. **Agent chat connection details do NOT live in `openclaw.json` (as of #320)** — `channels.agent_chat` and `plugins.entries.agent_chat.config` should be config-free of `database`/`host`/`port`/`user`/`password`; `agent-install.sh` actively strips those keys if present. The plugin resolves its connection from the nested `agent_chat` section of `~/.openclaw/postgres.json` instead (see `memory/docs/database-config.md`). Manual setups must provision that `postgres.json` section rather than the `openclaw.json` config keys
 
 ## Step 3: Workspace Setup
 
@@ -193,18 +211,28 @@ sessions_spawn(agentId="scout", task="Test: confirm you can spawn and respond")
 
 ## Advanced Configuration
 
-### Cross-Database Replication
+### Cross-Database Replication (superseded by #320 for `agent_chat`)
 
-For setups where agents use separate databases but need to share message history, see the [Cross-Database Replication Guide](cross-database-replication.md). This covers:
-
-- PostgreSQL logical replication setup
-- Trigger configuration for replicated data  
-- Automatic detection and configuration via `agent-install.sh`
-
-> **Note:** `agent-install.sh` configures both `channels.agent_chat` (channel definition) and `plugins.entries.agent_chat.config` (plugin configuration) with identical connection details. Both are required — the gateway validates plugin config separately from channel config.
-- Troubleshooting replication issues
-
-Example: Graybeard agent using `graybeard_memory` database while replicating messages from `nova_memory`.
+> **This section describes a pre-#320 architecture.** Logical replication of
+> `agent_chat` between per-agent memory databases (e.g. `nova_memory` ↔
+> `graybeard_memory`) has been **superseded** by the #320 shared dedicated
+> `agent_chat` database design — all agents now connect to the same `agent_chat`
+> database directly, so there is nothing to replicate for that table anymore.
+> `agent-install.sh` no longer configures `agent_chat` replication (see the
+> "agent_chat runtime configuration" section of `agent-install.sh` itself, which
+> notes the shared-DB design supersedes it). The [Cross-Database Replication
+> Guide](cross-database-replication.md) is kept for historical reference and in
+> case other tables still need cross-database replication in some deployments,
+> but do **not** follow it for `agent_chat` on a #320-or-later install. It
+> previously covered:
+>
+> - PostgreSQL logical replication setup
+> - Trigger configuration for replicated data
+> - Automatic detection and configuration via `agent-install.sh` (no longer true for `agent_chat`)
+> - Troubleshooting replication issues
+>
+> (Prior example: Graybeard agent using `graybeard_memory` database while
+> replicating `agent_chat` messages from `nova_memory` — no longer how this works.)
 
 ## Next Steps
 

--- a/cognition/focus/agent_chat/MIGRATION.md
+++ b/cognition/focus/agent_chat/MIGRATION.md
@@ -1,5 +1,12 @@
 # Migration Guide: agent_chat v1.x → v2.0
 
+> **Note:** This guide covers the historical v1.x (JavaScript) → v2.0 (TypeScript/Plugin SDK)
+> rewrite (nova-cognition#12). For the separate, later migration of the `agent_chat`
+> *database* out of `nova_memory` into its own dedicated `agent_chat` database
+> (nova-mind#320), see `scripts/agent-chat-migration/README.md`. The
+> "Configuration" section below is updated for the #320 config story; the rest
+> of this document describes the v1→v2 code rewrite and is otherwise historical.
+
 ## Overview
 
 The agent_chat plugin has been completely rewritten to use the OpenClaw Plugin SDK properly. This brings it in line with other official OpenClaw channels like Discord and Signal.
@@ -148,18 +155,32 @@ openclaw gateway restart
 
 ## Configuration
 
-Configuration format remains the same:
+> **Updated for #320:** the config shape below is current. Earlier versions of this
+> guide (and of the plugin itself, pre-#320) had `database`/`host`/`port`/`user`/`password`
+> directly under `channels.agent_chat`. Those keys are no longer read — connection
+> details now resolve from the nested `agent_chat` section of
+> `~/.openclaw/postgres.json` (see `memory/docs/database-config.md`).
 
 ```yaml
 channels:
   agent_chat:
     enabled: true
-    database: "openclaw"
-    host: "localhost"
-    port: 5432
-    user: "postgres"
-    password: "secret"
     pollIntervalMs: 1000
+```
+
+```json
+// ~/.openclaw/postgres.json
+{
+  "host": "localhost",
+  "database": "nova_memory",
+  "user": "<agent>",
+  "password": "...",
+  "agent_chat": {
+    "database": "agent_chat",
+    "user": "<agent>",
+    "password": "..."
+  }
+}
 ```
 
 > **Note:** `agentName` has been removed from the plugin config (see #118).
@@ -168,10 +189,15 @@ channels:
 
 ## Database Schema
 
-No changes required. The plugin still uses:
+No changes required for the v1→v2 rewrite covered by this guide. The plugin still uses:
 - `agent_chat` table
 - `agent_chat_processed` table
 - PostgreSQL LISTEN/NOTIFY
+
+(Separately, #320 later moved these tables from `nova_memory` into a dedicated
+`agent_chat` database — see `database/agent-chat/schema.sql` and
+`scripts/agent-chat-migration/README.md`. That migration did not change the table
+shapes themselves, only which database they live in.)
 
 ## Testing
 

--- a/cognition/focus/agent_chat/README.md
+++ b/cognition/focus/agent_chat/README.md
@@ -36,23 +36,52 @@ npm run build
 
 ## Configuration
 
-Add to your OpenClaw config:
+**As of #320, `agent_chat` lives in its own dedicated PostgreSQL database** (named
+`agent_chat`, separate from `nova_memory`). Connection details are **not** set under
+`channels.agent_chat` in `openclaw.json` — they are resolved from the nested `agent_chat`
+section of `~/.openclaw/postgres.json` via `loadPgEnv(undefined, "agent_chat")`
+(see `lib/pg-env.ts` and `memory/docs/database-config.md`).
+
+`agent-install.sh` provisions this section automatically (idempotent — safe to re-run).
+A typical `postgres.json` looks like:
+
+```json
+{
+  "host": "localhost",
+  "port": 5432,
+  "database": "nova_memory",
+  "user": "<agent>",
+  "password": "<password>",
+  "agent_chat": {
+    "database": "agent_chat",
+    "user": "<agent>",
+    "password": "<password>"
+  }
+}
+```
+
+Only `database`, `user`, and `password` are required inside the nested `agent_chat`
+block — `host` and `port` fall back to the top-level flat keys (or their defaults)
+if omitted.
+
+Add to your OpenClaw config (connection keys are intentionally absent — see above):
 
 ```yaml
 channels:
   agent_chat:
     enabled: true
-    database: "openclaw"
-    host: "localhost"
-    port: 5432
-    user: "postgres"
-    password: "secret"
     pollIntervalMs: 1000
 ```
 
 > **Note:** The agent name is resolved automatically from the top-level OpenClaw config
 > (`agents.list` — using the default agent's `name`, falling back to `id`).
 > No `agentName` field is needed in the plugin config.
+
+> **Historical note:** Older versions of this plugin (pre-#320) accepted
+> `database`/`host`/`port`/`user`/`password` directly under `channels.agent_chat`.
+> `agent-install.sh` now actively strips those keys from both `channels.agent_chat`
+> and `plugins.entries.agent_chat.config` on install/upgrade — see MIGRATION.md and
+> SETUP.md for the current config story. Do not add them back; they are no longer read.
 
 ### Multiple Accounts
 
@@ -62,17 +91,12 @@ channels:
     accounts:
       agent1:
         enabled: true
-        database: "openclaw"
-        host: "localhost"
-        user: "postgres"
-        password: "secret"
       agent2:
         enabled: true
-        database: "openclaw"
-        host: "localhost"
-        user: "postgres"
-        password: "secret"
 ```
+
+All accounts currently share the single connection resolved from the `agent_chat`
+section of `postgres.json` — there is no per-account connection override.
 
 ## Database Schema
 
@@ -177,5 +201,6 @@ This plugin follows the OpenClaw Plugin SDK pattern:
 
 ## Related
 
-- Issue: nova-cognition#12
+- Issue: nova-cognition#12 (TypeScript/Plugin SDK rewrite)
+- Issue: nova-mind#320 (dedicated `agent_chat` database migration — current DB/config story)
 - Reference: Discord plugin implementation

--- a/cognition/focus/agent_chat/SETUP.md
+++ b/cognition/focus/agent_chat/SETUP.md
@@ -1,5 +1,12 @@
 # Quick Setup Guide
 
+> **As of #320:** `agent_chat` lives in its own dedicated PostgreSQL database (named
+> `agent_chat`), not in the same database as the rest of nova-memory. If you are
+> setting up via the unified `agent-install.sh` installer, steps 2–3 below are handled
+> automatically (schema application via the migration tooling, and `postgres.json`
+> provisioning) — this guide documents what the installer does and how to verify or
+> reproduce it manually.
+
 ## 1. Install Dependencies
 
 ```bash
@@ -9,21 +16,19 @@ npm install
 
 ## 2. Set Up Database
 
-Connect to your PostgreSQL database and run the schema:
+Create the dedicated `agent_chat` database and apply its schema (see
+`scripts/agent-chat-migration/README.md` for the full migration runbook if migrating
+an existing installation):
 
 ```bash
-psql -h localhost -U <db_user> -d <database_name> -f schema.sql
+createdb agent_chat
+psql -h localhost -U <db_user> -d agent_chat -f database/agent-chat/schema.sql
 ```
 
-Or manually:
-
-```sql
--- See schema.sql for full details
-CREATE TABLE agent_chat (...);
-CREATE TABLE agent_chat_processed (...);
-CREATE FUNCTION notify_agent_chat() ...;
-CREATE TRIGGER agent_chat_notify ...;
-```
+The canonical schema (tables, `send_agent_message()`, triggers, views, grants) lives
+in `database/agent-chat/schema.sql` at the repo root — not in this directory's local
+`schema.sql`, which predates the dedicated-database design and is kept only for
+historical/local-dev reference.
 
 ### Required Permissions
 
@@ -37,26 +42,47 @@ GRANT SELECT, INSERT ON agent_chat TO <db_user>;
 GRANT USAGE, SELECT ON SEQUENCE agent_chat_id_seq TO <db_user>;
 ```
 
+(`database/agent-chat/schema.sql` already grants the full matrix for all
+nova-ecosystem roles; the above is for a manually-added user.)
+
 ## 3. Configure OpenClaw
 
-Edit your `openclaw.json` (or equivalent config):
+Connection details for `agent_chat` are **not** set in `openclaw.json`. They are
+resolved from the nested `agent_chat` section of `~/.openclaw/postgres.json`:
+
+```json
+{
+  "host": "localhost",
+  "port": 5432,
+  "database": "nova_memory",
+  "user": "<db_user>",
+  "password": "<db_password>",
+  "agent_chat": {
+    "database": "agent_chat",
+    "user": "<db_user>",
+    "password": "<db_password>"
+  }
+}
+```
+
+`agent-install.sh` writes/merges this nested section automatically and is idempotent
+(re-running reports the section is already correct — no clobber of existing values).
+
+Then in `openclaw.json`, enable the channel (no connection keys here):
 
 ```json
 {
   "channels": {
     "agent_chat": {
-      "enabled": true,
-      "database": "<database_name>",
-      "host": "localhost",
-      "port": 5432,
-      "user": "<db_user>",
-      "password": "<db_password>"
+      "enabled": true
     }
   }
 }
 ```
 
-**Important:** The `password` field must not be empty. The plugin's configuration check requires a truthy password value. Store credentials securely using your preferred secrets management solution.
+**Important:** `database`/`host`/`port`/`user`/`password` under `channels.agent_chat`
+are no longer read by the plugin — `agent-install.sh` strips them on install/upgrade.
+Store the password securely; the `postgres.json` file should be mode `600`.
 
 See `example-config.yaml` for more options.
 
@@ -93,9 +119,10 @@ The agent should receive and respond to the message.
 
 ### Database connection errors
 
-- Verify credentials work via TCP: `psql -h localhost -U <db_user> -d <database_name>`
-- Check that database and tables exist
-- Ensure your password is non-empty in the config
+- Verify credentials work via TCP: `psql -h localhost -U <db_user> -d agent_chat`
+- Check that the `agent_chat` database and its tables exist (`\dt` should show `agent_chat`, `agent_chat_processed`)
+- Confirm the nested `agent_chat` section in `~/.openclaw/postgres.json` has a non-empty `password`
+- Run `scripts/agent-chat-migration/audit_rollout.py` to check which database a given agent's config actually resolves to
 
 ### Messages not received
 

--- a/cognition/focus/agent_chat/example-config.yaml
+++ b/cognition/focus/agent_chat/example-config.yaml
@@ -1,37 +1,52 @@
-# Example Clawdbot configuration for agent_chat channel
+# Example OpenClaw configuration for the agent_chat channel
 #
-# Add this to your ~/.config/clawdbot/config.yaml
+# Add the "channels.agent_chat" block below to your ~/.openclaw/openclaw.json
+# (this file uses YAML for readability; openclaw.json itself is JSON).
+#
+# As of nova-mind#320, agent_chat lives in its own dedicated PostgreSQL
+# database ("agent_chat", separate from nova_memory). Connection details
+# (database/host/port/user/password) are NOT set here under
+# channels.agent_chat -- they are resolved from the nested "agent_chat"
+# section of ~/.openclaw/postgres.json via loadPgEnv(undefined, "agent_chat").
+# See memory/docs/database-config.md and
+# scripts/agent-chat-migration/README.md for the full config story.
+# agent-install.sh provisions the postgres.json section automatically.
 
-# 1. Register the plugin
+# 1. Register the plugin (agent-install.sh does this for you under
+#    ~/.openclaw/extensions/agent_chat/)
 plugins:
   paths:
-    - /home/nova/clawd/clawdbot-plugins/agent-chat-channel
+    - ~/.openclaw/extensions/agent_chat
 
-# 2. Configure the agent_chat channel
+# 2. Configure the agent_chat channel (no connection keys -- see above)
 channels:
   agent_chat:
     enabled: true
     # agentName is resolved automatically from top-level agents.list config
-    database: nova_memory
-    host: localhost
-    port: 5432
-    user: newhart
-    password: op://NOVA Shared Vault/Agent DB: newhart/password
     pollIntervalMs: 1000  # optional, defaults to 1000ms
 
-# Alternative: Multiple agent accounts
+# ~/.openclaw/postgres.json (JSON, not part of openclaw.json):
+# {
+#   "host": "localhost",
+#   "port": 5432,
+#   "database": "nova_memory",
+#   "user": "newhart",
+#   "password": "...",
+#   "agent_chat": {
+#     "database": "agent_chat",
+#     "user": "newhart",
+#     "password": "..."
+#   }
+# }
+
+# Alternative: Multiple agent accounts (all share the single connection
+# resolved from the "agent_chat" section of postgres.json above -- there is
+# no per-account connection override)
 # channels:
 #   agent_chat:
 #     enabled: true
 #     accounts:
 #       newhart:
-#         database: nova_memory
-#         host: localhost
-#         user: newhart
-#         password: op://NOVA Shared Vault/Agent DB: newhart/password
-#       
+#         enabled: true
 #       assistant2:
-#         database: nova_memory
-#         host: localhost
-#         user: assistant2
-#         password: op://NOVA Shared Vault/Agent DB: assistant2/password
+#         enabled: true

--- a/cognition/focus/agent_chat/lib/pg-env.test.ts
+++ b/cognition/focus/agent_chat/lib/pg-env.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for loadPgEnv() section-key fallback.
+ *
+ * TC-23  Section present and valid → uses section fields
+ * TC-24  Section absent → falls back to flat keys
+ * TC-25  Section partial → per-field fallback to flat keys / defaults
+ * TC-26  Malformed JSON file → warn and fall through to defaults
+ * TC-27  Section present but not an object → warn and fall back to flat keys
+ * TC-28  Python-only env overwrite semantics (see memory/tests/test_pg_env.py)
+ * TC-29  Section absent fallback (covered by TC-24)
+ *
+ * Framework: Node built-in test runner + tsx.
+ * Run: npx tsx --test lib/pg-env.test.ts
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadPgEnv } from "./pg-env.js";
+
+const PG_VARS = ["PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD"] as const;
+
+function writeJson(filePath: string, data: unknown) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data), "utf-8");
+}
+
+function clearPgEnv(): Record<string, string | undefined> {
+  const saved: Record<string, string | undefined> = {};
+  for (const v of PG_VARS) {
+    saved[v] = process.env[v];
+    delete process.env[v];
+  }
+  return saved;
+}
+
+function restorePgEnv(saved: Record<string, string | undefined>) {
+  for (const v of PG_VARS) {
+    if (saved[v] === undefined) {
+      delete process.env[v];
+    } else {
+      process.env[v] = saved[v];
+    }
+  }
+}
+
+// Run all describes sequentially and isolate env within each describe.
+describe("TC-23: section present and valid uses section fields", { concurrency: false }, () => {
+  let tmpDir: string;
+  let configPath: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  before(() => {
+    savedEnv = clearPgEnv();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pg-env-test-"));
+    configPath = path.join(tmpDir, "postgres.json");
+    writeJson(configPath, {
+      host: "flat-host",
+      database: "nova_memory",
+      user: "flat-user",
+      password: "flat-pass",
+      agent_chat: {
+        database: "agent_chat",
+        user: "chat-user",
+        password: "chat-pass",
+      },
+    });
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    restorePgEnv(savedEnv);
+  });
+
+  it("uses section database/user/password", () => {
+    const cfg = loadPgEnv(configPath, "agent_chat");
+    assert.strictEqual(cfg.database, "agent_chat");
+    assert.strictEqual(cfg.user, "chat-user");
+    assert.strictEqual(cfg.password, "chat-pass");
+  });
+
+  it("falls back to flat keys for omitted host/port", () => {
+    const cfg = loadPgEnv(configPath, "agent_chat");
+    assert.strictEqual(cfg.host, "flat-host");
+    assert.strictEqual(cfg.port, 5432);
+  });
+});
+
+describe("TC-24: section absent falls back to flat keys", { concurrency: false }, () => {
+  let tmpDir: string;
+  let configPath: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  before(() => {
+    savedEnv = clearPgEnv();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pg-env-test-"));
+    configPath = path.join(tmpDir, "postgres.json");
+    writeJson(configPath, {
+      host: "flat-host",
+      database: "nova_memory",
+      user: "flat-user",
+      password: "flat-pass",
+    });
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    restorePgEnv(savedEnv);
+  });
+
+  it("falls back to flat keys when section is missing", () => {
+    const cfg = loadPgEnv(configPath, "agent_chat");
+    assert.strictEqual(cfg.database, "nova_memory");
+    assert.strictEqual(cfg.user, "flat-user");
+    assert.strictEqual(cfg.password, "flat-pass");
+    assert.strictEqual(cfg.host, "flat-host");
+  });
+});
+
+describe("TC-25: partial section falls back per field", { concurrency: false }, () => {
+  let tmpDir: string;
+  let configPath: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  before(() => {
+    savedEnv = clearPgEnv();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pg-env-test-"));
+    configPath = path.join(tmpDir, "postgres.json");
+    writeJson(configPath, {
+      host: "flat-host",
+      port: 5433,
+      database: "nova_memory",
+      user: "flat-user",
+      password: "flat-pass",
+      agent_chat: {
+        database: "agent_chat",
+        user: "chat-user",
+      },
+    });
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    restorePgEnv(savedEnv);
+  });
+
+  it("uses section fields that are present", () => {
+    const cfg = loadPgEnv(configPath, "agent_chat");
+    assert.strictEqual(cfg.database, "agent_chat");
+    assert.strictEqual(cfg.user, "chat-user");
+  });
+
+  it("falls back to flat keys for omitted fields", () => {
+    const cfg = loadPgEnv(configPath, "agent_chat");
+    assert.strictEqual(cfg.host, "flat-host");
+    assert.strictEqual(cfg.port, 5433);
+    assert.strictEqual(cfg.password, "flat-pass");
+  });
+});
+
+describe("TC-26: malformed JSON falls through to defaults", { concurrency: false }, () => {
+  let tmpDir: string;
+  let configPath: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  before(() => {
+    savedEnv = clearPgEnv();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pg-env-test-"));
+    configPath = path.join(tmpDir, "postgres.json");
+    fs.writeFileSync(configPath, "{not valid json", "utf-8");
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    restorePgEnv(savedEnv);
+  });
+
+  it("returns defaults without throwing", () => {
+    const cfg = loadPgEnv(configPath, "agent_chat");
+    assert.strictEqual(cfg.host, "localhost");
+    assert.strictEqual(cfg.port, 5432);
+    assert.strictEqual(cfg.user, os.userInfo().username);
+    assert.strictEqual(cfg.database, undefined);
+  });
+});
+
+describe("TC-27: section not an object warns and falls back to flat keys", { concurrency: false }, () => {
+  let tmpDir: string;
+  let configPath: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  before(() => {
+    savedEnv = clearPgEnv();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pg-env-test-"));
+    configPath = path.join(tmpDir, "postgres.json");
+    writeJson(configPath, {
+      host: "flat-host",
+      database: "nova_memory",
+      user: "flat-user",
+      password: "flat-pass",
+      agent_chat: "oops",
+    });
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    restorePgEnv(savedEnv);
+  });
+
+  it("falls back to flat keys when section is not an object", () => {
+    const cfg = loadPgEnv(configPath, "agent_chat");
+    assert.strictEqual(cfg.database, "nova_memory");
+    assert.strictEqual(cfg.user, "flat-user");
+    assert.strictEqual(cfg.host, "flat-host");
+  });
+});
+
+describe("ENV override still wins over section", { concurrency: false }, () => {
+  let tmpDir: string;
+  let configPath: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  before(() => {
+    savedEnv = clearPgEnv();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pg-env-test-"));
+    configPath = path.join(tmpDir, "postgres.json");
+    writeJson(configPath, {
+      database: "nova_memory",
+      agent_chat: { database: "agent_chat" },
+    });
+    process.env.PGDATABASE = "env_db";
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    restorePgEnv(savedEnv);
+  });
+
+  it("uses ENV value when present", () => {
+    const cfg = loadPgEnv(configPath, "agent_chat");
+    assert.strictEqual(cfg.database, "env_db");
+  });
+});

--- a/cognition/focus/agent_chat/lib/pg-env.ts
+++ b/cognition/focus/agent_chat/lib/pg-env.ts
@@ -10,6 +10,18 @@ import { readFileSync } from "fs";
 import { homedir, userInfo } from "os";
 import { join } from "path";
 
+/**
+ * PostgreSQL connection options interface that matches
+ * the pg.Client constructor options.
+ */
+export interface PgConnectionConfig {
+  host?: string;
+  port?: number;
+  database?: string;
+  user?: string;
+  password?: string;
+}
+
 interface PgConfig {
   host?: string | null;
   port?: string | number | null;
@@ -19,7 +31,7 @@ interface PgConfig {
   [key: string]: unknown;
 }
 
-const FIELD_MAP: Array<[keyof PgConfig, string]> = [
+const FIELD_MAP: Array<[keyof PgConnectionConfig, string]> = [
   ["host", "PGHOST"],
   ["port", "PGPORT"],
   ["database", "PGDATABASE"],
@@ -32,18 +44,6 @@ const DEFAULTS: Record<string, string | (() => string)> = {
   PGPORT: "5432",
   PGUSER: () => userInfo().username,
 };
-
-/**
- * PostgreSQL connection options interface that matches
- * the pg.Client constructor options.
- */
-export interface PgConnectionConfig {
-  host?: string;
-  port?: number;
-  database?: string;
-  user?: string;
-  password?: string;
-}
 
 /**
  * Load PostgreSQL config with resolution: ENV → section → config file → defaults.

--- a/cognition/focus/agent_chat/lib/pg-env.ts
+++ b/cognition/focus/agent_chat/lib/pg-env.ts
@@ -1,8 +1,9 @@
 /**
- * pg-env.ts — Centralized PostgreSQL config loader for TypeScript/Node.js.
+ * pg-env.ts — Centralized PostgreSQL config loader for TypeScript/Node.js
+ * with optional nested-section support.
  *
- * Resolution order: ENV vars → ~/.openclaw/postgres.json → defaults
- * Issue: nova-memory #94, nova-mind #330
+ * Resolution order: ENV vars → section → ~/.openclaw/postgres.json (flat keys) → defaults
+ * Issue: nova-memory #94, nova-mind #330, nova-mind #320
  */
 
 import { readFileSync } from "fs";
@@ -15,6 +16,7 @@ interface PgConfig {
   database?: string | null;
   user?: string | null;
   password?: string | null;
+  [key: string]: unknown;
 }
 
 const FIELD_MAP: Array<[keyof PgConfig, string]> = [
@@ -44,7 +46,7 @@ export interface PgConnectionConfig {
 }
 
 /**
- * Load PostgreSQL config with resolution: ENV → config file → defaults.
+ * Load PostgreSQL config with resolution: ENV → section → config file → defaults.
  *
  * Returns connection config object suitable for pg.Client / pg.Pool constructor,
  * without modifying process.env to avoid pollution of the environment
@@ -52,9 +54,13 @@ export interface PgConnectionConfig {
  * Empty ENV strings are treated as unset.
  * Null values in JSON are treated as absent.
  * Malformed JSON is caught and warned about (falls through to defaults).
+ *
+ * If `section` is provided and the parsed config contains a valid object for that
+ * key, section fields take precedence over top-level keys (ENV still wins).
  */
 export function loadPgEnv(
-  configPath?: string
+  configPath?: string,
+  section?: string
 ): PgConnectionConfig {
   const cfgPath =
     configPath ?? join(homedir(), ".openclaw", "postgres.json");
@@ -81,6 +87,20 @@ export function loadPgEnv(
     }
   }
 
+  // Resolve nested section if requested. A non-object section mirrors the
+  // top-level object-type guard: warn and fall back to top-level keys.
+  let sectionConfig: PgConfig | undefined;
+  if (section) {
+    const sectionValue = config[section];
+    if (sectionValue && typeof sectionValue === "object" && !Array.isArray(sectionValue)) {
+      sectionConfig = sectionValue as PgConfig;
+    } else if (sectionValue !== undefined) {
+      console.error(
+        `WARNING: ${cfgPath}.${section} is not a JSON object, ignoring`
+      );
+    }
+  }
+
   const result: PgConnectionConfig = {};
 
   for (const [jsonKey, envVar] of FIELD_MAP) {
@@ -96,7 +116,24 @@ export function loadPgEnv(
       continue;
     }
 
-    // 2. Check config file (null/undefined = absent, empty string = absent)
+    // 2. Check section config (null/undefined = absent, empty string = absent)
+    if (sectionConfig) {
+      const sectionVal = sectionConfig[jsonKey];
+      if (sectionVal != null) {
+        const strVal = String(sectionVal);
+        if (strVal) {
+          if (jsonKey === "port") {
+            const portNum = Number(strVal);
+            if (!isNaN(portNum)) result[jsonKey] = portNum;
+          } else {
+            result[jsonKey] = strVal;
+          }
+          continue;
+        }
+      }
+    }
+
+    // 3. Check top-level config file (null/undefined = absent, empty string = absent)
     const cfgVal = config[jsonKey];
     if (cfgVal != null) {
       const strVal = String(cfgVal);
@@ -111,7 +148,7 @@ export function loadPgEnv(
       }
     }
 
-    // 3. Apply default
+    // 4. Apply default
     const def = DEFAULTS[envVar];
     if (def !== undefined) {
       const defaultVal = typeof def === "function" ? def() : def;

--- a/cognition/focus/agent_chat/openclaw.plugin.json
+++ b/cognition/focus/agent_chat/openclaw.plugin.json
@@ -35,7 +35,6 @@
         "type": "string",
         "description": "Route messages to a specific session instead of creating unique sessions per message"
       }
-    },
-    "required": ["database", "host", "user", "password"]
+    }
   }
 }

--- a/cognition/focus/agent_chat/src/channel.ts
+++ b/cognition/focus/agent_chat/src/channel.ts
@@ -9,8 +9,9 @@ import { loadPgEnv } from "../lib/pg-env.js";
 import { getAgentChatRuntime } from "./runtime.js";
 import { AgentChatConfigSchema, type ResolvedAgentChatAccount } from "./config.js";
 
-// Get PostgreSQL config without polluting process.env for child processes
-const pgConfig = loadPgEnv();
+// Resolve agent_chat DB from the nested config section, falling back to flat keys.
+// No process.env pollution so child processes/subagents keep their own env.
+const pgConfig = loadPgEnv(undefined, "agent_chat");
 
 const { Client } = pg;
 
@@ -319,7 +320,9 @@ async function startAgentChatMonitor(
 
   try {
     await client.connect();
-    log?.info?.(`Connected to PostgreSQL`);
+    log?.info?.(
+      `Connected to PostgreSQL host=${pgConfig.host ?? "localhost"} database=${pgConfig.database ?? "<unset>"}`
+    );
 
     // Listen to agent_chat channel
     await client.query("LISTEN agent_chat");
@@ -393,7 +396,10 @@ async function startAgentChatMonitor(
       }
     });
   } catch (error) {
-    log?.error?.(`Fatal error: ${error}`);
+    log?.error?.(
+      `agent_chat: fatal error connecting to PostgreSQL ` +
+      `host=${pgConfig.host ?? "localhost"} database=${pgConfig.database ?? "<unset>"}: ${error}`
+    );
     try {
       await client.end();
     } catch (cleanupError) {

--- a/cognition/focus/protocols/agent-chat.md
+++ b/cognition/focus/protocols/agent-chat.md
@@ -35,7 +35,12 @@ sessions_spawn(
 
 ### Peer Agent Communication
 
-Peers use the `agent_chat` table with PostgreSQL NOTIFY. As of 2026-02-13, **enhanced send support** allows flexible agent targeting:
+Peers use the `agent_chat` table with PostgreSQL NOTIFY. As of nova-mind#320,
+`agent_chat` lives in its own dedicated `agent_chat` database (separate from
+`nova_memory`) — the table shape and protocol below are unchanged, but if you're
+querying it directly rather than through the plugin, connect to the `agent_chat`
+database, not `nova_memory`. See `scripts/agent-chat-migration/README.md` and
+`memory/docs/database-config.md` for connection details. As of 2026-02-13, **enhanced send support** allows flexible agent targeting:
 
 #### New Send Workflow (Recommended)
 

--- a/cognition/focus/skills/agent-ecosystem/SKILL.md
+++ b/cognition/focus/skills/agent-ecosystem/SKILL.md
@@ -55,13 +55,25 @@ ORDER BY timestamp DESC LIMIT 5;
 
 #### Database Architecture for Peer Agents
 
-Not all peers share the same database. There are two valid architectures:
+> **Updated for nova-mind#320.** `agent_chat` now lives in its own dedicated `agent_chat`
+> database, separate from every agent's `nova_memory`-equivalent memory database. All
+> agents — regardless of which memory database they otherwise use (Newhart's `nova_memory`,
+> Graybeard's `graybeard_memory`, etc.) — connect to this **same** `agent_chat` database
+> directly for messaging. The two-architecture split described below (shared vs.
+> cross-database logical replication) is the pre-#320 design and is kept for historical
+> reference; it no longer describes how peer messaging works. Do not set up or expect
+> `agent_chat` logical replication on a #320-or-later install — see
+> `scripts/agent-chat-migration/README.md` and `memory/docs/database-config.md`.
 
-1. **Shared database** — The peer agent connects to the same `nova_memory` database (e.g., Newhart). Messages appear instantly in the same `agent_chat` table.
+Not all peers share the same *memory* database. There were historically two architectures
+for `agent_chat` specifically (both superseded by the single shared `agent_chat` database
+above):
 
-2. **Replicated database** — The peer agent has its own separate database (e.g., Graybeard uses `graybeard_memory`). The `agent_chat` table is bidirectionally replicated between databases via PostgreSQL logical replication. When Graybeard writes to `graybeard_memory.agent_chat`, it replicates to `nova_memory.agent_chat` and vice versa.
+1. **Shared database** — The peer agent connects to the same `nova_memory` database (e.g., Newhart). Messages appeared instantly in the same `agent_chat` table.
 
-**Both architectures are valid and working.** If a peer agent writes messages to their own database, that is expected behavior — not a bug. Their messages will replicate to your database automatically. Do not assume all agents must use `nova_memory` directly.
+2. **Replicated database** — The peer agent had its own separate database (e.g., Graybeard uses `graybeard_memory`). The `agent_chat` table was bidirectionally replicated between databases via PostgreSQL logical replication. When Graybeard wrote to `graybeard_memory.agent_chat`, it replicated to `nova_memory.agent_chat` and vice versa.
+
+**Neither architecture above is current for `agent_chat`.** As of #320, do not assume a peer's `agent_chat` messages live in their memory database at all — they live in the shared dedicated `agent_chat` database instead.
 
 ### Subagents (instance_type = 'subagent')
 

--- a/cognition/scripts/pg-notify-listener.py
+++ b/cognition/scripts/pg-notify-listener.py
@@ -27,7 +27,7 @@ _git_lock_fd = None
 _git_lock_path = os.path.expanduser('~/.openclaw/workspace/scripts/.pg-notify-git.lock')
 
 # Load PG config from postgres.json (central config, not hardcoded)
-sys.path.insert(0, os.path.join(os.path.expanduser("~"), ".openclaw/workspace/nova-mind/lib"))
+sys.path.insert(0, os.path.join(os.path.expanduser("~"), ".openclaw", "lib"))
 from pg_env import load_pg_env
 _pg_env = load_pg_env()
 _agent_chat_env = load_pg_env(section="agent_chat")

--- a/cognition/scripts/pg-notify-listener.py
+++ b/cognition/scripts/pg-notify-listener.py
@@ -1,0 +1,629 @@
+#!/usr/bin/env python3
+"""
+Listen for PostgreSQL notifications:
+- gambling_changed: Regenerate gambling dashboard
+- schema_changed: Auto-sync schema.sql to GitHub, notify NOVA
+
+Run as a background service via systemd.
+"""
+
+import fcntl
+import getpass
+import json
+import os
+import re
+import select
+import subprocess
+import sys
+import time
+import urllib.request
+import urllib.error
+import psycopg2
+import psycopg2.extensions
+from datetime import datetime, timezone
+
+# Git operation lock - prevents concurrent sync_schema_to_github from colliding
+_git_lock_fd = None
+_git_lock_path = os.path.expanduser('~/.openclaw/workspace/scripts/.pg-notify-git.lock')
+
+# Load PG config from postgres.json (central config, not hardcoded)
+sys.path.insert(0, os.path.join(os.path.expanduser("~"), ".openclaw/workspace/nova-mind/lib"))
+from pg_env import load_pg_env
+_pg_env = load_pg_env()
+_agent_chat_env = load_pg_env(section="agent_chat")
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", os.path.expanduser("~/.openclaw/workspace"))
+SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+DASHBOARD_SCRIPT = os.path.join(os.path.expanduser("~"), "www/static/gambling/generate-stats.py")
+DASHBOARD_HTML = os.path.join(os.path.expanduser("~"), "www/static/gambling/index.html")
+VENV_PYTHON = os.path.join(os.path.expanduser("~/.local/share"), getpass.getuser(), "venv/bin/python")
+
+# Schema sync config
+NOVA_MIND_DIR = os.path.join(WORKSPACE, "nova-mind")
+SCHEMA_FILE = os.path.join(NOVA_MIND_DIR, "database", "schema.sql")
+SCHEMA_REFERENCE_FILE = os.path.join(NOVA_MIND_DIR, "database", "schema-reference.md")
+RENAMES_FILE = os.path.join(NOVA_MIND_DIR, "memory", "database", "renames.json")
+
+# Clawdbot webhook config
+CLAWDBOT_WEBHOOK = "http://localhost:18789/hooks/wake"
+CLAWDBOT_TOKEN = "NOVA-schema-hook-2026"
+
+# Project ID for Nova Memory System
+NOVA_MEMORY_PROJECT_ID = 1
+
+def log(msg):
+    print(f"[{datetime.now().isoformat()}] {msg}", flush=True)
+
+def regenerate_dashboard():
+    """Run the dashboard generation script."""
+    try:
+        result = subprocess.run(
+            [VENV_PYTHON, DASHBOARD_SCRIPT, "--embed", DASHBOARD_HTML],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        if result.returncode == 0:
+            log(f"Dashboard regenerated: {result.stdout.strip()}")
+        else:
+            log(f"Dashboard error: {result.stderr}")
+    except Exception as e:
+        log(f"Failed to regenerate dashboard: {e}")
+
+def log_schema_event(command, obj_type, obj_name, success, commit_hash=None):
+    """Log schema change event to the database."""
+    try:
+        conn = psycopg2.connect(host=_pg_env.get('PGHOST', 'localhost'), database=_pg_env['PGDATABASE'], user=_pg_env['PGUSER'], password=_pg_env.get('PGPASSWORD', ''))
+        cur = conn.cursor()
+
+        table_name = obj_name.split('.')[-1] if '.' in obj_name else obj_name
+        title = f"Schema: {command} {obj_type} {table_name}"
+
+        if success:
+            description = f"Auto-synced {command} on {obj_name} to GitHub"
+            if commit_hash:
+                description += f" (commit: {commit_hash})"
+        else:
+            description = f"Failed to sync {command} on {obj_name}"
+
+        # Insert event
+        cur.execute("""
+            INSERT INTO events (event_date, title, description, source)
+            VALUES (NOW(), %s, %s, 'pg-notify-listener')
+            RETURNING id
+        """, (title, description))
+        event_id = cur.fetchone()[0]
+
+        # Link to Nova Memory project
+        cur.execute("""
+            INSERT INTO event_projects (event_id, project_id)
+            VALUES (%s, %s)
+            ON CONFLICT DO NOTHING
+        """, (event_id, NOVA_MEMORY_PROJECT_ID))
+
+        conn.commit()
+        cur.close()
+        conn.close()
+        log(f"Logged event #{event_id}: {title}")
+        return event_id
+
+    except Exception as e:
+        log(f"Failed to log event: {e}")
+        return None
+
+def notify_clawdbot(message):
+    """DEPRECATED: clawdbot webhook is dead. Keeping as no-op."""
+    return  # Webhook returns 404/405 - removed per nova-workspace#4
+
+    """Send a message to Clawdbot via webhook."""
+    try:
+        payload = json.dumps({
+            "text": message,
+            "mode": "now"
+        }).encode('utf-8')
+
+        req = urllib.request.Request(
+            CLAWDBOT_WEBHOOK,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {CLAWDBOT_TOKEN}"
+            }
+        )
+
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            log(f"Clawdbot notified: {resp.status}")
+            return True
+    except urllib.error.URLError as e:
+        log(f"Failed to notify Clawdbot: {e}")
+        return False
+    except Exception as e:
+        log(f"Error notifying Clawdbot: {e}")
+        return False
+
+def sync_schema_to_github(command, obj_type, obj_name):
+    """Dump schema and push to GitHub. Uses file lock to serialize concurrent calls."""
+    global _git_lock_fd
+    try:
+        # Acquire file lock to prevent concurrent git operations
+        _git_lock_fd = open(_git_lock_path, 'w')
+        fcntl.flock(_git_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (IOError, OSError):
+        log(f"Git lock held by another sync - skipping (would cause .git/index.lock collision)")
+        if _git_lock_fd:
+            try:
+                _git_lock_fd.close()
+            except Exception:
+                pass
+            _git_lock_fd = None
+        return False, None
+    try:
+        # Extract table name for commit message
+        table_name = obj_name.split('.')[-1] if '.' in obj_name else obj_name
+
+        # 1. Dump schema to file (pgschema produces clean SQL without pg_dump artifacts)
+        log(f"Dumping schema to {SCHEMA_FILE}...")
+        with open(SCHEMA_FILE, 'w') as schema_out:
+            result = subprocess.run(
+                ['pgschema', 'dump',
+                 '--host', '/var/run/postgresql',
+                 '--db', 'nova_memory',
+                 '--user', 'nova',
+                 '--schema', 'public'],
+                stdout=schema_out,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=60
+            )
+        if result.returncode != 0:
+            log(f"pgschema dump failed: {result.stderr}")
+            return False, None
+
+        # 2. Check if there are actual changes
+        status = subprocess.run(
+            ['git', '-C', NOVA_MIND_DIR, 'status', '--porcelain'],
+            capture_output=True,
+            text=True
+        )
+        if not status.stdout.strip():
+            log("No schema changes to commit (file unchanged)")
+            return True, None  # Success but no commit needed
+
+        # 3. Git add schema.sql and README.md (if README has changes too)
+        subprocess.run(
+            ['git', '-C', NOVA_MIND_DIR, 'add', 'database/schema.sql'],
+            check=True
+        )
+        # Also add README.md if it has uncommitted changes (manual docs updates)
+        readme_status = subprocess.run(
+            ['git', '-C', NOVA_MIND_DIR, 'status', '--porcelain', 'README.md'],
+            capture_output=True,
+            text=True
+        )
+        if readme_status.stdout.strip():
+            subprocess.run(
+                ['git', '-C', NOVA_MIND_DIR, 'add', 'README.md'],
+                check=True
+            )
+            log("Including README.md in commit")
+
+        # 4. Git commit
+        commit_msg = f"schema: {command} {table_name}"
+        subprocess.run(
+            ['git', '-C', NOVA_MIND_DIR, 'commit', '-m', commit_msg],
+            capture_output=True,
+            check=True
+        )
+        log(f"Committed: {commit_msg}")
+
+        # 5. Get commit hash
+        hash_result = subprocess.run(
+            ['git', '-C', NOVA_MIND_DIR, 'rev-parse', '--short', 'HEAD'],
+            capture_output=True,
+            text=True
+        )
+        commit_hash = hash_result.stdout.strip() if hash_result.returncode == 0 else None
+
+        # 6. Delegate push to Gidget (Version Control domain) via agent_chat
+        try:
+            push_conn = psycopg2.connect(
+                host=_agent_chat_env.get('PGHOST', 'localhost'),
+                database=_agent_chat_env['PGDATABASE'],
+                user=_agent_chat_env['PGUSER'],
+                password=_agent_chat_env.get('PGPASSWORD', '')
+            )
+            push_cur = push_conn.cursor()
+            push_cur.execute(
+                "SELECT send_agent_message(%s, %s, %s)",
+                (
+                    'schema-sync',
+                    f'Push pending schema commit to GitHub:\n'
+                    f'  repo: nova-mind\n'
+                    f'  path: {NOVA_MIND_DIR}\n'
+                    f'  commit: {commit_hash}\n'
+                    f'  message: schema: {command} {table_name}\n'
+                    f'Please run: cd {NOVA_MIND_DIR} && git push origin main',
+                    ['gidget']
+                )
+            )
+            push_conn.commit()
+            push_cur.close()
+            push_conn.close()
+            log(f"Delegated push to Gidget via agent_chat (commit: {commit_hash})")
+            return True, commit_hash
+        except Exception as push_err:
+            log(f"Failed to delegate push to Gidget: {push_err}")
+            return False, None
+
+    except subprocess.TimeoutExpired:
+        log("Schema sync timed out")
+        return False, None
+    except subprocess.CalledProcessError as e:
+        log(f"Schema sync failed: {e}")
+        return False, None
+    except Exception as e:
+        log(f"Error syncing schema: {e}")
+        return False, None
+    finally:
+        # Release git lock
+        if _git_lock_fd:
+            try:
+                fcntl.flock(_git_lock_fd, fcntl.LOCK_UN)
+            except Exception:
+                pass
+            try:
+                _git_lock_fd.close()
+            except Exception:
+                pass
+            _git_lock_fd = None
+
+def generate_schema_reference():
+    """Generate a human-readable schema reference for memory."""
+    try:
+        # Get list of tables with comments
+        query = """
+        SELECT
+            t.table_name,
+            pg_catalog.obj_description(pgc.oid, 'pg_class') as comment,
+            (SELECT count(*) FROM information_schema.columns c
+             WHERE c.table_name = t.table_name AND c.table_schema = 'public') as col_count
+        FROM information_schema.tables t
+        JOIN pg_catalog.pg_class pgc ON pgc.relname = t.table_name
+        WHERE t.table_schema = 'public'
+          AND t.table_type = 'BASE TABLE'
+        ORDER BY t.table_name;
+        """
+
+        result = subprocess.run(
+            ['psql', '-d', 'nova_memory', '-t', '-A', '-F', '|', '-c', query],
+            capture_output=True,
+            text=True
+        )
+
+        if result.returncode != 0:
+            log(f"Failed to query tables: {result.stderr}")
+            return False
+
+        # Build markdown content
+        lines = [
+            "# Database Schema Reference",
+            "",
+            f"*Auto-generated: {datetime.now().isoformat()}*",
+            "",
+            "## Tables",
+            "",
+            "| Table | Description | Columns |",
+            "|-------|-------------|---------|"
+        ]
+
+        for line in result.stdout.strip().split('\n'):
+            if not line:
+                continue
+            parts = line.split('|')
+            if len(parts) >= 3:
+                table = parts[0]
+                comment = parts[1] if parts[1] else '-'
+                cols = parts[2]
+                lines.append(f"| {table} | {comment} | {cols} |")
+
+        lines.extend([
+            "",
+            "## Quick Reference",
+            "",
+            "- **Full schema:** `~/.openclaw/workspace/nova-mind/database/schema.sql` (synced to GitHub)",
+            "- **Query tables:** `psql -d nova_memory -c '\\dt'`",
+            "- **Describe table:** `psql -d nova_memory -c '\\d table_name'`",
+            ""
+        ])
+
+        # Write to file
+        os.makedirs(os.path.dirname(SCHEMA_REFERENCE_FILE), exist_ok=True)
+        with open(SCHEMA_REFERENCE_FILE, 'w') as f:
+            f.write('\n'.join(lines))
+
+        log(f"Updated schema reference: {SCHEMA_REFERENCE_FILE}")
+        return True
+
+    except Exception as e:
+        log(f"Error generating schema reference: {e}")
+        return False
+
+def detect_and_record_rename(payload):
+    """Detect RENAME operations in DDL queries and append to renames.json."""
+    query = payload.get('query', '')
+    if not query:
+        return
+
+    # Patterns for all rename types:
+    # ALTER TABLE x RENAME TO y
+    # ALTER TABLE x RENAME COLUMN a TO b
+    # ALTER INDEX x RENAME TO y
+    # ALTER SEQUENCE x RENAME TO y
+    # ALTER TYPE x RENAME TO y
+    # ALTER TABLE x RENAME CONSTRAINT a TO b
+    patterns = [
+        # Column rename: ALTER TABLE <table> RENAME COLUMN <from> TO <to>
+        re.compile(
+            r'ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:"?(\w+)"?\.)?(?:"?(\w+)"?)\s+'
+            r'RENAME\s+COLUMN\s+"?(\w+)"?\s+TO\s+"?(\w+)"?',
+            re.IGNORECASE
+        ),
+        # Table rename: ALTER TABLE <from> RENAME TO <to>
+        re.compile(
+            r'ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:"?(\w+)"?\.)?(?:"?(\w+)"?)\s+'
+            r'RENAME\s+TO\s+"?(\w+)"?',
+            re.IGNORECASE
+        ),
+        # Index rename: ALTER INDEX <from> RENAME TO <to>
+        re.compile(
+            r'ALTER\s+INDEX\s+(?:IF\s+EXISTS\s+)?(?:"?(\w+)"?\.)?(?:"?(\w+)"?)\s+'
+            r'RENAME\s+TO\s+"?(\w+)"?',
+            re.IGNORECASE
+        ),
+        # Sequence rename: ALTER SEQUENCE <from> RENAME TO <to>
+        re.compile(
+            r'ALTER\s+SEQUENCE\s+(?:IF\s+EXISTS\s+)?(?:"?(\w+)"?\.)?(?:"?(\w+)"?)\s+'
+            r'RENAME\s+TO\s+"?(\w+)"?',
+            re.IGNORECASE
+        ),
+        # Constraint rename: ALTER TABLE <table> RENAME CONSTRAINT <from> TO <to>
+        re.compile(
+            r'ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:"?(\w+)"?\.)?(?:"?(\w+)"?)\s+'
+            r'RENAME\s+CONSTRAINT\s+"?(\w+)"?\s+TO\s+"?(\w+)"?',
+            re.IGNORECASE
+        ),
+    ]
+
+    entries = []
+    now = datetime.now(timezone.utc).isoformat()
+
+    # Check column rename (4-group pattern)
+    m = patterns[0].search(query)
+    if m:
+        schema, table, col_from, col_to = m.groups()
+        entries.append({
+            "table": table,
+            "column": {"from": col_from, "to": col_to},
+            "captured_at": now,
+            "captured_sql": query.strip()
+        })
+
+    # Check constraint rename (4-group pattern)
+    if not entries:
+        m = patterns[4].search(query)
+        if m:
+            schema, table, con_from, con_to = m.groups()
+            entries.append({
+                "table": table,
+                "constraint": {"from": con_from, "to": con_to},
+                "captured_at": now,
+                "captured_sql": query.strip()
+            })
+
+    # Check table/index/sequence rename (3-group patterns)
+    if not entries:
+        for i, pattern in enumerate(patterns[1:4], 1):
+            m = pattern.search(query)
+            if m:
+                schema, obj_from, obj_to = m.groups()
+                kind = ["table", "index", "sequence"][i - 1]
+                entry = {
+                    kind: {"from": obj_from, "to": obj_to},
+                    "captured_at": now,
+                    "captured_sql": query.strip()
+                }
+                entries.append(entry)
+                break
+
+    if not entries:
+        return
+
+    # Append to renames.json
+    try:
+        if os.path.isfile(RENAMES_FILE):
+            with open(RENAMES_FILE, 'r') as f:
+                data = json.load(f)
+        else:
+            data = {"renames": []}
+
+        for entry in entries:
+            # Dedup: skip if an identical rename already exists
+            is_dup = False
+            for existing in data.get("renames", []):
+                # Column rename dedup
+                if entry.get("column") and existing.get("column"):
+                    if (isinstance(existing["column"], dict) and
+                            existing.get("table") == entry.get("table") and
+                            existing["column"].get("from") == entry["column"]["from"] and
+                            existing["column"].get("to") == entry["column"]["to"]):
+                        is_dup = True
+                        break
+                # Constraint rename dedup
+                elif entry.get("constraint") and existing.get("constraint"):
+                    if (isinstance(existing["constraint"], dict) and
+                            existing.get("table") == entry.get("table") and
+                            existing["constraint"].get("from") == entry["constraint"]["from"] and
+                            existing["constraint"].get("to") == entry["constraint"]["to"]):
+                        is_dup = True
+                        break
+                # Table/index/sequence rename dedup (value is a dict with from/to)
+                else:
+                    for kind in ("table", "index", "sequence"):
+                        e_val = entry.get(kind)
+                        x_val = existing.get(kind)
+                        if (isinstance(e_val, dict) and isinstance(x_val, dict) and
+                                x_val.get("from") == e_val["from"] and
+                                x_val.get("to") == e_val["to"]):
+                            is_dup = True
+                            break
+                if is_dup:
+                    break
+
+            if not is_dup:
+                data["renames"].append(entry)
+                log(f"Recorded rename in renames.json: {json.dumps(entry, separators=(',', ':'))}")
+
+        os.makedirs(os.path.dirname(RENAMES_FILE), exist_ok=True)
+        with open(RENAMES_FILE, 'w') as f:
+            json.dump(data, f, indent=2)
+            f.write('\n')
+
+    except Exception as e:
+        log(f"Error appending to renames.json: {e}")
+
+
+def handle_schema_change(payload_str):
+    """Handle a schema change notification."""
+    try:
+        payload = json.loads(payload_str)
+        command = payload.get('command_tag', 'UNKNOWN')
+        obj_type = payload.get('object_type', 'unknown')
+        obj_name = payload.get('object_identity', 'unknown')
+
+        log(f"Schema change detected: {command} {obj_type} {obj_name}")
+
+        # Skip internal/system objects and pgschema temp schemas
+        if obj_name.startswith('pg_') or 'pg_toast' in obj_name:
+            log(f"Skipping system object: {obj_name}")
+            return
+        if 'pgschema_tmp_' in obj_name:
+            log(f"Skipping pgschema temp schema: {obj_name}")
+            return
+
+        # Auto-sync to GitHub
+        github_ok, commit_hash = sync_schema_to_github(command, obj_type, obj_name)
+
+        # Update local schema reference
+        ref_ok = generate_schema_reference()
+
+        # Log to events database
+        log_schema_event(command, obj_type, obj_name, github_ok, commit_hash)
+
+        # Notify NOVA of result (informational only - work is done)
+        table_name = obj_name.split('.')[-1] if '.' in obj_name else obj_name
+
+        if github_ok and ref_ok:
+            commit_info = f" ({commit_hash})" if commit_hash else ""
+            message = f"""✅ Schema auto-synced: {command} {obj_type} `{table_name}` → GitHub{commit_info}
+
+📝 **Action needed:** Update README.md documentation for `{table_name}` if this added/changed columns:
+1. Document new columns with purpose and usage patterns
+2. The README will be auto-included in the next schema commit"""
+        elif github_ok:
+            message = f"⚠️ Schema synced to GitHub ({command} {table_name}) but local reference failed"
+        else:
+            message = f"""❌ Schema sync FAILED for {command} {obj_type} `{obj_name}`
+
+Manual sync required:
+1. cd ~/.openclaw/workspace/nova-mind
+2. pgschema dump --db nova_memory --user nova > database/schema.sql
+3. git add -A && git commit -m "schema: {command} {table_name}"
+4. Delegate push to Gidget via agent_chat"""
+
+        notify_clawdbot(message)
+
+    except json.JSONDecodeError as e:
+        log(f"Invalid schema change payload: {e}")
+    except Exception as e:
+        log(f"Error handling schema change: {e}")
+
+def main():
+    log("Starting PostgreSQL notification listener...")
+
+    conn = psycopg2.connect(host=_pg_env.get('PGHOST', 'localhost'), database=_pg_env['PGDATABASE'], user=_pg_env['PGUSER'], password=_pg_env.get('PGPASSWORD', ''))
+    conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+
+    cur = conn.cursor()
+    cur.execute("LISTEN gambling_changed;")
+    cur.execute("LISTEN schema_changed;")
+    log("Listening for: gambling_changed, schema_changed")
+
+    # Track last updates to debounce rapid changes
+    last_gambling_update = 0
+    last_schema_update = 0
+    debounce_gambling = 5  # seconds
+    debounce_schema = 30   # seconds (schema changes less frequent, longer debounce)
+
+    # Dedup cache: tracks (object_identity, command_tag) seen within debounce window
+    # Prevents duplicate processing when the DB trigger fires multiple notifications
+    # for a single DDL statement (e.g., CREATE FUNCTION fires once per argument type)
+    schema_dedup_cache = {}  # key: (command_tag, object_identity) -> timestamp
+
+    while True:
+        try:
+            if select.select([conn], [], [], 60) == ([], [], []):
+                # Timeout - just continue (keeps connection alive)
+                continue
+
+            conn.poll()
+            while conn.notifies:
+                notify = conn.notifies.pop(0)
+                now = time.time()
+
+                if notify.channel == 'gambling_changed':
+                    log(f"Received: {notify.channel} - {notify.payload}")
+                    if now - last_gambling_update >= debounce_gambling:
+                        regenerate_dashboard()
+                        last_gambling_update = now
+                    else:
+                        log(f"Debounced gambling (last update {now - last_gambling_update:.1f}s ago)")
+
+                elif notify.channel == 'schema_changed':
+                    log(f"Received: {notify.channel} - {notify.payload}")
+
+                    # Rename detection runs on EVERY event (cheap file append, no debounce)
+                    try:
+                        detect_and_record_rename(json.loads(notify.payload))
+                    except Exception as e:
+                        log(f"Rename detection error: {e}")
+
+                    # Dedup: skip if we've seen this exact (command_tag, object_identity) recently
+                    is_dup = False
+                    try:
+                        p = json.loads(notify.payload)
+                        dedup_key = (p.get('command_tag', ''), p.get('object_identity', ''))
+                        if dedup_key in schema_dedup_cache and now - schema_dedup_cache[dedup_key] < debounce_schema:
+                            log(f"Deduplicated schema notification: {dedup_key[0]} {dedup_key[1]} (duplicate within {debounce_schema}s)")
+                            is_dup = True
+                        else:
+                            schema_dedup_cache[dedup_key] = now
+                            # Prune old entries from cache
+                            schema_dedup_cache = {k: v for k, v in schema_dedup_cache.items() if now - v < debounce_schema * 2}
+                    except (json.JSONDecodeError, Exception) as e:
+                        log(f"Dedup parse error (processing anyway): {e}")
+
+                    # Full schema sync is debounced (expensive git/push)
+                    if not is_dup and now - last_schema_update >= debounce_schema:
+                        handle_schema_change(notify.payload)
+                        last_schema_update = now
+                    elif is_dup:
+                        pass  # already logged above
+                    else:
+                        log(f"Debounced schema sync (last update {now - last_schema_update:.1f}s ago)")
+        except Exception as e:
+            log(f"Error in main loop: {e}")
+            time.sleep(5)
+
+if __name__ == "__main__":
+    main()

--- a/cognition/skills/introspect/SKILL.md
+++ b/cognition/skills/introspect/SKILL.md
@@ -43,6 +43,8 @@ Start with the channel transcript — it's usually enough. Fall back to memory f
 
 Build a list of **significant actions taken** — installs, config changes, new scripts, debugging steps, process deviations, lessons learned.
 
+> **⚠️ Secret-safe transcript greps:** Session transcripts may contain delivered credentials (rotated passwords DM'd to users, tokens echoed by tools). When grepping transcripts for evidence, match on context keywords only and cap capture length (e.g. `grep -o "htpasswd.\{0,40\}"`), never wide patterns like `.\{0,200\}` that can pull secret values into *this* session's transcript. Introspection must not become an exposure amplifier. (Learned 2026-07-03: an introspection grep re-surfaced a freshly rotated password verbatim.)
+
 ### 2. Socratic Self-Questioning
 
 Before identifying gaps, apply recursive Socratic questioning to each significant action. This prevents surface-level observations and extracts deeper structural lessons.

--- a/cognition/systemd/pg-notify-listener.service
+++ b/cognition/systemd/pg-notify-listener.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=PostgreSQL Notify Listener (%u)
+After=network.target postgresql.service
+
+[Service]
+Type=simple
+ExecStart=%h/.local/share/%u/venv/bin/python %h/.openclaw/workspace/scripts/pg-notify-listener.py
+WorkingDirectory=%h/.openclaw/workspace/scripts
+StandardOutput=append:%h/.openclaw/workspace/logs/pg-notify-listener.log
+StandardError=append:%h/.openclaw/workspace/logs/pg-notify-listener.log
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/database/agent-chat/schema.sql
+++ b/database/agent-chat/schema.sql
@@ -1,0 +1,303 @@
+--
+-- agent_chat database schema
+-- Issue: NOVA-Openclaw/nova-mind#320
+--
+-- This file defines the standalone messaging bus database. It is applied AFTER
+-- the `agent_chat` database has been created by the migration tooling.
+--
+-- Design decisions (authoritative, 2026-07-03):
+--   * agent_chat_status type migrates.
+--   * Tables agent_chat + agent_chat_processed migrate with all data.
+--   * Indexes migrate except the duplicate idx_chat_processed_agent.
+--   * Functions migrate: send_agent_message (SECURITY DEFINER), notify_agent_chat,
+--     enforce_agent_chat_function_use, expire_old_chat.
+--   * chat() and embed_chat_message() do NOT migrate; they are dropped from
+--     nova_memory at decommission.
+--   * Triggers migrate: trg_notify_agent_chat (ENABLE ALWAYS) and ONE enforce
+--     trigger (trg_enforce_agent_chat_function_use). trg_embed_chat_message is
+--     intentionally absent.
+--   * Views v_agent_chat_recent and v_agent_chat_stats migrate.
+--   * Grants replicate the nova_memory matrix for the 18 nova-ecosystem agent
+--     roles including Newhart's REVOKEs, plus victoria (send+receive) and
+--     nova-staging (SEND capability).
+--
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+--
+-- Name: agent_chat_status; Type: TYPE; Schema: public; Owner: -
+--
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace WHERE n.nspname = 'public' AND t.typname = 'agent_chat_status') THEN
+        CREATE TYPE public.agent_chat_status AS ENUM (
+            'received',
+            'routed',
+            'responded',
+            'failed'
+        );
+    END IF;
+END $$;
+
+--
+-- Name: agent_chat; Type: TABLE; Schema: public; Owner: -
+--
+CREATE TABLE IF NOT EXISTS public.agent_chat (
+    id SERIAL,
+    sender varchar(50) NOT NULL,
+    message text NOT NULL,
+    recipients text[] NOT NULL,
+    reply_to integer,
+    "timestamp" timestamptz DEFAULT now() NOT NULL,
+    CONSTRAINT agent_chat_pkey PRIMARY KEY (id),
+    CONSTRAINT agent_chat_reply_to_fkey FOREIGN KEY (reply_to) REFERENCES public.agent_chat (id),
+    CONSTRAINT agent_chat_recipients_check CHECK (array_length(recipients, 1) > 0)
+);
+
+COMMENT ON TABLE public.agent_chat IS 'Agent messaging. INSERT allowed for all, UPDATE/DELETE only Newhart.';
+
+--
+-- Name: agent_chat_processed; Type: TABLE; Schema: public; Owner: -
+--
+CREATE TABLE IF NOT EXISTS public.agent_chat_processed (
+    chat_id integer,
+    agent varchar(50),
+    received_at timestamp,
+    routed_at timestamp,
+    responded_at timestamp,
+    error_message text,
+    status public.agent_chat_status DEFAULT 'responded'::public.agent_chat_status,
+    CONSTRAINT agent_chat_processed_pkey PRIMARY KEY (chat_id, agent),
+    CONSTRAINT agent_chat_processed_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES public.agent_chat (id)
+);
+
+COMMENT ON TABLE public.agent_chat_processed IS 'Message processing state. Agents can track, Newhart manages.';
+
+--
+-- Indexes (duplicate idx_chat_processed_agent intentionally omitted)
+--
+CREATE INDEX IF NOT EXISTS idx_agent_chat_recipients ON public.agent_chat USING gin (recipients);
+CREATE INDEX IF NOT EXISTS idx_agent_chat_sender ON public.agent_chat (sender, "timestamp" DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_chat_timestamp ON public.agent_chat ("timestamp");
+
+CREATE INDEX IF NOT EXISTS idx_agent_chat_processed_agent ON public.agent_chat_processed (agent);
+CREATE INDEX IF NOT EXISTS idx_agent_chat_processed_status ON public.agent_chat_processed (status);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_chat_processed_unique ON public.agent_chat_processed (chat_id, agent);
+
+--
+-- Functions
+--
+
+-- Name: notify_agent_chat(); Type: FUNCTION; Schema: public; Owner: -
+CREATE OR REPLACE FUNCTION public.notify_agent_chat()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    PERFORM pg_notify('agent_chat', json_build_object(
+        'id', NEW.id,
+        'sender', NEW.sender,
+        'recipients', NEW.recipients
+    )::text);
+    RETURN NEW;
+END;
+$$;
+
+-- Name: send_agent_message(text, text, text[]); Type: FUNCTION; Schema: public; Owner: -
+CREATE OR REPLACE FUNCTION public.send_agent_message(
+    p_sender text,
+    p_message text,
+    p_recipients text[]
+)
+RETURNS integer
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_id        INTEGER;
+    v_sender    TEXT;
+    v_recipients TEXT[];
+BEGIN
+    -- Validate inputs
+    IF p_message IS NULL OR trim(p_message) = '' THEN
+        RAISE EXCEPTION 'send_agent_message: message cannot be empty';
+    END IF;
+
+    IF p_recipients IS NULL OR array_length(p_recipients, 1) IS NULL THEN
+        RAISE EXCEPTION 'send_agent_message: recipients cannot be NULL or empty — use ARRAY[''*''] for broadcast';
+    END IF;
+
+    -- Normalize to lowercase
+    v_sender := LOWER(p_sender);
+    v_recipients := ARRAY(SELECT LOWER(unnest(p_recipients)));
+
+    -- Bypass gate and insert
+    SET LOCAL agent_chat.bypass_gate = 'on';
+    INSERT INTO public.agent_chat (sender, message, recipients)
+    VALUES (v_sender, p_message, v_recipients)
+    RETURNING id INTO v_id;
+
+    RETURN v_id;
+END;
+$$;
+
+-- Name: enforce_agent_chat_function_use(); Type: FUNCTION; Schema: public; Owner: -
+CREATE OR REPLACE FUNCTION public.enforce_agent_chat_function_use()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    -- Skip enforcement for logical replication (apply worker)
+    IF current_setting('agent_chat.bypass_gate', true) IS NOT DISTINCT FROM 'on' THEN
+        RETURN NEW;
+    END IF;
+    -- Check if this is a replication apply worker
+    IF EXISTS (SELECT 1 FROM pg_stat_activity WHERE pid = pg_backend_pid() AND backend_type = 'logical replication worker') THEN
+        RETURN NEW;
+    END IF;
+    RAISE EXCEPTION 'Direct INSERT on agent_chat is not allowed. Use send_agent_message() instead.';
+END;
+$$;
+
+-- Name: expire_old_chat(integer); Type: FUNCTION; Schema: public; Owner: -
+CREATE OR REPLACE FUNCTION public.expire_old_chat(
+    retention_days integer DEFAULT 90
+)
+RETURNS integer
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+DECLARE deleted_count integer;
+BEGIN
+    DELETE FROM public.agent_chat WHERE "timestamp" < now() - (retention_days || ' days')::interval;
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$;
+
+--
+-- Views
+--
+
+-- Name: v_agent_chat_recent; Type: VIEW; Schema: public; Owner: -
+CREATE OR REPLACE VIEW public.v_agent_chat_recent AS
+ SELECT id,
+    sender,
+    message,
+    recipients,
+    reply_to,
+    "timestamp"
+   FROM public.agent_chat
+  WHERE "timestamp" > (now() - '30 days'::interval)
+  ORDER BY "timestamp" DESC;
+
+-- Name: v_agent_chat_stats; Type: VIEW; Schema: public; Owner: -
+CREATE OR REPLACE VIEW public.v_agent_chat_stats AS
+ SELECT count(*) AS total_messages,
+    count(*) FILTER (WHERE "timestamp" > (now() - '24:00:00'::interval)) AS messages_24h,
+    count(*) FILTER (WHERE "timestamp" > (now() - '7 days'::interval)) AS messages_7d,
+    count(DISTINCT sender) AS unique_senders,
+    pg_size_pretty(pg_total_relation_size('agent_chat'::regclass)) AS table_size,
+    min("timestamp") AS oldest_message,
+    max("timestamp") AS newest_message
+   FROM public.agent_chat;
+
+--
+-- Triggers
+--
+
+-- Name: trg_notify_agent_chat; Type: TRIGGER; Schema: public; Owner: -
+-- ENABLE ALWAYS is required so that replication-apply-worker-originated inserts
+-- still notify bus listeners.
+DROP TRIGGER IF EXISTS trg_notify_agent_chat ON public.agent_chat;
+CREATE TRIGGER trg_notify_agent_chat
+    AFTER INSERT ON public.agent_chat
+    FOR EACH ROW
+    EXECUTE FUNCTION public.notify_agent_chat();
+
+ALTER TABLE public.agent_chat ENABLE ALWAYS TRIGGER trg_notify_agent_chat;
+
+-- Name: trg_enforce_agent_chat_function_use; Type: TRIGGER; Schema: public; Owner: -
+-- Only ONE enforce trigger is created in the new DB (duplicate
+-- trg_enforce_function_use is intentionally omitted).
+DROP TRIGGER IF EXISTS trg_enforce_agent_chat_function_use ON public.agent_chat;
+CREATE TRIGGER trg_enforce_agent_chat_function_use
+    BEFORE INSERT ON public.agent_chat
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_agent_chat_function_use();
+
+--
+-- Privileges
+--
+-- Replicate the effective grant matrix from nova_memory.
+-- Default privileges mirror the source dump so future objects created by
+-- postgres/nova get the same grants; explicit grants make current objects
+-- deterministic regardless of which role creates them.
+--
+
+-- Default privileges (mirrors nova_memory dump).
+-- The postgres-role default privileges can only be set by a superuser. They
+-- are wrapped so that the schema file can still be applied by a non-superuser
+-- (e.g. nova in a devtest environment) without failing.
+DO $$
+BEGIN
+    ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT USAGE ON SEQUENCES TO argus, athena, coder, conductor, erato, flint, gem, gidget, hermes, iris, marcie, nova, quill, scout, scribe, ticker;
+    ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT DELETE, INSERT, SELECT, UPDATE ON TABLES TO argus, athena, coder, conductor, erato, flint, gem, gidget, hermes, iris, marcie, nova, quill, scout, scribe, ticker;
+EXCEPTION WHEN insufficient_privilege THEN
+    RAISE NOTICE 'Skipping postgres default privileges: current user is not a superuser';
+END $$;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE nova IN SCHEMA public GRANT SELECT ON TABLES TO argus, athena, coder, conductor, erato, flint, gem, gidget, graybeard, hermes, iris, marcie, newhart, "nova-staging", quill, scout, scribe, ticker;
+
+-- Explicit table grants for all nova-ecosystem agent roles (18 roles)
+GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE public.agent_chat TO argus, athena, coder, conductor, erato, flint, gem, gidget, hermes, iris, marcie, nova, quill, scout, scribe, ticker;
+GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE public.agent_chat_processed TO argus, athena, coder, conductor, erato, flint, gem, gidget, hermes, iris, marcie, nova, quill, scout, scribe, ticker;
+
+-- Newhart's access is intentionally restricted: revoke all privileges that
+-- default privileges would otherwise grant.
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE public.agent_chat FROM newhart;
+REVOKE SELECT ON TABLE public.agent_chat FROM newhart;
+REVOKE DELETE, INSERT, SELECT, UPDATE ON TABLE public.agent_chat_processed FROM newhart;
+REVOKE SELECT ON TABLE public.agent_chat_processed FROM newhart;
+
+-- Peer agent graybeard gets the same full CRUD as subagents.
+GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE public.agent_chat TO graybeard;
+GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE public.agent_chat_processed TO graybeard;
+
+-- nova-staging: SEND capability per decision #6. EXECUTE on send_agent_message
+-- is granted explicitly below; SELECT on the bus tables lets it read/poll.
+GRANT SELECT ON TABLE public.agent_chat TO "nova-staging";
+GRANT SELECT ON TABLE public.agent_chat_processed TO "nova-staging";
+
+-- victoria: send+receive capability on the shared cross-ecosystem bus.
+GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE public.agent_chat TO victoria;
+GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE public.agent_chat_processed TO victoria;
+
+-- Sequence grants (replicate nova_memory matrix; newhart intentionally absent)
+GRANT USAGE ON SEQUENCE public.agent_chat_id_seq TO argus, coder, conductor, erato, flint, gem, gidget, graybeard, hermes, iris, marcie, nova, quill, scribe, ticker;
+GRANT SELECT, USAGE ON SEQUENCE public.agent_chat_id_seq TO athena, scout;
+GRANT USAGE ON SEQUENCE public.agent_chat_id_seq TO victoria;
+-- nova-staging only needs SEND capability; it does not need to allocate sequence values.
+
+-- View grants (replicate nova_memory matrix)
+GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE public.v_agent_chat_recent TO argus, athena, coder, conductor, erato, flint, gem, gidget, hermes, iris, marcie, newhart, nova, quill, scout, scribe, ticker;
+GRANT SELECT ON TABLE public.v_agent_chat_recent TO graybeard, "nova-staging";
+GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE public.v_agent_chat_stats TO argus, athena, coder, conductor, erato, flint, gem, gidget, hermes, iris, marcie, newhart, nova, quill, scout, scribe, ticker;
+GRANT SELECT ON TABLE public.v_agent_chat_stats TO graybeard, "nova-staging";
+
+-- victoria view grants (read access for receive/polling)
+GRANT SELECT ON TABLE public.v_agent_chat_recent TO victoria;
+GRANT SELECT ON TABLE public.v_agent_chat_stats TO victoria;
+
+-- Function grants: existing nova_memory functions default to PUBLIC EXECUTE.
+-- We explicitly document the required EXECUTE capability for victoria and
+-- nova-staging without revoking PUBLIC access.
+GRANT EXECUTE ON FUNCTION public.send_agent_message(text, text, text[]) TO victoria, "nova-staging";

--- a/database/schema-reference.md
+++ b/database/schema-reference.md
@@ -2,6 +2,16 @@
 
 *Auto-generated: 2026-06-09T03:38:05.109007*
 
+> **Stale as of nova-mind#320 for `agent_chat` / `agent_chat_processed`.** This file was
+> generated before the #320 migration and lists `agent_chat` and `agent_chat_processed`
+> below as if they are `nova_memory` tables. As of #320, both tables live in a separate,
+> dedicated `agent_chat` database — not `nova_memory`. This is an auto-generated file;
+> do not hand-edit the table listing below to "fix" this. Regenerate it against the
+> current `nova_memory` schema (which will correctly omit `agent_chat`/`agent_chat_processed`
+> going forward) using whatever tool produced it originally, and see
+> `memory/docs/database-config.md` / `scripts/agent-chat-migration/README.md` for the
+> current `agent_chat` schema and connection story.
+
 ## Tables
 
 | Table | Description | Columns |

--- a/lib/pg-env.ts
+++ b/lib/pg-env.ts
@@ -10,6 +10,18 @@ import { readFileSync } from "fs";
 import { homedir, userInfo } from "os";
 import { join } from "path";
 
+/**
+ * PostgreSQL connection options interface that matches
+ * the pg.Client constructor options.
+ */
+export interface PgConnectionConfig {
+  host?: string;
+  port?: number;
+  database?: string;
+  user?: string;
+  password?: string;
+}
+
 interface PgConfig {
   host?: string | null;
   port?: string | number | null;
@@ -19,7 +31,7 @@ interface PgConfig {
   [key: string]: unknown;
 }
 
-const FIELD_MAP: Array<[keyof PgConfig, string]> = [
+const FIELD_MAP: Array<[keyof PgConnectionConfig, string]> = [
   ["host", "PGHOST"],
   ["port", "PGPORT"],
   ["database", "PGDATABASE"],
@@ -32,18 +44,6 @@ const DEFAULTS: Record<string, string | (() => string)> = {
   PGPORT: "5432",
   PGUSER: () => userInfo().username,
 };
-
-/**
- * PostgreSQL connection options interface that matches
- * the pg.Client constructor options.
- */
-export interface PgConnectionConfig {
-  host?: string;
-  port?: number;
-  database?: string;
-  user?: string;
-  password?: string;
-}
 
 /**
  * Load PostgreSQL config with resolution: ENV → section → config file → defaults.

--- a/lib/pg-env.ts
+++ b/lib/pg-env.ts
@@ -1,8 +1,9 @@
 /**
- * pg-env.ts — Centralized PostgreSQL config loader for TypeScript/Node.js.
+ * pg-env.ts — Centralized PostgreSQL config loader for TypeScript/Node.js
+ * with optional nested-section support.
  *
- * Resolution order: ENV vars → ~/.openclaw/postgres.json → defaults
- * Issue: nova-memory #94, nova-mind #330
+ * Resolution order: ENV vars → section → ~/.openclaw/postgres.json (flat keys) → defaults
+ * Issue: nova-memory #94, nova-mind #330, nova-mind #320
  */
 
 import { readFileSync } from "fs";
@@ -15,6 +16,7 @@ interface PgConfig {
   database?: string | null;
   user?: string | null;
   password?: string | null;
+  [key: string]: unknown;
 }
 
 const FIELD_MAP: Array<[keyof PgConfig, string]> = [
@@ -44,7 +46,7 @@ export interface PgConnectionConfig {
 }
 
 /**
- * Load PostgreSQL config with resolution: ENV → config file → defaults.
+ * Load PostgreSQL config with resolution: ENV → section → config file → defaults.
  *
  * Returns connection config object suitable for pg.Client / pg.Pool constructor,
  * without modifying process.env to avoid pollution of the environment
@@ -52,9 +54,13 @@ export interface PgConnectionConfig {
  * Empty ENV strings are treated as unset.
  * Null values in JSON are treated as absent.
  * Malformed JSON is caught and warned about (falls through to defaults).
+ *
+ * If `section` is provided and the parsed config contains a valid object for that
+ * key, section fields take precedence over top-level keys (ENV still wins).
  */
 export function loadPgEnv(
-  configPath?: string
+  configPath?: string,
+  section?: string
 ): PgConnectionConfig {
   const cfgPath =
     configPath ?? join(homedir(), ".openclaw", "postgres.json");
@@ -81,6 +87,20 @@ export function loadPgEnv(
     }
   }
 
+  // Resolve nested section if requested. A non-object section mirrors the
+  // top-level object-type guard: warn and fall back to top-level keys.
+  let sectionConfig: PgConfig | undefined;
+  if (section) {
+    const sectionValue = config[section];
+    if (sectionValue && typeof sectionValue === "object" && !Array.isArray(sectionValue)) {
+      sectionConfig = sectionValue as PgConfig;
+    } else if (sectionValue !== undefined) {
+      console.error(
+        `WARNING: ${cfgPath}.${section} is not a JSON object, ignoring`
+      );
+    }
+  }
+
   const result: PgConnectionConfig = {};
 
   for (const [jsonKey, envVar] of FIELD_MAP) {
@@ -96,7 +116,24 @@ export function loadPgEnv(
       continue;
     }
 
-    // 2. Check config file (null/undefined = absent, empty string = absent)
+    // 2. Check section config (null/undefined = absent, empty string = absent)
+    if (sectionConfig) {
+      const sectionVal = sectionConfig[jsonKey];
+      if (sectionVal != null) {
+        const strVal = String(sectionVal);
+        if (strVal) {
+          if (jsonKey === "port") {
+            const portNum = Number(strVal);
+            if (!isNaN(portNum)) result[jsonKey] = portNum;
+          } else {
+            result[jsonKey] = strVal;
+          }
+          continue;
+        }
+      }
+    }
+
+    // 3. Check top-level config file (null/undefined = absent, empty string = absent)
     const cfgVal = config[jsonKey];
     if (cfgVal != null) {
       const strVal = String(cfgVal);
@@ -111,7 +148,7 @@ export function loadPgEnv(
       }
     }
 
-    // 3. Apply default
+    // 4. Apply default
     const def = DEFAULTS[envVar];
     if (def !== undefined) {
       const defaultVal = typeof def === "function" ? def() : def;

--- a/lib/pg_env.py
+++ b/lib/pg_env.py
@@ -1,8 +1,8 @@
 """
 pg_env.py — Centralized PostgreSQL config loader for Python.
 
-Resolution order: ENV vars → ~/.openclaw/postgres.json → defaults
-Issue: nova-memory #94
+Resolution order: ENV vars → section → ~/.openclaw/postgres.json (flat keys) → defaults
+Issue: nova-memory #94, nova-mind #320
 """
 
 import json
@@ -29,18 +29,53 @@ _DEFAULTS = {
     "PGUSER": None,  # filled dynamically with getpass.getuser()
 }
 
+# State to make repeated calls with different sections safe.  os.environ is
+# both the input (ENV overrides) and output (for child processes).  Without
+# bookkeeping, a second call would see the values written by the first call
+# as "external ENV overrides" and refuse to overwrite them.
+#
+# _PREVIOUS_ENV[var] = value before our last write (None = absent)
+# _LAST_WRITTEN[var] = value we last wrote
+_PREVIOUS_ENV: dict[str, Optional[str]] = {}
+_LAST_WRITTEN: dict[str, str] = {}
 
-def load_pg_env(config_path: Optional[str] = None) -> dict:
+
+def _restore_external_env() -> None:
+    """Undo our own writes so the next read sees only external env values."""
+    for env_var in _FIELD_MAP.values():
+        last = _LAST_WRITTEN.get(env_var)
+        if last is None:
+            continue
+        current = os.environ.get(env_var, "")
+        if current == last:
+            prev = _PREVIOUS_ENV.get(env_var)
+            if prev is None:
+                os.environ.pop(env_var, None)
+            else:
+                os.environ[env_var] = prev
+
+
+def load_pg_env(config_path: Optional[str] = None, section: Optional[str] = None) -> dict:
     """
-    Load PostgreSQL env vars with resolution: ENV → config file → defaults.
+    Load PostgreSQL env vars with resolution: ENV → section → config file → defaults.
 
     Sets os.environ for each PG* var and returns the resulting dict.
     Empty ENV strings are treated as unset.
     Null values in JSON are treated as absent.
     Malformed JSON is caught and warned about (falls through to defaults).
+
+    If `section` is provided and the config file contains a valid object for that
+    key, section fields take precedence over top-level keys (ENV still wins).
+
+    Because this function mutates os.environ, a later call with a different
+    `section` fully overwrites any PG* vars set by an earlier call — no stale
+    values leak to child processes.
     """
     if config_path is None:
         config_path = os.path.join(Path.home(), ".openclaw", "postgres.json")
+
+    # Undo our own previous writes so we don't mistake them for external ENV.
+    _restore_external_env()
 
     # Try to read config file
     config = {}
@@ -56,6 +91,19 @@ def load_pg_env(config_path: Optional[str] = None) -> dict:
         print(f"WARNING: Failed to read {config_path}: {e}, falling through to defaults", file=sys.stderr)
         config = {}
 
+    # Resolve nested section if requested. A non-object section mirrors the
+    # top-level object-type guard: warn and fall back to top-level keys.
+    section_config = {}
+    if section:
+        section_value = config.get(section)
+        if isinstance(section_value, dict):
+            section_config = section_value
+        elif section_value is not None:
+            print(
+                f"WARNING: {config_path}.{section} is not a JSON object, ignoring",
+                file=sys.stderr,
+            )
+
     result = {}
 
     for json_key, env_var in _FIELD_MAP.items():
@@ -65,16 +113,23 @@ def load_pg_env(config_path: Optional[str] = None) -> dict:
             result[env_var] = env_val
             continue
 
-        # 2. Check config file (None/null = absent, empty string = absent)
+        # 2. Check section config (None/null = absent, empty string = absent)
+        section_val = section_config.get(json_key) if section_config else None
+        if section_val is not None:
+            str_val = str(section_val)
+            if str_val:
+                result[env_var] = str_val
+                continue
+
+        # 3. Check top-level config file (None/null = absent, empty string = absent)
         cfg_val = config.get(json_key)
         if cfg_val is not None:
             str_val = str(cfg_val)
             if str_val:
                 result[env_var] = str_val
-                os.environ[env_var] = str_val
                 continue
 
-        # 3. Apply default
+        # 4. Apply default
         if env_var == "PGUSER":
             default = getpass.getuser()
         else:
@@ -82,6 +137,18 @@ def load_pg_env(config_path: Optional[str] = None) -> dict:
 
         if default is not None:
             result[env_var] = default
-            os.environ[env_var] = default
+
+    # Update os.environ and bookkeeping.  Record the value that was present
+    # before we overwrite it so the next call can restore the external baseline.
+    for env_var in _FIELD_MAP.values():
+        if env_var in result:
+            _PREVIOUS_ENV[env_var] = os.environ.get(env_var)
+            os.environ[env_var] = result[env_var]
+            _LAST_WRITTEN[env_var] = result[env_var]
+        else:
+            if env_var in _LAST_WRITTEN:
+                os.environ.pop(env_var, None)
+            _PREVIOUS_ENV.pop(env_var, None)
+            _LAST_WRITTEN.pop(env_var, None)
 
     return result

--- a/lib/tests/test_pg_env.py
+++ b/lib/tests/test_pg_env.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Test suite for lib/pg_env.py section-key support.
+
+Covers TC-23 through TC-29 for the canonical Python loader.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import importlib
+import getpass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+PASS = 0
+FAIL = 0
+
+
+def assert_eq(desc, expected, actual):
+    global PASS, FAIL
+    if expected == actual:
+        print(f"  PASS: {desc}")
+        PASS += 1
+    else:
+        print(f"  FAIL: {desc} (expected='{expected}', got='{actual}')")
+        FAIL += 1
+
+
+def assert_env_eq(desc, env_var, expected):
+    global PASS, FAIL
+    actual = os.environ.get(env_var)
+    if expected == actual:
+        print(f"  PASS: {desc}")
+        PASS += 1
+    else:
+        print(f"  FAIL: {desc} (expected='{expected}', got='{actual}')")
+        FAIL += 1
+
+
+def clear_pg_vars():
+    for v in ("PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD"):
+        os.environ.pop(v, None)
+
+
+def write_config(tmpdir, data):
+    d = os.path.join(tmpdir, ".openclaw")
+    os.makedirs(d, exist_ok=True)
+    path = os.path.join(d, "postgres.json")
+    if isinstance(data, str):
+        with open(path, "w") as f:
+            f.write(data)
+    else:
+        with open(path, "w") as f:
+            json.dump(data, f)
+    return path
+
+
+def reload_pg_env():
+    """Import a fresh copy of pg_env so module-level state is isolated."""
+    clear_pg_vars()
+    if "pg_env" in sys.modules:
+        del sys.modules["pg_env"]
+    import pg_env
+
+    return pg_env
+
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    # TC-23: Section present and valid uses section fields
+    print("TC-23: section present and valid uses section fields")
+    pg_env = reload_pg_env()
+    cfg_path = write_config(tmpdir + "/tc23", {
+        "host": "flat-host",
+        "database": "nova_memory",
+        "user": "flat-user",
+        "password": "flat-pass",
+        "agent_chat": {
+            "database": "agent_chat",
+            "user": "chat-user",
+            "password": "chat-pass",
+        },
+    })
+    result = pg_env.load_pg_env(cfg_path, section="agent_chat")
+    assert_eq("PGDATABASE", "agent_chat", result.get("PGDATABASE"))
+    assert_eq("PGUSER", "chat-user", result.get("PGUSER"))
+    assert_eq("PGPASSWORD", "chat-pass", result.get("PGPASSWORD"))
+    assert_eq("PGHOST", "flat-host", result.get("PGHOST"))
+    assert_eq("PGPORT", "5432", result.get("PGPORT"))
+
+    # TC-24: Section absent falls back to flat keys
+    print("TC-24: section absent falls back to flat keys")
+    pg_env = reload_pg_env()
+    cfg_path = write_config(tmpdir + "/tc24", {
+        "host": "flat-host",
+        "database": "nova_memory",
+        "user": "flat-user",
+        "password": "flat-pass",
+    })
+    result = pg_env.load_pg_env(cfg_path, section="agent_chat")
+    assert_eq("PGDATABASE", "nova_memory", result.get("PGDATABASE"))
+    assert_eq("PGUSER", "flat-user", result.get("PGUSER"))
+    assert_eq("PGPASSWORD", "flat-pass", result.get("PGPASSWORD"))
+    assert_eq("PGHOST", "flat-host", result.get("PGHOST"))
+
+    # TC-25: Partial section falls back per field
+    print("TC-25: partial section falls back per field")
+    pg_env = reload_pg_env()
+    cfg_path = write_config(tmpdir + "/tc25", {
+        "host": "flat-host",
+        "port": 5433,
+        "database": "nova_memory",
+        "user": "flat-user",
+        "password": "flat-pass",
+        "agent_chat": {
+            "database": "agent_chat",
+            "user": "chat-user",
+        },
+    })
+    result = pg_env.load_pg_env(cfg_path, section="agent_chat")
+    assert_eq("PGDATABASE", "agent_chat", result.get("PGDATABASE"))
+    assert_eq("PGUSER", "chat-user", result.get("PGUSER"))
+    assert_eq("PGHOST", "flat-host", result.get("PGHOST"))
+    assert_eq("PGPORT", "5433", result.get("PGPORT"))
+    assert_eq("PGPASSWORD", "flat-pass", result.get("PGPASSWORD"))
+
+    # TC-26: Malformed JSON falls through to defaults
+    print("TC-26: malformed JSON falls through to defaults")
+    pg_env = reload_pg_env()
+    cfg_path = write_config(tmpdir + "/tc26", "{not valid json")
+    result = pg_env.load_pg_env(cfg_path, section="agent_chat")
+    assert_eq("PGHOST", "localhost", result.get("PGHOST"))
+    assert_eq("PGPORT", "5432", result.get("PGPORT"))
+    assert_eq("PGUSER", getpass.getuser(), result.get("PGUSER"))
+    assert_eq("PGDATABASE unset", None, result.get("PGDATABASE"))
+
+    # TC-27: Section present but not an object
+    print("TC-27: section present but not an object")
+    pg_env = reload_pg_env()
+    cfg_path = write_config(tmpdir + "/tc27", {
+        "host": "flat-host",
+        "database": "nova_memory",
+        "user": "flat-user",
+        "password": "flat-pass",
+        "agent_chat": "oops",
+    })
+    result = pg_env.load_pg_env(cfg_path, section="agent_chat")
+    assert_eq("PGDATABASE", "nova_memory", result.get("PGDATABASE"))
+    assert_eq("PGUSER", "flat-user", result.get("PGUSER"))
+    assert_eq("PGHOST", "flat-host", result.get("PGHOST"))
+
+    # TC-28: Second call with section overwrites previously-set PG* env vars
+    print("TC-28: second call with section overwrites stale env vars")
+    pg_env = reload_pg_env()
+    cfg_path = write_config(tmpdir + "/tc28", {
+        "host": "flat-host",
+        "database": "nova_memory",
+        "user": "flat-user",
+        "password": "flat-pass",
+        "agent_chat": {
+            "database": "agent_chat",
+            "user": "chat-user",
+            "password": "chat-pass",
+        },
+    })
+    result1 = pg_env.load_pg_env(cfg_path)
+    assert_eq("first call PGDATABASE", "nova_memory", result1.get("PGDATABASE"))
+    assert_env_eq("first call os.environ PGDATABASE", "PGDATABASE", "nova_memory")
+
+    result2 = pg_env.load_pg_env(cfg_path, section="agent_chat")
+    assert_eq("second call PGDATABASE", "agent_chat", result2.get("PGDATABASE"))
+    assert_eq("second call PGUSER", "chat-user", result2.get("PGUSER"))
+    assert_env_eq("second call os.environ PGDATABASE", "PGDATABASE", "agent_chat")
+    assert_env_eq("second call os.environ PGUSER", "PGUSER", "chat-user")
+
+    # TC-29: ENV override still wins over section
+    print("TC-29: ENV override still wins over section")
+    pg_env = reload_pg_env()
+    os.environ["PGDATABASE"] = "env_db"
+    cfg_path = write_config(tmpdir + "/tc29", {
+        "database": "nova_memory",
+        "agent_chat": {"database": "agent_chat"},
+    })
+    result = pg_env.load_pg_env(cfg_path, section="agent_chat")
+    assert_eq("PGDATABASE", "env_db", result.get("PGDATABASE"))
+    assert_env_eq("os.environ PGDATABASE", "PGDATABASE", "env_db")
+
+print()
+print("═══════════════════════════════════════════")
+print(f"  Python section tests: {PASS} passed, {FAIL} failed")
+print("═══════════════════════════════════════════")
+sys.exit(0 if FAIL == 0 else 1)

--- a/memory/ARCHITECTURE.md
+++ b/memory/ARCHITECTURE.md
@@ -177,7 +177,7 @@ The `memory_type_priorities` table controls which memory types surface first dur
 | tasks | 1.20 | Active work items |
 | entity_fact | 1.00 | Baseline — entity knowledge |
 | daily_log | 0.90 | Recent session history |
-| agent_chat | 0.70 | Inter-agent messages (often verbose) |
+| agent_chat | 0.70 | Inter-agent messages (often verbose). **Note (#320):** the trigger that embedded new `agent_chat` messages was dropped when `agent_chat` moved to its own dedicated database (cross-database triggers aren't supported); this priority weight currently only affects any embeddings from before that migration. See `memory/docs/semantic-search-guide.md`. |
 
 Semantic search results are scored as `vector_similarity × priority_weight`. Adjust priorities via:
 ```sql

--- a/memory/README.md
+++ b/memory/README.md
@@ -370,6 +370,8 @@ VALUES (
 
 ### Agent Chat Tables (Inter-Agent Messaging)
 
+> **As of nova-mind#320, these tables live in a dedicated `agent_chat` database, not `nova_memory`.** The schema and protocol described below are otherwise unchanged — only the database they live in moved. Agents resolve the connection via the nested `agent_chat` section of `~/.openclaw/postgres.json` (see `memory/docs/database-config.md` and `scripts/agent-chat-migration/README.md`), not via the `nova_memory` connection used for the rest of this document.
+
 The `agent_chat` and `agent_chat_processed` tables enable asynchronous communication between AI agents via PostgreSQL NOTIFY:
 
 **agent_chat** - Message queue for inter-agent communication

--- a/memory/docs/database-config.md
+++ b/memory/docs/database-config.md
@@ -20,16 +20,53 @@ nova-memory uses a centralized configuration file (`~/.openclaw/postgres.json`) 
 
 All fields are optional. Missing fields fall through to environment variables or built-in defaults.
 
+## Nested Sections (Multiple Databases)
+
+Since nova-mind#330/#320, `postgres.json` can carry additional named, nested
+objects alongside the flat top-level keys — one per additional database a
+component needs to reach. The primary current consumer is **`agent_chat`**
+(#320: `agent_chat` moved out of `nova_memory` into its own dedicated database):
+
+```json
+{
+  "host": "localhost",
+  "port": 5432,
+  "database": "nova_memory",
+  "user": "nova",
+  "password": "secret",
+  "agent_chat": {
+    "database": "agent_chat",
+    "user": "nova",
+    "password": "secret"
+  }
+}
+```
+
+Only `database`, `user`, and `password` are typically needed inside a nested
+section — `host` and `port` fall back to the top-level flat keys (or their
+defaults) if omitted from the section. Every loader function accepts an
+optional `section` parameter; when given, fields inside that named object take
+precedence over the top-level flat keys (environment variables still win over
+both). See "Loader Functions" below for the exact call signature per language.
+
+`agent-install.sh` provisions the `agent_chat` section automatically and is
+idempotent — re-running it reports the section is already correct rather than
+clobbering existing values. See `scripts/agent-chat-migration/README.md` for
+the full rollout runbook.
+
 ## Resolution Order
 
 Every loader follows the same precedence:
 
 1. **Environment variables** — `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`
-2. **Config file** — `~/.openclaw/postgres.json`
-3. **Defaults** — `localhost` for host, `5432` for port, current OS user for username
+2. **Nested section** (if a `section` name is passed to the loader and the config file has a matching object at that key)
+3. **Config file top-level (flat) keys** — `~/.openclaw/postgres.json`
+4. **Defaults** — `localhost` for host, `5432` for port, current OS user for username
 
-Empty environment strings are treated as unset (fall through to step 2).  
-Null/missing JSON values are treated as absent (fall through to step 3).  
+Empty environment strings are treated as unset (fall through to step 2/3).  
+Null/missing JSON values are treated as absent (fall through to the next step).  
+If a `section` value exists but is not a JSON object, a warning is printed and
+the loader falls back to the top-level flat keys.  
 `PGDATABASE` and `PGPASSWORD` have no built-in defaults.
 
 ## Loader Functions
@@ -43,6 +80,12 @@ load_pg_env
 psql -c "SELECT 1"
 ```
 
+> **No section support in Bash.** `pg-env.sh` does not currently support the
+> nested-section feature described above — it only reads top-level flat keys.
+> Scripts that need the `agent_chat` DB from Bash should read the nested JSON
+> directly with `jq` (e.g. `jq -r '.agent_chat.database' ~/.openclaw/postgres.json`)
+> rather than relying on `load_pg_env`.
+
 ### Python
 
 ```python
@@ -55,24 +98,45 @@ import psycopg2
 conn = psycopg2.connect()  # reads PG* env vars automatically
 ```
 
+With a nested section (e.g. to resolve the `agent_chat` database):
+
+```python
+load_pg_env(section="agent_chat")
+# os.environ PG* vars now point at the agent_chat DB instead of the flat/default config.
+# A later call with a different (or no) section fully overwrites these -- no stale values leak.
+conn = psycopg2.connect()
+```
+
 ### TypeScript
 
 ```typescript
 import { loadPgEnv } from "~/.openclaw/lib/pg-env";
 
-loadPgEnv();
-// process.env now has PG* vars; node-postgres reads them automatically
-import { Pool } from "pg";
-const pool = new Pool(); // uses PGHOST, PGPORT, etc.
+const pgConfig = loadPgEnv();
+// pgConfig is a connection-options object for pg.Client/pg.Pool -- does NOT
+// mutate process.env, avoiding pollution for child processes/subagents.
+import { Client } from "pg";
+const client = new Client(pgConfig);
 ```
+
+With a nested section:
+
+```typescript
+const agentChatConfig = loadPgEnv(undefined, "agent_chat");
+const client = new Client(agentChatConfig);
+```
+
+This is exactly the pattern `cognition/focus/agent_chat/src/channel.ts` uses to
+resolve its dedicated database connection (`loadPgEnv(undefined, "agent_chat")`).
 
 ### Custom config path
 
-All loaders accept an optional path argument to override the default location:
+All loaders accept an optional path argument to override the default location,
+and (except Bash) an optional `section` argument:
 
-- Bash: not supported (reads `~/.openclaw/postgres.json` only)
-- Python: `load_pg_env(config_path="/custom/path.json")`
-- TypeScript: `loadPgEnv("/custom/path.json")`
+- Bash: only the default path is supported (reads `~/.openclaw/postgres.json` only); no section support
+- Python: `load_pg_env(config_path="/custom/path.json", section="agent_chat")`
+- TypeScript: `loadPgEnv("/custom/path.json", "agent_chat")`
 
 ## How It Fits Together
 
@@ -98,8 +162,10 @@ hooks & scripts
 - **Malformed JSON** — warned on stderr, config file ignored, falls through to defaults
 - **Missing file** — silently falls through to env vars and defaults
 - **Permission denied** — warned on stderr, falls through to defaults
+- **Section value present but not a JSON object** — warned on stderr, falls back to top-level flat keys (as if no section had been requested)
 
 ## Security Notes
 
-- The config file may contain a plaintext password. Ensure `~/.openclaw/` has `700` permissions.
+- The config file may contain a plaintext password (in both the flat top-level keys and any nested section such as `agent_chat`). Ensure `~/.openclaw/` has `700` permissions and `postgres.json` itself is mode `600`.
 - Prefer peer authentication or env vars in production over storing passwords in the file.
+- `agent-install.sh` provisions `~/.pgpass` entries and the `postgres.json` `agent_chat` section together, so most installs never need to hand-edit passwords into this file.

--- a/memory/docs/database-schema-guide.md
+++ b/memory/docs/database-schema-guide.md
@@ -253,6 +253,8 @@ COMMENT ON TABLE agents IS 'Agent definitions. READ-ONLY except Newhart (Agent D
 #### agent_chat table
 **Purpose:** Inter-agent messaging via PostgreSQL NOTIFY
 
+> **As of nova-mind#320, this table lives in a dedicated `agent_chat` database, not `nova_memory`.** The schema and protocol below are otherwise accurate and unchanged by the move — they describe the table shape, not which database hosts it. Agents resolve the connection via the nested `agent_chat` section of `~/.openclaw/postgres.json` (`load_pg_env(section="agent_chat")` / `loadPgEnv(undefined, "agent_chat")`); see `memory/docs/database-config.md` and `scripts/agent-chat-migration/README.md`.
+
 > **Column history (#106):** `mentions → recipients`, `created_at → "timestamp"` (TIMESTAMPTZ), `channel` dropped. All inserts via `send_agent_message()`.
 
 ```sql

--- a/memory/docs/deployment-setup-guide.md
+++ b/memory/docs/deployment-setup-guide.md
@@ -303,10 +303,12 @@ openclaw plugins enable agent-chat-channel
 
 ### 2. Configure NOTIFY/LISTEN
 
+> **As of nova-mind#320, `agent_chat` lives in its own dedicated `agent_chat` database, not `nova_memory`.** Every `psql` command in this section (and the rest of this guide's `agent_chat` references) must target that database explicitly — e.g. `psql -d agent_chat -c ...` — rather than relying on the default connection database used elsewhere in this guide. See `memory/docs/database-config.md` and `scripts/agent-chat-migration/README.md`.
+
 PostgreSQL configuration for inter-agent messaging:
 
 ```sql
--- Verify NOTIFY works
+-- Verify NOTIFY works (run against the agent_chat database)
 NOTIFY agent_chat, 'test message';
 
 -- Check for listening connections
@@ -316,11 +318,11 @@ SELECT * FROM pg_stat_activity WHERE state = 'idle in transaction';
 ### 3. Test Inter-Agent Communication
 
 ```bash
-# Terminal 1: Start listener
-psql -c "LISTEN agent_chat;"
+# Terminal 1: Start listener (against the agent_chat database)
+psql -d agent_chat -c "LISTEN agent_chat;"
 
 # Terminal 2: Send message via send_agent_message() (direct INSERT is blocked)
-psql -c "SELECT send_agent_message('nova', 'Hello world', ARRAY['test_agent']);"
+psql -d agent_chat -c "SELECT send_agent_message('nova', 'Hello world', ARRAY['test_agent']);"
 ```
 
 ## Performance Optimization
@@ -332,6 +334,8 @@ psql -c "SELECT send_agent_message('nova', 'Hello world', ARRAY['test_agent']);"
 CREATE INDEX CONCURRENTLY idx_entities_name ON entities(name);
 CREATE INDEX CONCURRENTLY idx_entity_facts_entity_id ON entity_facts(entity_id);
 CREATE INDEX CONCURRENTLY idx_events_date ON events(date);
+-- agent_chat lives in the dedicated agent_chat database (#320); run this one
+-- against `-d agent_chat`, not alongside the other indexes above.
 CREATE INDEX CONCURRENTLY idx_agent_chat_recipients ON agent_chat USING gin(recipients);
 
 -- Update table statistics
@@ -412,7 +416,11 @@ fi
 
 # Schema integrity
 echo -n "Schema integrity: "
-EXPECTED_TABLES=("entities" "entity_facts" "projects" "agents" "agent_chat" "sops" "lessons")
+# NOTE (#320): agent_chat now lives in its own dedicated `agent_chat` database,
+# not in nova_memory. It is intentionally excluded from EXPECTED_TABLES below
+# since this health check runs against the default (nova_memory) connection.
+# To also check agent_chat, run a separate `psql -d agent_chat -c '\dt agent_chat'`.
+EXPECTED_TABLES=("entities" "entity_facts" "projects" "agents" "sops" "lessons")
 MISSING_TABLES=()
 
 for table in "${EXPECTED_TABLES[@]}"; do
@@ -481,17 +489,15 @@ UNION ALL
 SELECT 'events', COUNT(*), 
        COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '24 hours'),
        COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '1 hour')
-FROM events
-UNION ALL  
-SELECT 'agent_chat', COUNT(*),
-       COUNT(*) FILTER (WHERE "timestamp" > NOW() - INTERVAL '24 hours'),
-       COUNT(*) FILTER (WHERE "timestamp" > NOW() - INTERVAL '1 hour')
-FROM agent_chat;
+FROM events;
+-- NOTE (#320): the `agent_chat` UNION branch that used to appear here has been
+-- removed -- agent_chat now lives in its own dedicated `agent_chat` database and
+-- can no longer be UNIONed into a view running against nova_memory. Query its
+-- stats separately, against the agent_chat database:
+--   psql -d agent_chat -c "SELECT * FROM v_agent_chat_stats;"
 
--- Query system health
+-- Query system health (nova_memory only)
 SELECT * FROM system_stats;
--- Or use the built-in view:
-SELECT * FROM v_agent_chat_stats;
 ```
 
 ## Security Configuration

--- a/memory/docs/semantic-search-guide.md
+++ b/memory/docs/semantic-search-guide.md
@@ -49,8 +49,23 @@ USING ivfflat (embedding vector_cosine_ops) WITH (lists='100');
 
 Embeddings are generated automatically via database triggers:
 
+> **`agent_chat` no longer triggers automatic embedding (as of nova-mind#320).**
+> The example below (`embed_chat_message()` / `embed_chat_message_trigger`) reflects
+> the pre-#320 architecture, where `agent_chat` lived in `nova_memory` alongside
+> `memory_embeddings` and could reference it in an `AFTER INSERT` trigger. Since
+> #320 moved `agent_chat` into its own dedicated database, this cross-database
+> trigger is no longer possible in plain PostgreSQL (no cross-database triggers)
+> and was intentionally dropped during migration — see `database/agent-chat/schema.sql`
+> header notes and `scripts/agent-chat-migration/README.md`. `agent_chat` messages
+> are currently **not** automatically embedded into `memory_embeddings`; this is a
+> known gap, not a design decision, and is tracked for a future batch/ETL-based
+> re-embedding path rather than an in-database trigger. Other trigger-embedded
+> source types (`entity_fact`, `event`, `lesson`, etc.) that still live in
+> `nova_memory` are unaffected and continue to work as shown elsewhere in this guide.
+
 ```sql
--- Example trigger for agent_chat table
+-- Historical (pre-#320) example trigger for agent_chat table --
+-- no longer present; kept for historical reference only.
 CREATE FUNCTION embed_chat_message() RETURNS TRIGGER AS $$
 BEGIN
     INSERT INTO memory_embeddings (source_type, source_id, content)
@@ -178,6 +193,14 @@ LEFT JOIN entities e ON ef.entity_id = e.id
 LEFT JOIN events ev ON me.source_type = 'event' AND me.source_id = ev.id::text  
 LEFT JOIN agent_chat ac ON me.source_type = 'agent_chat' AND me.source_id = ac.id::text;
 ```
+
+> **Note (#320):** The `agent_chat` branch of the `CASE` and its `LEFT JOIN` above
+> are historical. `agent_chat` now lives in a separate dedicated database (not
+> `nova_memory`), so a same-query `JOIN` against it is no longer possible from
+> `nova_memory`, and (per the note above) no new `source_type = 'agent_chat'` rows
+> are being created since the embedding trigger was dropped. Existing historical
+> `agent_chat` embedding rows, if any remain from before #320, will simply resolve
+> `context` to `NULL` here rather than erroring.
 
 ### 3. Hybrid Search (Semantic + Keyword)
 

--- a/memory/lib/pg-env.ts
+++ b/memory/lib/pg-env.ts
@@ -1,8 +1,9 @@
 /**
- * pg-env.ts — Centralized PostgreSQL config loader for TypeScript/Node.js.
+ * pg-env.ts — Centralized PostgreSQL config loader for TypeScript/Node.js
+ * with optional nested-section support.
  *
- * Resolution order: ENV vars → ~/.openclaw/postgres.json → defaults
- * Issue: nova-memory #94, nova-mind #330
+ * Resolution order: ENV vars → section → ~/.openclaw/postgres.json (flat keys) → defaults
+ * Issue: nova-memory #94, nova-mind #330, nova-mind #320
  */
 
 import { readFileSync } from "fs";
@@ -15,6 +16,7 @@ interface PgConfig {
   database?: string | null;
   user?: string | null;
   password?: string | null;
+  [key: string]: unknown;
 }
 
 const FIELD_MAP: Array<[keyof PgConfig, string]> = [
@@ -44,7 +46,7 @@ export interface PgConnectionConfig {
 }
 
 /**
- * Load PostgreSQL config with resolution: ENV → config file → defaults.
+ * Load PostgreSQL config with resolution: ENV → section → config file → defaults.
  *
  * Returns connection config object suitable for pg.Client / pg.Pool constructor,
  * without modifying process.env to avoid pollution of the environment
@@ -52,9 +54,13 @@ export interface PgConnectionConfig {
  * Empty ENV strings are treated as unset.
  * Null values in JSON are treated as absent.
  * Malformed JSON is caught and warned about (falls through to defaults).
+ *
+ * If `section` is provided and the parsed config contains a valid object for that
+ * key, section fields take precedence over top-level keys (ENV still wins).
  */
 export function loadPgEnv(
-  configPath?: string
+  configPath?: string,
+  section?: string
 ): PgConnectionConfig {
   const cfgPath =
     configPath ?? join(homedir(), ".openclaw", "postgres.json");
@@ -81,6 +87,20 @@ export function loadPgEnv(
     }
   }
 
+  // Resolve nested section if requested. A non-object section mirrors the
+  // top-level object-type guard: warn and fall back to top-level keys.
+  let sectionConfig: PgConfig | undefined;
+  if (section) {
+    const sectionValue = config[section];
+    if (sectionValue && typeof sectionValue === "object" && !Array.isArray(sectionValue)) {
+      sectionConfig = sectionValue as PgConfig;
+    } else if (sectionValue !== undefined) {
+      console.error(
+        `WARNING: ${cfgPath}.${section} is not a JSON object, ignoring`
+      );
+    }
+  }
+
   const result: PgConnectionConfig = {};
 
   for (const [jsonKey, envVar] of FIELD_MAP) {
@@ -96,7 +116,24 @@ export function loadPgEnv(
       continue;
     }
 
-    // 2. Check config file (null/undefined = absent, empty string = absent)
+    // 2. Check section config (null/undefined = absent, empty string = absent)
+    if (sectionConfig) {
+      const sectionVal = sectionConfig[jsonKey];
+      if (sectionVal != null) {
+        const strVal = String(sectionVal);
+        if (strVal) {
+          if (jsonKey === "port") {
+            const portNum = Number(strVal);
+            if (!isNaN(portNum)) result[jsonKey] = portNum;
+          } else {
+            result[jsonKey] = strVal;
+          }
+          continue;
+        }
+      }
+    }
+
+    // 3. Check top-level config file (null/undefined = absent, empty string = absent)
     const cfgVal = config[jsonKey];
     if (cfgVal != null) {
       const strVal = String(cfgVal);
@@ -111,7 +148,7 @@ export function loadPgEnv(
       }
     }
 
-    // 3. Apply default
+    // 4. Apply default
     const def = DEFAULTS[envVar];
     if (def !== undefined) {
       const defaultVal = typeof def === "function" ? def() : def;

--- a/memory/lib/pg_env.py
+++ b/memory/lib/pg_env.py
@@ -1,8 +1,8 @@
 """
 pg_env.py — Centralized PostgreSQL config loader for Python.
 
-Resolution order: ENV vars → ~/.openclaw/postgres.json → defaults
-Issue: nova-memory #94
+Resolution order: ENV vars → section → ~/.openclaw/postgres.json (flat keys) → defaults
+Issue: nova-memory #94, nova-mind #320
 """
 
 import json
@@ -29,18 +29,53 @@ _DEFAULTS = {
     "PGUSER": None,  # filled dynamically with getpass.getuser()
 }
 
+# State to make repeated calls with different sections safe.  os.environ is
+# both the input (ENV overrides) and output (for child processes).  Without
+# bookkeeping, a second call would see the values written by the first call
+# as "external ENV overrides" and refuse to overwrite them.
+#
+# _PREVIOUS_ENV[var] = value before our last write (None = absent)
+# _LAST_WRITTEN[var] = value we last wrote
+_PREVIOUS_ENV: dict[str, Optional[str]] = {}
+_LAST_WRITTEN: dict[str, str] = {}
 
-def load_pg_env(config_path: Optional[str] = None) -> dict:
+
+def _restore_external_env() -> None:
+    """Undo our own writes so the next read sees only external env values."""
+    for env_var in _FIELD_MAP.values():
+        last = _LAST_WRITTEN.get(env_var)
+        if last is None:
+            continue
+        current = os.environ.get(env_var, "")
+        if current == last:
+            prev = _PREVIOUS_ENV.get(env_var)
+            if prev is None:
+                os.environ.pop(env_var, None)
+            else:
+                os.environ[env_var] = prev
+
+
+def load_pg_env(config_path: Optional[str] = None, section: Optional[str] = None) -> dict:
     """
-    Load PostgreSQL env vars with resolution: ENV → config file → defaults.
+    Load PostgreSQL env vars with resolution: ENV → section → config file → defaults.
 
     Sets os.environ for each PG* var and returns the resulting dict.
     Empty ENV strings are treated as unset.
     Null values in JSON are treated as absent.
     Malformed JSON is caught and warned about (falls through to defaults).
+
+    If `section` is provided and the config file contains a valid object for that
+    key, section fields take precedence over top-level keys (ENV still wins).
+
+    Because this function mutates os.environ, a later call with a different
+    `section` fully overwrites any PG* vars set by an earlier call — no stale
+    values leak to child processes.
     """
     if config_path is None:
         config_path = os.path.join(Path.home(), ".openclaw", "postgres.json")
+
+    # Undo our own previous writes so we don't mistake them for external ENV.
+    _restore_external_env()
 
     # Try to read config file
     config = {}
@@ -56,6 +91,19 @@ def load_pg_env(config_path: Optional[str] = None) -> dict:
         print(f"WARNING: Failed to read {config_path}: {e}, falling through to defaults", file=sys.stderr)
         config = {}
 
+    # Resolve nested section if requested. A non-object section mirrors the
+    # top-level object-type guard: warn and fall back to top-level keys.
+    section_config = {}
+    if section:
+        section_value = config.get(section)
+        if isinstance(section_value, dict):
+            section_config = section_value
+        elif section_value is not None:
+            print(
+                f"WARNING: {config_path}.{section} is not a JSON object, ignoring",
+                file=sys.stderr,
+            )
+
     result = {}
 
     for json_key, env_var in _FIELD_MAP.items():
@@ -65,16 +113,23 @@ def load_pg_env(config_path: Optional[str] = None) -> dict:
             result[env_var] = env_val
             continue
 
-        # 2. Check config file (None/null = absent, empty string = absent)
+        # 2. Check section config (None/null = absent, empty string = absent)
+        section_val = section_config.get(json_key) if section_config else None
+        if section_val is not None:
+            str_val = str(section_val)
+            if str_val:
+                result[env_var] = str_val
+                continue
+
+        # 3. Check top-level config file (None/null = absent, empty string = absent)
         cfg_val = config.get(json_key)
         if cfg_val is not None:
             str_val = str(cfg_val)
             if str_val:
                 result[env_var] = str_val
-                os.environ[env_var] = str_val
                 continue
 
-        # 3. Apply default
+        # 4. Apply default
         if env_var == "PGUSER":
             default = getpass.getuser()
         else:
@@ -82,6 +137,18 @@ def load_pg_env(config_path: Optional[str] = None) -> dict:
 
         if default is not None:
             result[env_var] = default
-            os.environ[env_var] = default
+
+    # Update os.environ and bookkeeping.  Record the value that was present
+    # before we overwrite it so the next call can restore the external baseline.
+    for env_var in _FIELD_MAP.values():
+        if env_var in result:
+            _PREVIOUS_ENV[env_var] = os.environ.get(env_var)
+            os.environ[env_var] = result[env_var]
+            _LAST_WRITTEN[env_var] = result[env_var]
+        else:
+            if env_var in _LAST_WRITTEN:
+                os.environ.pop(env_var, None)
+            _PREVIOUS_ENV.pop(env_var, None)
+            _LAST_WRITTEN.pop(env_var, None)
 
     return result

--- a/motivation/ARCHITECTURE.md
+++ b/motivation/ARCHITECTURE.md
@@ -99,7 +99,7 @@ OpenClaw heartbeat fires
   → Bootstrap context loads HEARTBEAT.md
   → NOVA runs proactive-gate-check.py    ← deterministic, no LLM
       → reads sessions.json              ← idle check
-      → queries nova_memory DB           ← agent_chat, tasks, entities, unsolved_problems
+      → queries nova_memory + agent_chat DBs ← agent_chat (own DB, #320), tasks, entities, unsolved_problems
       → reads state files                ← heartbeat-state.json, memory-maintenance-last-run.json
       → calls gh CLI                     ← open GitHub issues
       → reads sessions.json + JSONL      ← unanswered user messages
@@ -116,7 +116,8 @@ owns that role entirely — the LLM only sees the output, never the gate logic.
 | Source | What It Checks |
 |--------|----------------|
 | `~/.openclaw/agents/nova/sessions/sessions.json` | Idle detection (last interaction timestamp across user-facing sessions) |
-| PostgreSQL `nova_memory` | `agent_chat` unacknowledged messages, `tasks` (pending/unblocked), `entities` dedup candidates, `unsolved_problems` |
+| PostgreSQL `nova_memory` | `tasks` (pending/unblocked), `entities` dedup candidates, `unsolved_problems` |
+| PostgreSQL `agent_chat` (dedicated DB, #320) | `agent_chat` unacknowledged messages — `proactive-gate-check.py` resolves this connection via `load_pg_env(section="agent_chat")` (see `memory/docs/database-config.md`), separately from the `nova_memory` connection above |
 | `~/.openclaw/workspace/memory/heartbeat-state.json` | Introspection state (last run timestamp, daily log line count, session transcript bytes) |
 | `~/.openclaw/state/memory-maintenance-last-run.json` | Memory maintenance cooldown state |
 | `~/.openclaw/workspace/.last-fs-audit` | Filesystem audit staleness marker |

--- a/motivation/scripts/README.md
+++ b/motivation/scripts/README.md
@@ -92,7 +92,7 @@ lists). Error conditions appear as `{ "actionable": false, "error": "..." }`.
 
 | Dependency | How It Is Used |
 |------------|----------------|
-| `psycopg2` | PostgreSQL queries (agent_chat, tasks, entities, unsolved_problems). Loaded from the nova venv at `~/.local/share/nova/venv/` — no manual activation required. |
+| `psycopg2` | PostgreSQL queries against `nova_memory` (tasks, entities, unsolved_problems) and, separately, the dedicated `agent_chat` database (#320) via `load_pg_env(section="agent_chat")` — see `memory/docs/database-config.md`. Loaded from the nova venv at `~/.local/share/nova/venv/` — no manual activation required. |
 | `gh` CLI | Lists open GitHub issues across NOVA-Openclaw repos (Step 7) and enumerates repos. |
 | `~/.openclaw/agents/nova/sessions/sessions.json` + per-session JSONL files | Detects unanswered user messages directly from session state (Step 2). |
 

--- a/motivation/scripts/proactive-gate-check.py
+++ b/motivation/scripts/proactive-gate-check.py
@@ -36,6 +36,20 @@ try:
 except ImportError:
     _DB_AVAILABLE = False
 
+# Load centralized PG config loader so agent_chat queries resolve to the
+# dedicated messaging DB while memory-DB queries keep flat/memory config.
+_PG_ENV_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "..", "lib"
+)
+if os.path.isdir(_PG_ENV_DIR) and _PG_ENV_DIR not in sys.path:
+    sys.path.insert(0, _PG_ENV_DIR)
+
+try:
+    from pg_env import load_pg_env
+    _PG_ENV_AVAILABLE = True
+except ImportError:
+    _PG_ENV_AVAILABLE = False
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -91,12 +105,53 @@ BLOCKERS_PER_MESSAGE = 3
 # D100 forced-roll threshold (issue #358)
 D100_FORCED_COOLDOWN_H = 12
 
-DB_DSN = "host=/var/run/postgresql dbname=nova_memory user=nova"
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _dsn_from_pg_env(section: str | None = None) -> str:
+    """Build a psycopg2 DSN from pg_env, honoring the optional section key.
+
+    Falls back to the original Unix-socket default when no host is configured,
+    preserving pre-cutover behavior while still respecting explicit config.
+    Password is intentionally omitted from the DSN string; libpq reads
+    PGPASSWORD from the environment set by load_pg_env and/or .pgpass.
+    """
+    if not _PG_ENV_AVAILABLE:
+        raise RuntimeError("pg_env loader not importable")
+    env = load_pg_env(section=section)
+    parts: list[str] = []
+    host = env.get("PGHOST")
+    if host:
+        parts.append(f"host={host}")
+    else:
+        # Preserve the legacy Unix-socket default used by the hardcoded DSN.
+        parts.append("host=/var/run/postgresql")
+    if env.get("PGPORT"):
+        parts.append(f"port={env['PGPORT']}")
+    if env.get("PGDATABASE"):
+        parts.append(f"dbname={env['PGDATABASE']}")
+    if env.get("PGUSER"):
+        parts.append(f"user={env['PGUSER']}")
+    return " ".join(parts)
+
+
+def _db_connect(section: str | None = None):
+    """Return a psycopg2 connection for the requested config section."""
+    if not _DB_AVAILABLE:
+        raise RuntimeError("psycopg2 not importable")
+    return psycopg2.connect(_dsn_from_pg_env(section=section))
+
+
+def _memory_db_connect():
+    """Connect to the agent's memory database (flat config keys)."""
+    return _db_connect(section=None)
+
+
+def _agent_chat_db_connect():
+    """Connect to the agent_chat messaging database (nested section)."""
+    return _db_connect(section="agent_chat")
+
 
 def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
@@ -115,13 +170,6 @@ def _parse_iso(ts: str) -> datetime:
         ts = ts.split(".")[0]
     dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%S")
     return dt.replace(tzinfo=timezone.utc)
-
-
-def _db_connect():
-    """Return a psycopg2 connection or raise if unavailable."""
-    if not _DB_AVAILABLE:
-        raise RuntimeError("psycopg2 not importable")
-    return psycopg2.connect(DB_DSN)
 
 
 def _step_error(msg: str) -> dict:
@@ -232,7 +280,7 @@ def check_idle() -> dict:
 def check_step1_agent_chat() -> dict:
     """Step 1: Unacknowledged agent_chat messages addressed to nova."""
     try:
-        conn = _db_connect()
+        conn = _agent_chat_db_connect()
         try:
             with conn:
                 with conn.cursor() as cur:
@@ -627,7 +675,7 @@ def check_step7_github_issues() -> dict:
             "reason": f"{total_issues} open issue(s) across {len(per_repo)} repo(s)",
             "data": result_dict,
         }
-    msg = "0 open GitHub issues"
+    msg = "0 open Git issues"
     if errors:
         msg += f" ({len(errors)} repo(s) had errors)"
     return {"actionable": False, "reason": msg, "data": result_dict}
@@ -904,14 +952,12 @@ def check_step8_blocker_outreach() -> dict:
     (entity_id=2), the blocker set is reassigned to the next domain entity
     (via _reassign_exhausted_entity — agent_domains first, then
     user_domains by priority, excluding already-exhausted entities in the
-    chain), restarting cascade level at 1 against the new entity. If every
-    domain entity is exhausted, the chain falls to I)ruid as final
-    fallback. If I)ruid himself is the exhausted entity, no reassignment
-    occurs — he holds at his last available channel/level and the normal
-    72h per-blocker cooldown continues to gate the next attempt. Each
-    returned entity entry carries "exhausted" (True only for the I)ruid
-    hold-in-place case) and, when reassignment occurred, the original
-    "reassigned_from_entity_id".
+    chain), eventually falling to I)ruid if every domain entity is exhausted.
+    If I)ruid himself is the exhausted entity, no reassignment occurs — he
+    holds at his last available channel/level and the normal 72h per-blocker
+    cooldown continues to gate the next attempt. Each returned entity entry
+    carries "exhausted" (True only for the I)ruid hold-in-place case) and,
+    when reassignment occurred, the original "reassigned_from_entity_id".
     """
     try:
         conn = _db_connect()

--- a/scripts/agent-chat-migration/README.md
+++ b/scripts/agent-chat-migration/README.md
@@ -1,0 +1,236 @@
+# agent_chat Database Migration Runbook
+
+Issue: [NOVA-Openclaw/nova-mind#320](https://github.com/NOVA-Openclaw/nova-mind/issues/320)
+
+Move the `agent_chat` messaging bus from `nova_memory` into a dedicated
+`agent_chat` database on the same PostgreSQL instance. This runbook covers the
+SQL/migration tooling (Chunk A). Plugin, Python consumer, and installer changes
+are handled in Chunks B and C.
+
+## Audience
+
+Database/operators — the human running the cutover. All commands assume a
+PostgreSQL superuser connection via `.pgpass` or environment variables.
+
+## Prerequisites
+
+* PostgreSQL 16+ superuser access (for `CREATE DATABASE`, `--disable-triggers`).
+* All nova-ecosystem, Victoria, and peer agent DB roles already exist.
+* `psql`, `pg_dump`, Python 3, and `psycopg2` are installed.
+* Source database is `nova_memory`; target database will be `agent_chat`.
+* A maintenance window where `agent_chat` table drops are acceptable.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `database/agent-chat/schema.sql` | Full schema for the new `agent_chat` database |
+| `scripts/agent-chat-migration/migrate.sh` | One-shot migration: create DB, apply schema, copy data, verify |
+| `scripts/agent-chat-migration/delta_check_and_migrate.py` | Repeated delta detection/migration after rollout |
+| `scripts/agent-chat-migration/pre_drop_gate_check.sh` | Six-gate checklist before dropping old objects |
+| `scripts/agent-chat-migration/decommission.sh` | Drop objects from `nova_memory` |
+| `scripts/agent-chat-migration/README.md` | This runbook |
+
+## Strict Operator Sequence
+
+The migration must be performed in this order. Skipping steps risks data loss
+or a broken bus.
+
+### 1. Pre-migration checks
+
+Record baseline counts and max ids:
+
+```bash
+psql -U postgres -d nova_memory -c "SELECT count(*) FROM agent_chat;"
+psql -U postgres -d nova_memory -c "SELECT count(*) FROM agent_chat_processed;"
+psql -U postgres -d nova_memory -c "SELECT max(id) FROM agent_chat;"
+psql -U postgres -d nova_memory -c "SELECT last_value, is_called FROM agent_chat_id_seq;"
+```
+
+### 2. Migrate schema and data
+
+Run the migration script. It is idempotent: re-running after a successful
+migration skips the data copy and reapplies schema safely.
+
+```bash
+./scripts/agent-chat-migration/migrate.sh \
+  --source-db nova_memory \
+  --target-db agent_chat \
+  --host localhost \
+  --port 5432 \
+  --superuser postgres
+```
+
+Expected output:
+
+* `agent_chat` database created (if not present).
+* Schema applied.
+* Data copied with `--disable-triggers` (notify/enforce triggers do not fire).
+* `agent_chat_id_seq` set to `max(id)` with `is_called = true`.
+* Verification reports row-count parity, sequence alignment, and zero orphans.
+
+Do **not** point live agents at the new DB until the verification passes.
+
+### 3. Verify the new bus directly
+
+```bash
+psql -U nova -d agent_chat -c "SELECT send_agent_message('nova', 'round-trip test', ARRAY['newhart']);"
+```
+
+Confirm a LISTEN client on `agent_chat` receives the NOTIFY payload.
+
+### 4. Roll out agent configs (Chunk B/C pointer)
+
+Update every agent's `~/.openclaw/postgres.json` to include the nested
+`agent_chat` section:
+
+```json
+{
+  "host": "localhost",
+  "database": "nova_memory",
+  "user": "<agent>",
+  "password": "...",
+  "agent_chat": {
+    "database": "agent_chat",
+    "user": "<agent>",
+    "password": "..."
+  }
+}
+```
+
+Covered in Chunk B:
+
+* `loadPgEnv()` / `load_pg_env()` section-key support.
+* `agent_chat` plugin reads the nested section with fallback to flat keys.
+* `pg-notify-listener.py` repointed.
+* `proactive-gate-check.py` hardcoded DSN fixed.
+* `agent_config_sync` pinned to `nova_memory` with explicit config.
+
+Covered in Chunk C:
+
+* `agent-install.sh` writes `.pgpass` entries for memory + messaging DBs.
+* `agent-install.sh` removes dead `channels.agent_chat` connection keys.
+* Installer verification arrays are two-DB aware.
+
+### 5. Interim delta check / migrate
+
+After all agents are verified on the new DB, check for any rows written to
+`nova_memory` during the rollout window and migrate them:
+
+```bash
+# Report-only
+./scripts/agent-chat-migration/delta_check_and_migrate.py \
+  --source-db nova_memory \
+  --target-db agent_chat \
+  --user postgres
+
+# Apply
+./scripts/agent-chat-migration/delta_check_and_migrate.py \
+  --source-db nova_memory \
+  --target-db agent_chat \
+  --user postgres \
+  --migrate
+```
+
+Repeat until the report shows zero delta rows. The script aborts if it detects
+an id-space collision where the same id has different content in the two DBs.
+
+### 6. Pre-DROP gate check
+
+Run the six-gate checklist. Two gates require operator attestations because
+they cannot be verified automatically by SQL alone.
+
+```bash
+# Create attestation files first:
+cat > /tmp/agent_chat_roundtrips.log <<EOF
+2026-07-03T12:00:00Z nova peer round-trip passed
+2026-07-03T12:01:00Z newhart peer round-trip passed
+2026-07-03T12:02:00Z graybeard peer round-trip passed
+2026-07-03T12:03:00Z subagent (gem) round-trip passed
+2026-07-03T12:04:00Z victoria cross-ecosystem round-trip passed
+EOF
+
+cat > /tmp/agent_chat_consumers.log <<EOF
+2026-07-03T12:05:00Z proactive-gate-check.py repointed and smoke-tested
+2026-07-03T12:06:00Z pg-notify-listener.py repointed and smoke-tested
+2026-07-03T12:07:00Z agent_chat plugin configs rolled out fleet-wide
+EOF
+
+./scripts/agent-chat-migration/pre_drop_gate_check.sh \
+  --source-db nova_memory \
+  --target-db agent_chat \
+  --user postgres \
+  --round-trip-log /tmp/agent_chat_roundtrips.log \
+  --consumer-attestation /tmp/agent_chat_consumers.log \
+  --gate-pass-marker /run/agent_chat_gate_pass.timestamp
+```
+
+Gates:
+
+1. **Row count match** — `agent_chat` and `agent_chat_processed` counts match.
+2. **Sequence alignment** — `last_value >= max(id)` and `is_called = true`.
+3. **Round-trip freshness** — attestation that all required peers/subagents/Victoria have fresh round-trips.
+4. **Zero delta rows** — no unresolved rows in `nova_memory` after the cutoff.
+5. **Dependent-object resolution** — `pg_depend` shows only objects in the planned drop list.
+6. **Consumer scripts repointed** — attestation that all consumers are on the new DB.
+
+### 7. Decommission old objects in nova_memory
+
+Only after gate check passes:
+
+```bash
+./scripts/agent-chat-migration/decommission.sh \
+  --source-db nova_memory \
+  --target-db agent_chat \
+  --user postgres \
+  --gate-pass-marker /run/agent_chat_gate_pass.timestamp \
+  --i-understand-the-risk
+```
+
+The script drops, in order:
+
+1. `job_messages.message_id_fkey`
+2. Triggers: `trg_embed_chat_message`, `trg_enforce_agent_chat_function_use`, `trg_enforce_function_use`, `trg_notify_agent_chat`
+3. Views: `v_agent_chat_recent`, `v_agent_chat_stats`
+4. Functions: `send_agent_message`, `notify_agent_chat`, `enforce_agent_chat_function_use`, `expire_old_chat`, `chat`, `embed_chat_message`
+5. Tables: `agent_chat_processed`, `agent_chat`
+6. Sequence: `agent_chat_id_seq`
+7. Type: `agent_chat_status`
+
+No `CASCADE` is used. If any unexpected dependency remains, the script fails
+before dropping tables.
+
+### 8. Post-DROP smoke test
+
+```bash
+psql -U nova -d agent_chat -c "SELECT send_agent_message('nova', 'post-DROP smoke test', ARRAY['newhart']);"
+psql -U postgres -d nova_memory -c "SELECT count(*) FROM agent_chat;"  # should fail with "relation does not exist"
+```
+
+## Rollback notes
+
+Before Step 7, the original `nova_memory` tables still contain all data.
+If the migration must be abandoned before decommission:
+
+1. Stop agents from writing to `agent_chat`.
+2. Truncate the target tables and rerun `migrate.sh`, or drop the entire
+   `agent_chat` database with `DROP DATABASE agent_chat;`.
+3. Revert agent configs to remove the `agent_chat` nested section.
+
+After Step 7, rollback requires restoring from backup.
+
+## Design decisions (authoritative)
+
+* New DB name: `agent_chat`.
+* Migrated objects: type, both tables, non-duplicate indexes, `agent_chat_id_seq`,
+  `send_agent_message`, `notify_agent_chat`, `enforce_agent_chat_function_use`,
+  `expire_old_chat`, one enforce trigger, `trg_notify_agent_chat` (ENABLE ALWAYS),
+  both views, comments.
+* Dropped from `nova_memory` (not migrated): `embed_chat_message()` and
+  `trg_embed_chat_message`, `chat()` helper, duplicate index
+  `idx_chat_processed_agent`, duplicate trigger `trg_enforce_function_use`,
+  `openproject_user` grants.
+* Grants: 18 nova-ecosystem roles plus `victoria` (send+receive) and
+  `nova-staging` (SEND capability via `send_agent_message` + SELECT).
+* `send_agent_message` retains `SECURITY DEFINER`; its owner must have INSERT on
+  `agent_chat` in the new DB.

--- a/scripts/agent-chat-migration/README.md
+++ b/scripts/agent-chat-migration/README.md
@@ -29,6 +29,8 @@ PostgreSQL superuser connection via `.pgpass` or environment variables.
 | `scripts/agent-chat-migration/delta_check_and_migrate.py` | Repeated delta detection/migration after rollout |
 | `scripts/agent-chat-migration/pre_drop_gate_check.sh` | Six-gate checklist before dropping old objects |
 | `scripts/agent-chat-migration/decommission.sh` | Drop objects from `nova_memory` |
+| `scripts/agent-chat-migration/audit_rollout.py` | Rollout-status audit — reports which DB each agent's config resolves to |
+| `agent-install.sh` | Auto-provisions the `postgres.json` `agent_chat` section, `.pgpass` entries, and the `pg-notify-listener.py` systemd service for new/upgraded installs (see Step 4 below) |
 | `scripts/agent-chat-migration/README.md` | This runbook |
 
 ## Strict Operator Sequence
@@ -81,8 +83,23 @@ Confirm a LISTEN client on `agent_chat` receives the NOTIFY payload.
 
 ### 4. Roll out agent configs (Chunk B/C pointer)
 
-Update every agent's `~/.openclaw/postgres.json` to include the nested
-`agent_chat` section:
+As of the installer fix cycle (`c5fa491`, tested in `4c812d3`), running
+`agent-install.sh` **automatically** provisions the nested `agent_chat` section
+of `~/.openclaw/postgres.json` for you — this step no longer requires manual
+JSON editing on a fresh or upgraded install. The installer:
+
+* Writes/merges the nested section (idempotent — re-running reports the
+  section is "already correct", never clobbers existing values).
+* Adds `~/.pgpass` entries for both `nova_memory` and `agent_chat` on `localhost`
+  and `127.0.0.1`.
+* Deploys `pg-notify-listener.py` to `~/.openclaw/workspace/scripts/` plus a
+  user-level systemd unit (`~/.config/systemd/user/pg-notify-listener.service`),
+  and places `pg_env.py` at `~/.openclaw/lib/pg_env.py` (the listener does
+  `sys.path.insert(0, ~/.openclaw/lib)` to import it).
+* Strips dead `database`/`host`/`port`/`user`/`password` connection keys from
+  both `channels.agent_chat` and `plugins.entries.agent_chat.config`.
+
+The resulting `postgres.json` looks like:
 
 ```json
 {
@@ -98,6 +115,24 @@ Update every agent's `~/.openclaw/postgres.json` to include the nested
 }
 ```
 
+For a manual/from-scratch setup without the installer, add this section by hand.
+
+**Known post-install check (tracked as #379):** the installer's `systemctl --user
+enable --now pg-notify-listener.service` step silently degrades to a warning
+when `agent-install.sh` is run under `sudo`, because there is no D-Bus user
+session available in that context. If you see a warning like "pg-notify-listener.service
+enable/start failed" during install, verify the service afterward and start it
+manually if needed:
+
+```bash
+systemctl --user status pg-notify-listener.service
+# If not active:
+systemctl --user enable --now pg-notify-listener.service
+```
+
+This is a known limitation of running the installer via `sudo`; it does not
+affect installs run as the target user directly (no `sudo`).
+
 Covered in Chunk B:
 
 * `loadPgEnv()` / `load_pg_env()` section-key support.
@@ -111,6 +146,10 @@ Covered in Chunk C:
 * `agent-install.sh` writes `.pgpass` entries for memory + messaging DBs.
 * `agent-install.sh` removes dead `channels.agent_chat` connection keys.
 * Installer verification arrays are two-DB aware.
+* `agent-install.sh` auto-provisions the `postgres.json` `agent_chat` section
+  and deploys `pg-notify-listener.py` + its systemd unit (fix cycle `c5fa491`/`4c812d3`,
+  after an earlier ordering bug where these blocks ran after an early exit in the
+  `agent_chat` extension build step).
 
 ### 5. Interim delta check / migrate
 

--- a/scripts/agent-chat-migration/README.md
+++ b/scripts/agent-chat-migration/README.md
@@ -207,6 +207,60 @@ psql -U nova -d agent_chat -c "SELECT send_agent_message('nova', 'post-DROP smok
 psql -U postgres -d nova_memory -c "SELECT count(*) FROM agent_chat;"  # should fail with "relation does not exist"
 ```
 
+## Rollout-status audit
+
+`scripts/agent-chat-migration/audit_rollout.py` reads each candidate
+`~/.openclaw/postgres.json` and resolves which database `agent_chat` would
+connect to, using the same nested-section → flat-key fallback as the
+plugin and consumer scripts.
+
+```bash
+./scripts/agent-chat-migration/audit_rollout.py
+```
+
+Sample output:
+
+```
+Agent        Status       Database             User            Path
+------------------------------------------------------------------------------------------
+nova         migrated     agent_chat           nova            /home/nova/.openclaw/postgres.json
+newhart      unreadable   None                 None            /home/newhart/.openclaw/postgres.json
+             error: [Errno 13] Permission denied: '/home/newhart/.openclaw/postgres.json'
+graybeard    unreadable   None                 None            /home/graybeard/.openclaw/postgres.json
+             error: [Errno 13] Permission denied: '/home/graybeard/.openclaw/postgres.json'
+
+Summary: 1 migrated, 0 unmigrated, 2 unreadable/missing (of 3 candidates)
+```
+
+Peer agents (`newhart`, `graybeard`) run as separate unix users, so a
+non-root audit will see permission-denied for their home directories. Run
+the audit as root, or run it once per peer as that peer's unix user, to
+verify those configs. The script exits non-zero until every candidate is
+readable and resolves to the `agent_chat` database.
+
+### Required postgres.json snippet per agent
+
+Every agent must add the nested `agent_chat` section to its
+`~/.openclaw/postgres.json`:
+
+```json
+{
+  "host": "localhost",
+  "port": 5432,
+  "database": "nova_memory",
+  "user": "<agent>",
+  "password": "<password>",
+  "agent_chat": {
+    "database": "agent_chat",
+    "user": "<agent>",
+    "password": "<password>"
+  }
+}
+```
+
+Only `database`, `user`, and `password` are required inside `agent_chat`;
+`host` and `port` fall back to the flat keys (or their defaults) if omitted.
+
 ## Rollback notes
 
 Before Step 7, the original `nova_memory` tables still contain all data.

--- a/scripts/agent-chat-migration/audit_rollout.py
+++ b/scripts/agent-chat-migration/audit_rollout.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+audit_rollout.py — Report which agents on this host have migrated to the
+dedicated agent_chat database.
+
+Reads each candidate postgres.json and resolves the agent_chat database using
+the same config-file logic as load_pg_env(section="agent_chat"): the nested
+agent_chat section takes precedence over top-level flat keys, with per-field
+fallback to defaults. ENV vars are deliberately ignored so the audit reflects
+persistent config state rather than the shell environment of this run.
+
+Exit code:
+  0  all candidates readable and migrated (agent_chat resolves to agent_chat)
+  1  any candidate is unmigrated, unreadable, or missing
+
+Usage:
+  ./scripts/agent-chat-migration/audit_rollout.py
+  ./scripts/agent-chat-migration/audit_rollout.py --json
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+# Peer agents run as separate unix users with their own home dirs and pgpass.
+# Permission errors on peer homes are expected when this script is run as a
+# non-root user; they are reported as unreadable and the operator should re-run
+# the audit as that peer or from a user with read access.
+CANDIDATE_PATHS = [
+    Path("/home/nova/.openclaw/postgres.json"),
+    Path("/home/newhart/.openclaw/postgres.json"),
+    Path("/home/graybeard/.openclaw/postgres.json"),
+]
+
+# Per-agent workspace conventions observed in the NOVA ecosystem.
+_PER_AGENT_PATTERNS = [
+    "~/.openclaw/workspace-*/postgres.json",
+    "~/.openclaw/agents/*/postgres.json",
+]
+
+_FIELD_MAP = [
+    ("host", "localhost"),
+    ("port", "5432"),
+    ("database", None),
+    ("user", os.environ.get("USER", "unknown")),
+    ("password", None),
+]
+
+
+def _expand_candidates() -> list[Path]:
+    """Return candidate postgres.json paths, de-duplicated by real path."""
+    candidates: list[Path] = []
+    seen: set[str] = set()
+
+    for path in CANDIDATE_PATHS:
+        try:
+            rp = path.resolve()
+            if str(rp) not in seen:
+                candidates.append(path)
+                seen.add(str(rp))
+        except OSError:
+            candidates.append(path)
+            seen.add(str(path))
+
+    for pattern in _PER_AGENT_PATTERNS:
+        for path in Path.home().glob(pattern):
+            try:
+                rp = path.resolve()
+                if str(rp) not in seen:
+                    candidates.append(path)
+                    seen.add(str(rp))
+            except OSError:
+                if str(path) not in seen:
+                    candidates.append(path)
+                    seen.add(str(path))
+
+    return candidates
+
+
+def _resolve_agent_chat_db(path: Path) -> tuple[str, str | None, str | None, str | None]:
+    """Return (status, database, user, error) for agent_chat resolution."""
+    if not path.exists():
+        return ("missing", None, None, "file not found")
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            config = json.load(f)
+    except (json.JSONDecodeError, OSError, PermissionError) as e:
+        return ("unreadable", None, None, str(e))
+
+    if not isinstance(config, dict):
+        return ("unreadable", None, None, "top level is not a JSON object")
+
+    section = config.get("agent_chat")
+    section_is_valid = isinstance(section, dict)
+    if section is not None and not section_is_valid:
+        return ("unreadable", None, None, "agent_chat section is not a JSON object")
+
+    result: dict[str, str] = {}
+    for json_key, default in _FIELD_MAP:
+        # 1. section field
+        if section_is_valid and section.get(json_key) is not None:
+            result[json_key] = str(section[json_key])
+            continue
+
+        # 2. top-level flat key
+        cfg_val = config.get(json_key)
+        if cfg_val is not None:
+            result[json_key] = str(cfg_val)
+            continue
+
+        # 3. default
+        if default is not None:
+            result[json_key] = default
+
+    database = result.get("database")
+    user = result.get("user")
+    status = "migrated" if database == "agent_chat" else "unmigrated"
+    return (status, database, user, None)
+
+
+def _agent_name_from_path(path: Path) -> str:
+    """Best-effort agent name from a postgres.json path."""
+    parts = path.parts
+    path_str = str(path)
+
+    if "workspace-" in path_str:
+        for part in parts:
+            if part.startswith("workspace-"):
+                return part.split("-", 1)[1]
+
+    if "agents" in parts:
+        try:
+            idx = parts.index("agents")
+            if idx + 1 < len(parts):
+                return parts[idx + 1]
+        except ValueError:
+            pass
+
+    home = Path.home()
+    if path == home / ".openclaw" / "postgres.json":
+        return os.environ.get("USER", "current")
+
+    for home_dir in ("/home/nova", "/home/newhart", "/home/graybeard"):
+        if path_str.startswith(home_dir):
+            return Path(home_dir).name
+
+    return "unknown"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit agent_chat database rollout status across agents."
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output raw JSON instead of a human-readable table.",
+    )
+    args = parser.parse_args()
+
+    candidates = _expand_candidates()
+    rows: list[dict] = []
+
+    for path in candidates:
+        status, database, user, error = _resolve_agent_chat_db(path)
+        agent = _agent_name_from_path(path)
+        rows.append(
+            {
+                "agent": agent,
+                "path": str(path),
+                "status": status,
+                "database": database,
+                "user": user,
+                "error": error,
+            }
+        )
+
+    if args.json:
+        print(json.dumps(rows, indent=2))
+    else:
+        print(f"{'Agent':<12} {'Status':<12} {'Database':<20} {'User':<15} {'Path'}")
+        print("-" * 90)
+        for row in rows:
+            print(
+                f"{row['agent']:<12} {row['status']:<12} "
+                f"{str(row['database']):<20} {str(row['user']):<15} {row['path']}"
+            )
+            if row["error"]:
+                print(f"             error: {row['error']}")
+
+        migrated = sum(1 for r in rows if r["status"] == "migrated")
+        unmigrated = sum(1 for r in rows if r["status"] == "unmigrated")
+        unreadable = sum(1 for r in rows if r["status"] in ("unreadable", "missing"))
+        print()
+        print(
+            f"Summary: {migrated} migrated, {unmigrated} unmigrated, "
+            f"{unreadable} unreadable/missing (of {len(rows)} candidates)"
+        )
+
+    if any(r["status"] != "migrated" for r in rows):
+        if not args.json:
+            print("At least one agent is not fully migrated.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/agent-chat-migration/decommission.sh
+++ b/scripts/agent-chat-migration/decommission.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# decommission.sh — Drop agent_chat bus objects from the legacy nova_memory database.
+#
+# Issue: NOVA-Openclaw/nova-mind#320
+#
+# This script performs explicit, object-by-object drops (NO CASCADE) in the
+# required order:
+#   1. Drop the job_messages.message_id FK constraint (decision #3).
+#   2. Drop triggers on agent_chat.
+#   3. Drop views that depend on agent_chat.
+#   4. Drop functions (including the broken chat() helper and embed_chat_message).
+#   5. Drop tables (processed first because of the FK to agent_chat).
+#   6. Drop the sequence.
+#   7. Drop the enum type.
+#
+# Safety:
+#   * Refuses to run unless a fresh gate-pass marker exists, OR the operator
+#     passes --rerun-gate (which re-runs pre_drop_gate_check.sh before DROP).
+#   * Refuses to run if --i-understand-the-risk is not provided.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE_CHECK_SCRIPT="${SCRIPT_DIR}/pre_drop_gate_check.sh"
+
+SOURCE_DB="nova_memory"
+TARGET_DB="agent_chat"
+HOST="localhost"
+PORT="5432"
+USER="postgres"
+GATE_PASS_MARKER=""
+RERUN_GATE=false
+I_UNDERSTAND=false
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+  --source-db DB          Source/legacy database (default: nova_memory)
+  --target-db DB          Target database (default: agent_chat)
+  --host HOST             PostgreSQL host (default: localhost)
+  --port PORT             PostgreSQL port (default: 5432)
+  --user USER             PostgreSQL user (default: postgres)
+  --gate-pass-marker PATH Path to gate-pass marker file (required unless --rerun-gate)
+  --rerun-gate            Re-run the gate check before dropping
+  --i-understand-the-risk Acknowledge that this DESTROYS agent_chat data in the source DB
+  -h, --help              Show this help
+
+Example:
+  $(basename "$0") --gate-pass-marker /run/agent_chat_gate_pass.timestamp --i-understand-the-risk
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source-db) SOURCE_DB="$2"; shift 2 ;;
+        --target-db) TARGET_DB="$2"; shift 2 ;;
+        --host) HOST="$2"; shift 2 ;;
+        --port) PORT="$2"; shift 2 ;;
+        --user) USER="$2"; shift 2 ;;
+        --gate-pass-marker) GATE_PASS_MARKER="$2"; shift 2 ;;
+        --rerun-gate) RERUN_GATE=true; shift ;;
+        --i-understand-the-risk) I_UNDERSTAND=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if [[ "${I_UNDERSTAND}" != "true" ]]; then
+    echo "ERROR: This script drops agent_chat objects from ${SOURCE_DB}. Re-run with --i-understand-the-risk." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Gate check
+# ---------------------------------------------------------------------------
+if [[ "${RERUN_GATE}" == "true" ]]; then
+    echo "== Re-running decommission gate check =="
+    if ! "${GATE_CHECK_SCRIPT}" \
+            --source-db "${SOURCE_DB}" \
+            --target-db "${TARGET_DB}" \
+            --host "${HOST}" \
+            --port "${PORT}" \
+            --user "${USER}" \
+            --gate-pass-marker "${GATE_PASS_MARKER:-/dev/null}"; then
+        echo "ERROR: Gate check failed. DROP aborted." >&2
+        exit 1
+    fi
+    echo "Gate check passed."
+elif [[ -z "${GATE_PASS_MARKER}" || ! -f "${GATE_PASS_MARKER}" ]]; then
+    echo "ERROR: Gate-pass marker missing: ${GATE_PASS_MARKER}" >&2
+    echo "Run pre_drop_gate_check.sh first, or pass --rerun-gate." >&2
+    exit 1
+else
+    # Marker exists; verify it is fresh (within last 24 hours) to avoid stale passes.
+    MARKER_AGE_MINUTES=$(( ($(date +%s) - $(stat -c %Y "${GATE_PASS_MARKER}")) / 60 ))
+    if [[ "${MARKER_AGE_MINUTES}" -gt 1440 ]]; then
+        echo "ERROR: Gate-pass marker is older than 24 hours (${MARKER_AGE_MINUTES} minutes). Re-run gate check." >&2
+        exit 1
+    fi
+    echo "== Using gate-pass marker: ${GATE_PASS_MARKER} (age ${MARKER_AGE_MINUTES} minutes) =="
+fi
+
+PSQL="psql -h ${HOST} -p ${PORT} -U ${USER} -d ${SOURCE_DB} -v ON_ERROR_STOP=1"
+
+run_sql() {
+    local sql="$1"
+    ${PSQL} -c "${sql}"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Drop FK constraint on job_messages.message_id
+# ---------------------------------------------------------------------------
+echo "== Step 1: Drop job_messages.message_id FK =="
+run_sql "ALTER TABLE public.job_messages DROP CONSTRAINT IF EXISTS job_messages_message_id_fkey;"
+
+# ---------------------------------------------------------------------------
+# 2. Drop triggers on agent_chat
+# ---------------------------------------------------------------------------
+echo "== Step 2: Drop triggers on agent_chat =="
+run_sql "DROP TRIGGER IF EXISTS trg_embed_chat_message ON public.agent_chat;"
+run_sql "DROP TRIGGER IF EXISTS trg_enforce_agent_chat_function_use ON public.agent_chat;"
+run_sql "DROP TRIGGER IF EXISTS trg_enforce_function_use ON public.agent_chat;"
+run_sql "DROP TRIGGER IF EXISTS trg_notify_agent_chat ON public.agent_chat;"
+
+# ---------------------------------------------------------------------------
+# 3. Drop views
+# ---------------------------------------------------------------------------
+echo "== Step 3: Drop views =="
+run_sql "DROP VIEW IF EXISTS public.v_agent_chat_recent;"
+run_sql "DROP VIEW IF EXISTS public.v_agent_chat_stats;"
+
+# ---------------------------------------------------------------------------
+# 4. Drop functions
+# ---------------------------------------------------------------------------
+echo "== Step 4: Drop functions =="
+run_sql "DROP FUNCTION IF EXISTS public.send_agent_message(text, text, text[]);"
+run_sql "DROP FUNCTION IF EXISTS public.notify_agent_chat();"
+run_sql "DROP FUNCTION IF EXISTS public.enforce_agent_chat_function_use();"
+run_sql "DROP FUNCTION IF EXISTS public.expire_old_chat(integer);"
+run_sql "DROP FUNCTION IF EXISTS public.chat(text, varchar);"
+run_sql "DROP FUNCTION IF EXISTS public.embed_chat_message();"
+
+# ---------------------------------------------------------------------------
+# 5. Drop tables
+# ---------------------------------------------------------------------------
+echo "== Step 5: Drop tables =="
+run_sql "DROP TABLE IF EXISTS public.agent_chat_processed;"
+run_sql "DROP TABLE IF EXISTS public.agent_chat;"
+
+# ---------------------------------------------------------------------------
+# 6. Drop sequence
+# ---------------------------------------------------------------------------
+echo "== Step 6: Drop sequence =="
+run_sql "DROP SEQUENCE IF EXISTS public.agent_chat_id_seq;"
+
+# ---------------------------------------------------------------------------
+# 7. Drop type
+# ---------------------------------------------------------------------------
+echo "== Step 7: Drop enum type =="
+run_sql "DROP TYPE IF EXISTS public.agent_chat_status;"
+
+# ---------------------------------------------------------------------------
+# Confirm source DB no longer contains the objects
+# ---------------------------------------------------------------------------
+echo "== Step 8: Post-DROP sanity check =="
+REMAINING=$(run_sql "SELECT count(*) FROM pg_class WHERE relnamespace = 'public'::regnamespace AND relname IN ('agent_chat','agent_chat_processed','agent_chat_id_seq');")
+echo "   Remaining agent_chat class count: ${REMAINING}"
+
+if [[ "${REMAINING}" -ne 0 ]]; then
+    echo "ERROR: Some agent_chat objects remain in ${SOURCE_DB}." >&2
+    exit 1
+fi
+
+echo ""
+echo "SUCCESS: agent_chat bus objects decommissioned from ${SOURCE_DB}."
+echo "The shared messaging bus now lives only in ${TARGET_DB}."

--- a/scripts/agent-chat-migration/delta_check_and_migrate.py
+++ b/scripts/agent-chat-migration/delta_check_and_migrate.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""
+delta_check_and_migrate.py — Identify and migrate rows written to the legacy
+nova_memory agent_chat tables after the initial migration.
+
+Issue: NOVA-Openclaw/nova-mind#320
+
+The script is designed to be run repeatedly until it reports zero delta rows.
+It supports two cutoffs:
+  * --cutoff-id      : source rows with agent_chat.id > CUTOFF_ID are considered delta.
+  * --cutoff-ts      : ISO 8601 timestamp; processed rows updated after this time
+                       are also checked.
+
+If neither cutoff is provided, the script uses the current maximum id and the
+latest message timestamp in the target `agent_chat` database.
+
+Collision handling:
+  * If a source agent_chat row has the same id as a target row and the content
+    matches, the source row is skipped (already present).
+  * If the content differs, the script aborts without making changes; the
+    operator must resolve the id-space conflict manually.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+import psycopg2
+from psycopg2 import sql
+from psycopg2.extras import RealDictCursor
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check for and migrate delta rows from nova_memory to the agent_chat database."
+    )
+    parser.add_argument("--source-db", default="nova_memory", help="Source database (default: nova_memory)")
+    parser.add_argument("--target-db", default="agent_chat", help="Target database (default: agent_chat)")
+    parser.add_argument("--host", default="localhost", help="PostgreSQL host")
+    parser.add_argument("--port", type=int, default=5432, help="PostgreSQL port")
+    parser.add_argument("--user", default="postgres", help="PostgreSQL superuser")
+    parser.add_argument("--password", default=None, help="PostgreSQL password (optional, .pgpass preferred)")
+    parser.add_argument("--cutoff-id", type=int, default=None, help="Agent_chat.id cutoff (default: target max id)")
+    parser.add_argument(
+        "--cutoff-ts",
+        default=None,
+        help="ISO 8601 timestamp for processed-row updates (default: target newest timestamp)",
+    )
+    parser.add_argument(
+        "--migrate",
+        action="store_true",
+        help="Actually migrate detected delta rows. Without this flag the script reports only.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print SQL that would be executed without running it.",
+    )
+    return parser.parse_args()
+
+
+def connect(dbname: str, args: argparse.Namespace) -> psycopg2.connection:
+    conn_kwargs: dict[str, Any] = {
+        "host": args.host,
+        "port": args.port,
+        "user": args.user,
+        "dbname": dbname,
+    }
+    if args.password:
+        conn_kwargs["password"] = args.password
+    return psycopg2.connect(**conn_kwargs)
+
+
+def scalar(conn: psycopg2.connection, query: sql.Composed | str, params: tuple[Any, ...] = ()) -> Any:
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def query_rows(conn: psycopg2.connection, query: sql.Composed | str, params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(query, params)
+        return [dict(row) for row in cur.fetchall()]
+
+
+def build_comparable(row: dict[str, Any]) -> tuple[Any, ...]:
+    """Return a hashable tuple of the columns that identify content."""
+    return (
+        row["id"],
+        row["sender"],
+        row["message"],
+        row["recipients"],
+        row["reply_to"],
+        row["timestamp"].replace(tzinfo=timezone.utc) if row["timestamp"] and row["timestamp"].tzinfo is None else row["timestamp"],
+    )
+
+
+def build_processed_comparable(row: dict[str, Any]) -> tuple[Any, ...]:
+    ts_cols = ["received_at", "routed_at", "responded_at"]
+    values = [row["chat_id"], row["agent"], row["status"], row["error_message"]]
+    for col in ts_cols:
+        v = row.get(col)
+        if v and v.tzinfo is None:
+            v = v.replace(tzinfo=timezone.utc)
+        values.append(v)
+    return tuple(values)
+
+
+def parse_cutoff_ts(value: str) -> datetime:
+    value = value.strip().replace("Z", "+00:00")
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.dry_run:
+        print("DRY-RUN mode: no changes will be made.")
+
+    source = connect(args.source_db, args)
+    target = connect(args.target_db, args)
+
+    try:
+        # Determine cutoffs if not provided.
+        if args.cutoff_id is None:
+            cutoff_id = scalar(target, "SELECT COALESCE(max(id), 0) FROM public.agent_chat")
+        else:
+            cutoff_id = args.cutoff_id
+
+        if args.cutoff_ts is None:
+            cutoff_ts = scalar(target, "SELECT max(\"timestamp\") FROM public.agent_chat")
+        else:
+            cutoff_ts = parse_cutoff_ts(args.cutoff_ts)
+
+        print(f"Using cutoff id: {cutoff_id}")
+        print(f"Using cutoff timestamp: {cutoff_ts}")
+
+        # ------------------------------------------------------------------
+        # agent_chat delta
+        # ------------------------------------------------------------------
+        source_chat = query_rows(
+            source,
+            "SELECT id, sender, message, recipients, reply_to, \"timestamp\" FROM public.agent_chat WHERE id > %s ORDER BY id",
+            (cutoff_id,),
+        )
+        target_chat = query_rows(
+            target,
+            "SELECT id, sender, message, recipients, reply_to, \"timestamp\" FROM public.agent_chat WHERE id > %s ORDER BY id",
+            (cutoff_id,),
+        )
+
+        target_chat_by_id = {row["id"]: row for row in target_chat}
+
+        delta_chat: list[dict[str, Any]] = []
+        collisions: list[tuple[dict[str, Any], dict[str, Any]]] = []
+
+        for srow in source_chat:
+            tid = srow["id"]
+            trow = target_chat_by_id.get(tid)
+            if trow is None:
+                delta_chat.append(srow)
+            elif build_comparable(srow) != build_comparable(trow):
+                collisions.append((srow, trow))
+
+        print(f"\nagent_chat rows in source > cutoff id {cutoff_id}: {len(source_chat)}")
+        print(f"agent_chat rows in target > cutoff id {cutoff_id}: {len(target_chat)}")
+        print(f"agent_chat delta rows to migrate: {len(delta_chat)}")
+        print(f"agent_chat id collisions: {len(collisions)}")
+
+        if collisions:
+            print("\nERROR: id-space collisions detected. Manual resolution required.", file=sys.stderr)
+            for srow, trow in collisions[:10]:
+                print(f"  id={srow['id']} source_sender={srow['sender']} target_sender={trow['sender']}", file=sys.stderr)
+            if len(collisions) > 10:
+                print(f"  ... and {len(collisions) - 10} more", file=sys.stderr)
+            return 2
+
+        # ------------------------------------------------------------------
+        # agent_chat_processed delta
+        # ------------------------------------------------------------------
+        # Two categories:
+        #   A) processed rows for newly-detected chat ids
+        #   B) processed rows for existing chat ids updated after cutoff_ts
+        source_processed_delta_ids = {r["id"] for r in delta_chat}
+
+        if source_processed_delta_ids:
+            source_proc_a = query_rows(
+                source,
+                "SELECT chat_id, agent, received_at, routed_at, responded_at, error_message, status "
+                "FROM public.agent_chat_processed WHERE chat_id = ANY(%s)",
+                (list(source_processed_delta_ids),),
+            )
+        else:
+            source_proc_a = []
+
+        source_proc_b = query_rows(
+            source,
+            "SELECT chat_id, agent, received_at, routed_at, responded_at, error_message, status "
+            "FROM public.agent_chat_processed "
+            "WHERE chat_id <= %s AND ("
+            "      received_at > %s OR routed_at > %s OR responded_at > %s"
+            ")",
+            (cutoff_id, cutoff_ts, cutoff_ts, cutoff_ts),
+        )
+
+        # Combine and de-duplicate by (chat_id, agent)
+        source_processed: dict[tuple[Any, Any], dict[str, Any]] = {}
+        for row in source_proc_a + source_proc_b:
+            source_processed[(row["chat_id"], row["agent"])] = row
+
+        # Fetch corresponding target rows for comparison.
+        # Use a temporary table because composite-array parameter passing is
+        # brittle across psycopg2 versions.
+        target_processed: list[dict[str, Any]] = []
+        if source_processed:
+            keys = list(source_processed.keys())
+            with target.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute("CREATE TEMP TABLE _delta_proc_keys (chat_id int, agent varchar(50)) ON COMMIT DROP")
+                for chat_id, agent in keys:
+                    cur.execute("INSERT INTO _delta_proc_keys VALUES (%s, %s)", (chat_id, agent))
+                cur.execute(
+                    "SELECT p.chat_id, p.agent, p.received_at, p.routed_at, p.responded_at, "
+                    "       p.error_message, p.status "
+                    "FROM public.agent_chat_processed p "
+                    "JOIN _delta_proc_keys k USING (chat_id, agent)"
+                )
+                target_processed = [dict(row) for row in cur.fetchall()]
+            # Stay in the same transaction for the comparison; commit later.
+            target.rollback()  # drop temp table, no actual changes yet
+
+        target_proc_by_key = {(r["chat_id"], r["agent"]): r for r in target_processed}
+
+        proc_to_insert: list[dict[str, Any]] = []
+        proc_to_update: list[dict[str, Any]] = []
+
+        for key, srow in source_processed.items():
+            trow = target_proc_by_key.get(key)
+            if trow is None:
+                proc_to_insert.append(srow)
+            elif build_processed_comparable(srow) != build_processed_comparable(trow):
+                proc_to_update.append(srow)
+
+        print(f"\nagent_chat_processed delta rows to insert: {len(proc_to_insert)}")
+        print(f"agent_chat_processed delta rows to update: {len(proc_to_update)}")
+
+        # ------------------------------------------------------------------
+        # Apply changes
+        # ------------------------------------------------------------------
+        if not args.migrate:
+            total_delta = len(delta_chat) + len(proc_to_insert) + len(proc_to_update)
+            if total_delta == 0:
+                print("\nOK: No delta rows found. Migration is clean.")
+                return 0
+            print(f"\nREPORT-ONLY: {total_delta} delta rows would be migrated. Re-run with --migrate to apply.")
+            return 1
+
+        if args.dry_run:
+            print(f"\nDRY-RUN: Would insert {len(delta_chat)} agent_chat rows.")
+            print(f"DRY-RUN: Would insert {len(proc_to_insert)} and update {len(proc_to_update)} agent_chat_processed rows.")
+            print("DRY-RUN: Would re-set agent_chat_id_seq to max(id) in target.")
+            return 0
+
+        if not delta_chat and not proc_to_insert and not proc_to_update:
+            print("\nOK: No delta rows found. Migration is clean.")
+            return 0
+
+        print("\nApplying delta migration...")
+        with target.cursor() as cur:
+            # Bypass the insert enforcement trigger for the bulk delta load.
+            cur.execute("SET LOCAL agent_chat.bypass_gate = 'on'")
+
+            # Insert delta chat rows
+            for row in delta_chat:
+                cur.execute(
+                    "INSERT INTO public.agent_chat (id, sender, message, recipients, reply_to, \"timestamp\") "
+                    "VALUES (%s, %s, %s, %s, %s, %s)",
+                    (row["id"], row["sender"], row["message"], row["recipients"], row["reply_to"], row["timestamp"]),
+                )
+
+            # Insert new processed rows
+            for row in proc_to_insert:
+                cur.execute(
+                    "INSERT INTO public.agent_chat_processed "
+                    "(chat_id, agent, received_at, routed_at, responded_at, error_message, status) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                    (
+                        row["chat_id"],
+                        row["agent"],
+                        row["received_at"],
+                        row["routed_at"],
+                        row["responded_at"],
+                        row["error_message"],
+                        row["status"],
+                    ),
+                )
+
+            # Update changed processed rows
+            for row in proc_to_update:
+                cur.execute(
+                    "UPDATE public.agent_chat_processed SET "
+                    "received_at = %s, routed_at = %s, responded_at = %s, error_message = %s, status = %s "
+                    "WHERE chat_id = %s AND agent = %s",
+                    (
+                        row["received_at"],
+                        row["routed_at"],
+                        row["responded_at"],
+                        row["error_message"],
+                        row["status"],
+                        row["chat_id"],
+                        row["agent"],
+                    ),
+                )
+
+            # Re-align sequence
+            cur.execute("SELECT setval('public.agent_chat_id_seq', (SELECT COALESCE(max(id), 1) FROM public.agent_chat), true)")
+
+        target.commit()
+
+        # Verify
+        new_max_id = scalar(target, "SELECT max(id) FROM public.agent_chat")
+        new_seq = scalar(target, "SELECT last_value FROM public.agent_chat_id_seq")
+        print(f"\nSUCCESS: Delta migration applied.")
+        print(f"  Inserted agent_chat rows: {len(delta_chat)}")
+        print(f"  Inserted agent_chat_processed rows: {len(proc_to_insert)}")
+        print(f"  Updated agent_chat_processed rows: {len(proc_to_update)}")
+        print(f"  New max(agent_chat.id): {new_max_id}")
+        print(f"  Sequence last_value: {new_seq}")
+        if new_seq < new_max_id:
+            print("ERROR: Sequence last_value is below max(id)!", file=sys.stderr)
+            return 3
+
+        return 0
+
+    finally:
+        source.close()
+        target.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/agent-chat-migration/migrate.sh
+++ b/scripts/agent-chat-migration/migrate.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# migrate.sh — Create the dedicated agent_chat database and migrate the bus.
+# Issue: NOVA-Openclaw/nova-mind#320
+#
+# Usage:
+#   ./migrate.sh [--source-db nova_memory] [--target-db agent_chat]
+#                [--host localhost] [--port 5432] [--superuser postgres]
+#                [--dry-run]
+#
+# This script is idempotent for the schema-creation path: re-running it after a
+# successful migration will skip the database creation and re-apply the schema
+# (CREATE IF NOT EXISTS / OR REPLACE are safe). Data is NOT copied twice unless
+# the target tables are empty; if target tables already contain rows, the data
+# copy step is skipped and a warning is printed.
+#
+# The script must be run as a PostgreSQL superuser (or a role with CREATEDB and
+# REPLICATION/ bypass-replication-session privileges so that --disable-triggers
+# works during the data copy).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCHEMA_FILE="${REPO_ROOT}/database/agent-chat/schema.sql"
+
+SOURCE_DB="nova_memory"
+TARGET_DB="agent_chat"
+HOST="localhost"
+PORT="5432"
+SUPERUSER="postgres"
+DRY_RUN=false
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+  --source-db DB      Source database (default: nova_memory)
+  --target-db DB      Target database to create (default: agent_chat)
+  --host HOST         PostgreSQL host (default: localhost)
+  --port PORT         PostgreSQL port (default: 5432)
+  --superuser USER    Superuser name for DB creation/schema apply (default: postgres)
+  --dry-run           Print commands without executing them
+  -h, --help          Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source-db) SOURCE_DB="$2"; shift 2 ;;
+        --target-db) TARGET_DB="$2"; shift 2 ;;
+        --host) HOST="$2"; shift 2 ;;
+        --port) PORT="$2"; shift 2 ;;
+        --superuser) SUPERUSER="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+PSQL_SUPER="psql -h ${HOST} -p ${PORT} -U ${SUPERUSER} -d"
+PSQL_TARGET="psql -h ${HOST} -p ${PORT} -U ${SUPERUSER} -d ${TARGET_DB}"
+
+run_sql() {
+    local db="$1"
+    local sql="$2"
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        echo "DRY-RUN: psql -h ${HOST} -p ${PORT} -U ${SUPERUSER} -d ${db} -c '${sql}'"
+        return 0
+    fi
+    psql -h "${HOST}" -p "${PORT}" -U "${SUPERUSER}" -d "${db}" -v ON_ERROR_STOP=1 -c "${sql}"
+}
+
+run_sql_value() {
+    local db="$1"
+    local sql="$2"
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        echo "DRY-RUN: psql -h ${HOST} -p ${PORT} -U ${SUPERUSER} -d ${db} -tA -c '${sql}'"
+        return 0
+    fi
+    psql -h "${HOST}" -p "${PORT}" -U "${SUPERUSER}" -d "${db}" -v ON_ERROR_STOP=1 -tA -c "${sql}"
+}
+
+run_file() {
+    local db="$1"
+    local file="$2"
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        echo "DRY-RUN: psql -h ${HOST} -p ${PORT} -U ${SUPERUSER} -d ${db} -f ${file}"
+        return 0
+    fi
+    psql -h "${HOST}" -p "${PORT}" -U "${SUPERUSER}" -d "${db}" -v ON_ERROR_STOP=1 -f "${file}"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Validate source database and count rows before migration.
+# ---------------------------------------------------------------------------
+echo "== Step 1: Validate source database ${SOURCE_DB} =="
+if [[ "${DRY_RUN}" == "true" ]]; then
+    SOURCE_CHAT_COUNT="DRYRUN"
+    SOURCE_PROC_COUNT="DRYRUN"
+    SOURCE_MAX_ID="DRYRUN"
+    SOURCE_ORPHAN_REPLY=0
+    SOURCE_ORPHAN_PROC=0
+else
+    SOURCE_CHAT_COUNT=$(run_sql_value "${SOURCE_DB}" "SELECT count(*)::bigint FROM public.agent_chat;")
+    SOURCE_PROC_COUNT=$(run_sql_value "${SOURCE_DB}" "SELECT count(*)::bigint FROM public.agent_chat_processed;")
+    SOURCE_MAX_ID=$(run_sql_value "${SOURCE_DB}" "SELECT coalesce(max(id), 0) FROM public.agent_chat;")
+    SOURCE_ORPHAN_REPLY=$(run_sql_value "${SOURCE_DB}" "SELECT count(*) FROM public.agent_chat WHERE reply_to IS NOT NULL AND reply_to NOT IN (SELECT id FROM public.agent_chat);")
+    SOURCE_ORPHAN_PROC=$(run_sql_value "${SOURCE_DB}" "SELECT count(*) FROM public.agent_chat_processed WHERE chat_id NOT IN (SELECT id FROM public.agent_chat);")
+fi
+
+echo "   Source agent_chat rows:        ${SOURCE_CHAT_COUNT}"
+echo "   Source agent_chat_processed rows: ${SOURCE_PROC_COUNT}"
+echo "   Source max(agent_chat.id):     ${SOURCE_MAX_ID}"
+echo "   Source orphan reply_to refs:   ${SOURCE_ORPHAN_REPLY}"
+echo "   Source orphan processed refs:  ${SOURCE_ORPHAN_PROC}"
+
+if [[ "${DRY_RUN}" != "true" && ( -z "${SOURCE_CHAT_COUNT}" || -z "${SOURCE_PROC_COUNT}" || -z "${SOURCE_MAX_ID}" ) ]]; then
+    echo "ERROR: Could not read source counts. Check connection and privileges." >&2
+    exit 1
+fi
+
+if [[ "${SOURCE_ORPHAN_REPLY}" -gt 0 || "${SOURCE_ORPHAN_PROC}" -gt 0 ]]; then
+    echo "   WARNING: source database has ${SOURCE_ORPHAN_REPLY} orphan reply_to and ${SOURCE_ORPHAN_PROC} orphan processed references." >&2
+    echo "   These will be preserved in the target and FK constraints re-added as NOT VALID." >&2
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Create target database if it does not exist.
+# ---------------------------------------------------------------------------
+echo "== Step 2: Create target database ${TARGET_DB} (if missing) =="
+DB_EXISTS=$(run_sql_value "postgres" "SELECT 1 FROM pg_database WHERE datname = '${TARGET_DB}';")
+if [[ "${DB_EXISTS}" == "1" ]]; then
+    echo "   Database ${TARGET_DB} already exists."
+else
+    run_sql "postgres" "CREATE DATABASE \"${TARGET_DB}\";"
+    echo "   Created database ${TARGET_DB}."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Apply schema to target database.
+# ---------------------------------------------------------------------------
+echo "== Step 3: Apply schema to ${TARGET_DB} =="
+if [[ ! -f "${SCHEMA_FILE}" ]]; then
+    echo "ERROR: Schema file not found: ${SCHEMA_FILE}" >&2
+    exit 1
+fi
+run_file "${TARGET_DB}" "${SCHEMA_FILE}"
+echo "   Schema applied."
+
+# ---------------------------------------------------------------------------
+# 4. Copy data from source to target.
+#    --disable-triggers avoids firing notify/enforce triggers during bulk load.
+# ---------------------------------------------------------------------------
+echo "== Step 4: Copy data from ${SOURCE_DB} to ${TARGET_DB} =="
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+    TARGET_CHAT_COUNT=0
+else
+    TARGET_CHAT_COUNT=$(run_sql_value "${TARGET_DB}" "SELECT count(*)::bigint FROM public.agent_chat;")
+fi
+if [[ "${TARGET_CHAT_COUNT}" -gt 0 ]]; then
+    echo "   WARNING: target agent_chat already has ${TARGET_CHAT_COUNT} rows. Skipping data copy." >&2
+    echo "   If you want to re-copy, truncate the target tables first." >&2
+else
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        echo "DRY-RUN: COPY data from ${SOURCE_DB} to ${TARGET_DB} with triggers disabled"
+    else
+        # Disable user triggers in target to avoid firing notify/enforce triggers
+        # on historical data. Drop the self-referential reply_to FK temporarily
+        # so the bulk load does not have to be ordered; re-add it after load.
+        run_sql "${TARGET_DB}" "ALTER TABLE public.agent_chat DISABLE TRIGGER USER; ALTER TABLE public.agent_chat_processed DISABLE TRIGGER USER; ALTER TABLE public.agent_chat DROP CONSTRAINT IF EXISTS agent_chat_reply_to_fkey; ALTER TABLE public.agent_chat_processed DROP CONSTRAINT IF EXISTS agent_chat_processed_chat_id_fkey;"
+
+        # Stream COPY from source to target for agent_chat.
+        psql -h "${HOST}" -p "${PORT}" -U "${SUPERUSER}" -d "${SOURCE_DB}" -v ON_ERROR_STOP=1 -c "COPY public.agent_chat (id, sender, message, recipients, reply_to, \"timestamp\") TO STDOUT;" \
+            | psql -h "${HOST}" -p "${PORT}" -U "${SUPERUSER}" -d "${TARGET_DB}" -v ON_ERROR_STOP=1 -c "COPY public.agent_chat (id, sender, message, recipients, reply_to, \"timestamp\") FROM STDIN;"
+
+        # Stream COPY from source to target for agent_chat_processed.
+        psql -h "${HOST}" -p "${PORT}" -U "${SUPERUSER}" -d "${SOURCE_DB}" -v ON_ERROR_STOP=1 -c "COPY public.agent_chat_processed (chat_id, agent, received_at, routed_at, responded_at, error_message, status) TO STDOUT;" \
+            | psql -h "${HOST}" -p "${PORT}" -U "${SUPERUSER}" -d "${TARGET_DB}" -v ON_ERROR_STOP=1 -c "COPY public.agent_chat_processed (chat_id, agent, received_at, routed_at, responded_at, error_message, status) FROM STDIN;"
+
+        # Re-add FK constraints and re-enable triggers. If the source has orphan
+        # references, re-add constraints as NOT VALID to preserve data exactly.
+        if [[ "${SOURCE_ORPHAN_REPLY}" -gt 0 ]]; then
+            REPLY_VALID="NOT VALID"
+        else
+            REPLY_VALID=""
+        fi
+        if [[ "${SOURCE_ORPHAN_PROC}" -gt 0 ]]; then
+            PROC_VALID="NOT VALID"
+        else
+            PROC_VALID=""
+        fi
+        run_sql "${TARGET_DB}" "ALTER TABLE public.agent_chat ADD CONSTRAINT agent_chat_reply_to_fkey FOREIGN KEY (reply_to) REFERENCES public.agent_chat(id) ${REPLY_VALID}; ALTER TABLE public.agent_chat_processed ADD CONSTRAINT agent_chat_processed_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES public.agent_chat(id) ${PROC_VALID}; ALTER TABLE public.agent_chat ENABLE TRIGGER USER; ALTER TABLE public.agent_chat_processed ENABLE TRIGGER USER; ALTER TABLE public.agent_chat ENABLE ALWAYS TRIGGER trg_notify_agent_chat;"
+    fi
+    echo "   Data copy complete."
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Set sequence to max(id) with is_called = true.
+# ---------------------------------------------------------------------------
+echo "== Step 5: Align agent_chat_id_seq with migrated data =="
+run_sql "${TARGET_DB}" "SELECT setval('public.agent_chat_id_seq', (SELECT COALESCE(max(id), 1) FROM public.agent_chat), true);"
+echo "   Sequence aligned."
+
+# ---------------------------------------------------------------------------
+# 6. Post-copy verification.
+# ---------------------------------------------------------------------------
+echo "== Step 6: Post-copy verification =="
+VERIFY_SQL=$(cat <<'EOF'
+SELECT
+    (SELECT count(*)::bigint FROM public.agent_chat) AS chat_rows,
+    (SELECT count(*)::bigint FROM public.agent_chat_processed) AS proc_rows,
+    (SELECT COALESCE(max(id), 0) FROM public.agent_chat) AS max_chat_id,
+    (SELECT last_value FROM public.agent_chat_id_seq) AS seq_last_value,
+    (SELECT COALESCE(max(id), 0) FROM public.agent_chat_id_seq) AS seq_max,  -- dummy, same as last_value
+    (SELECT count(*) FROM public.agent_chat WHERE reply_to IS NOT NULL AND reply_to NOT IN (SELECT id FROM public.agent_chat)) AS orphan_reply_to,
+    (SELECT count(*) FROM public.agent_chat_processed WHERE chat_id NOT IN (SELECT id FROM public.agent_chat)) AS orphan_processed;
+EOF
+)
+
+# Re-run verification using a clean, pipe-delimited query.
+VERIFY_SQL=$(cat <<'EOF'
+SELECT
+    (SELECT count(*)::bigint FROM public.agent_chat) || '|' ||
+    (SELECT count(*)::bigint FROM public.agent_chat_processed) || '|' ||
+    (SELECT COALESCE(max(id), 0) FROM public.agent_chat) || '|' ||
+    (SELECT last_value FROM public.agent_chat_id_seq) || '|' ||
+    (SELECT count(*) FROM public.agent_chat WHERE reply_to IS NOT NULL AND reply_to NOT IN (SELECT id FROM public.agent_chat)) || '|' ||
+    (SELECT count(*) FROM public.agent_chat_processed WHERE chat_id NOT IN (SELECT id FROM public.agent_chat));
+EOF
+)
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+    VERIFY_RESULT="0|0|0|0|0|0"
+else
+    VERIFY_RESULT=$(run_sql_value "${TARGET_DB}" "${VERIFY_SQL}")
+fi
+
+echo "   Verification result: ${VERIFY_RESULT}"
+
+# Parse the result.
+TGT_CHAT_COUNT=$(echo "${VERIFY_RESULT}" | cut -d'|' -f1)
+TGT_PROC_COUNT=$(echo "${VERIFY_RESULT}" | cut -d'|' -f2)
+TGT_MAX_ID=$(echo "${VERIFY_RESULT}" | cut -d'|' -f3)
+TGT_SEQ_LAST=$(echo "${VERIFY_RESULT}" | cut -d'|' -f4)
+TGT_ORPHAN_REPLY=$(echo "${VERIFY_RESULT}" | cut -d'|' -f5)
+TGT_ORPHAN_PROC=$(echo "${VERIFY_RESULT}" | cut -d'|' -f6)
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+    echo ""
+    echo "DRY-RUN: Migration plan complete (no changes made)."
+    exit 0
+fi
+
+PASS=true
+if [[ "${TGT_CHAT_COUNT}" != "${SOURCE_CHAT_COUNT}" ]]; then
+    echo "   FAIL: agent_chat row count mismatch (source=${SOURCE_CHAT_COUNT}, target=${TGT_CHAT_COUNT})" >&2
+    PASS=false
+fi
+if [[ "${TGT_PROC_COUNT}" != "${SOURCE_PROC_COUNT}" ]]; then
+    echo "   FAIL: agent_chat_processed row count mismatch (source=${SOURCE_PROC_COUNT}, target=${TGT_PROC_COUNT})" >&2
+    PASS=false
+fi
+if [[ "${TGT_SEQ_LAST}" -lt "${TGT_MAX_ID}" ]]; then
+    echo "   FAIL: sequence last_value (${TGT_SEQ_LAST}) < max(id) (${TGT_MAX_ID})" >&2
+    PASS=false
+fi
+if [[ "${TGT_ORPHAN_REPLY}" != "${SOURCE_ORPHAN_REPLY}" ]]; then
+    echo "   FAIL: target has ${TGT_ORPHAN_REPLY} orphan reply_to refs but source had ${SOURCE_ORPHAN_REPLY}" >&2
+    PASS=false
+fi
+if [[ "${TGT_ORPHAN_PROC}" != "${SOURCE_ORPHAN_PROC}" ]]; then
+    echo "   FAIL: target has ${TGT_ORPHAN_PROC} orphan processed refs but source had ${SOURCE_ORPHAN_PROC}" >&2
+    PASS=false
+fi
+if [[ "${TGT_ORPHAN_REPLY}" -gt 0 || "${TGT_ORPHAN_PROC}" -gt 0 ]]; then
+    echo "   WARNING: target preserved ${TGT_ORPHAN_REPLY} reply_to and ${TGT_ORPHAN_PROC} processed orphans from source." >&2
+fi
+
+if [[ "${PASS}" == "true" ]]; then
+    echo ""
+    echo "SUCCESS: Migration verification passed."
+    echo "   Target DB: ${TARGET_DB}"
+    echo "   agent_chat rows: ${TGT_CHAT_COUNT}"
+    echo "   agent_chat_processed rows: ${TGT_PROC_COUNT}"
+    echo "   max(chat.id): ${TGT_MAX_ID}"
+    echo "   sequence last_value: ${TGT_SEQ_LAST}"
+else
+    echo ""
+    echo "ERROR: Migration verification failed. Do not proceed to rollout." >&2
+    exit 1
+fi

--- a/scripts/agent-chat-migration/pre_drop_gate_check.sh
+++ b/scripts/agent-chat-migration/pre_drop_gate_check.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# pre_drop_gate_check.sh — Verify all six decommission gates before dropping
+# agent_chat objects from nova_memory.
+#
+# Issue: NOVA-Openclaw/nova-mind#320
+#
+# Gates:
+#   1. Row counts match between source and target databases.
+#   2. Sequence last_value >= max(id) in target database.
+#   3. Round-trip freshness verified (manual attestation required).
+#   4. Zero unresolved delta rows in source database after cutoff.
+#   5. No unresolved dependent objects blocking DROP (pg_depend check).
+#   6. Consumer scripts repointed (manual attestation required).
+#
+# Usage:
+#   ./pre_drop_gate_check.sh \
+#       [--source-db nova_memory] [--target-db agent_chat] \
+#       [--host localhost] [--port 5432] [--user postgres] \
+#       [--round-trip-log path/to/roundtrip.log] \
+#       [--consumer-attestation path/to/consumers.log] \
+#       [--gate-pass-marker /var/run/agent_chat_gate_pass.timestamp] \
+#       [--delta-cutoff-id ID] [--delta-cutoff-ts ISO8601]
+#
+# Exit codes:
+#   0  All gates passed; marker file written.
+#   1  One or more gates failed (details printed).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SOURCE_DB="nova_memory"
+TARGET_DB="agent_chat"
+HOST="localhost"
+PORT="5432"
+USER="postgres"
+ROUND_TRIP_LOG=""
+CONSUMER_ATTESTATION=""
+GATE_PASS_MARKER=""
+DELTA_CUTOFF_ID=""
+DELTA_CUTOFF_TS=""
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+  --source-db DB                  Source database (default: nova_memory)
+  --target-db DB                  Target database (default: agent_chat)
+  --host HOST                     PostgreSQL host (default: localhost)
+  --port PORT                     PostgreSQL port (default: 5432)
+  --user USER                     PostgreSQL user (default: postgres)
+  --round-trip-log PATH           Log file attesting fresh round-trip tests (gate 3)
+  --consumer-attestation PATH     File attesting consumer scripts are repointed (gate 6)
+  --gate-pass-marker PATH         Path to write on success (default: none)
+  --delta-cutoff-id ID            Cutoff id for delta check (default: target max id)
+  --delta-cutoff-ts ISO8601       Cutoff timestamp for delta check (default: target newest)
+  -h, --help                      Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source-db) SOURCE_DB="$2"; shift 2 ;;
+        --target-db) TARGET_DB="$2"; shift 2 ;;
+        --host) HOST="$2"; shift 2 ;;
+        --port) PORT="$2"; shift 2 ;;
+        --user) USER="$2"; shift 2 ;;
+        --round-trip-log) ROUND_TRIP_LOG="$2"; shift 2 ;;
+        --consumer-attestation) CONSUMER_ATTESTATION="$2"; shift 2 ;;
+        --gate-pass-marker) GATE_PASS_MARKER="$2"; shift 2 ;;
+        --delta-cutoff-id) DELTA_CUTOFF_ID="$2"; shift 2 ;;
+        --delta-cutoff-ts) DELTA_CUTOFF_TS="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+PSQL="psql -h ${HOST} -p ${PORT} -U ${USER} -v ON_ERROR_STOP=1"
+
+run_sql_value() {
+    local db="$1"
+    local sql="$2"
+    ${PSQL} -d "${db}" -tA -c "${sql}"
+}
+
+run_sql() {
+    local db="$1"
+    local sql="$2"
+    ${PSQL} -d "${db}" -c "${sql}"
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+fail_gate() {
+    local gate="$1"
+    local reason="$2"
+    echo ""
+    echo "GATE ${gate} FAILED: ${reason}" >&2
+}
+
+GATES_PASSED=true
+
+# ---------------------------------------------------------------------------
+# Gate 1: Row count match
+# ---------------------------------------------------------------------------
+echo "== Gate 1: Row count match =="
+COUNTS=$(cat <<'EOF'
+SELECT
+    (SELECT count(*)::bigint FROM public.agent_chat) || '|' ||
+    (SELECT count(*)::bigint FROM public.agent_chat_processed);
+EOF
+)
+SRC_COUNTS=$(run_sql_value "${SOURCE_DB}" "${COUNTS}")
+TGT_COUNTS=$(run_sql_value "${TARGET_DB}" "${COUNTS}")
+
+SRC_CHAT_COUNT=$(echo "${SRC_COUNTS}" | cut -d'|' -f1)
+SRC_PROC_COUNT=$(echo "${SRC_COUNTS}" | cut -d'|' -f2)
+TGT_CHAT_COUNT=$(echo "${TGT_COUNTS}" | cut -d'|' -f1)
+TGT_PROC_COUNT=$(echo "${TGT_COUNTS}" | cut -d'|' -f2)
+
+echo "   Source: agent_chat=${SRC_CHAT_COUNT}, agent_chat_processed=${SRC_PROC_COUNT}"
+echo "   Target: agent_chat=${TGT_CHAT_COUNT}, agent_chat_processed=${TGT_PROC_COUNT}"
+
+if [[ "${SRC_CHAT_COUNT}" != "${TGT_CHAT_COUNT}" || "${SRC_PROC_COUNT}" != "${TGT_PROC_COUNT}" ]]; then
+    fail_gate 1 "Row counts differ between ${SOURCE_DB} and ${TARGET_DB}."
+    GATES_PASSED=false
+else
+    echo "   PASS"
+fi
+
+# ---------------------------------------------------------------------------
+# Gate 2: Sequence / max(id) alignment
+# ---------------------------------------------------------------------------
+echo "== Gate 2: Sequence / max(id) alignment =="
+ALIGN=$(cat <<'EOF'
+SELECT
+    (SELECT COALESCE(max(id), 0) FROM public.agent_chat) || '|' ||
+    (SELECT last_value FROM public.agent_chat_id_seq) || '|' ||
+    (SELECT is_called FROM public.agent_chat_id_seq);
+EOF
+)
+ALIGN_RESULT=$(run_sql_value "${TARGET_DB}" "${ALIGN}")
+MAX_ID=$(echo "${ALIGN_RESULT}" | cut -d'|' -f1)
+SEQ_LAST=$(echo "${ALIGN_RESULT}" | cut -d'|' -f2)
+SEQ_IS_CALLED=$(echo "${ALIGN_RESULT}" | cut -d'|' -f3)
+
+echo "   max(id): ${MAX_ID}, last_value: ${SEQ_LAST}, is_called: ${SEQ_IS_CALLED}"
+
+if [[ "${SEQ_LAST}" -lt "${MAX_ID}" ]]; then
+    fail_gate 2 "Sequence last_value (${SEQ_LAST}) is less than max(id) (${MAX_ID})."
+    GATES_PASSED=false
+elif [[ "${SEQ_IS_CALLED}" != "t" && "${SEQ_IS_CALLED}" != "true" ]]; then
+    fail_gate 2 "Sequence is_called flag is not true (would cause next nextval to repeat max id)."
+    GATES_PASSED=false
+else
+    echo "   PASS"
+fi
+
+# ---------------------------------------------------------------------------
+# Gate 3: Round-trip freshness attestation
+# ---------------------------------------------------------------------------
+echo "== Gate 3: Round-trip freshness =="
+if [[ -z "${ROUND_TRIP_LOG}" || ! -f "${ROUND_TRIP_LOG}" ]]; then
+    fail_gate 3 "Missing or unreadable round-trip attestation log (--round-trip-log). Fresh round-trips for all peers/subagents/Victoria must be recorded."
+    GATES_PASSED=false
+else
+    echo "   Attestation file: ${ROUND_TRIP_LOG}"
+    echo "   Contents:"
+    sed 's/^/      /' "${ROUND_TRIP_LOG}"
+    echo "   PASS (operator attestation accepted)"
+fi
+
+# ---------------------------------------------------------------------------
+# Gate 4: Zero unresolved delta rows
+# ---------------------------------------------------------------------------
+echo "== Gate 4: Zero unresolved delta rows =="
+
+if [[ -z "${DELTA_CUTOFF_ID}" ]]; then
+    DELTA_CUTOFF_ID=$(run_sql_value "${TARGET_DB}" "SELECT COALESCE(max(id), 0) FROM public.agent_chat;")
+fi
+if [[ -z "${DELTA_CUTOFF_TS}" ]]; then
+    DELTA_CUTOFF_TS=$(run_sql_value "${TARGET_DB}" "SELECT max(\"timestamp\")::text FROM public.agent_chat;")
+fi
+
+echo "   Delta cutoff id: ${DELTA_CUTOFF_ID}"
+echo "   Delta cutoff ts: ${DELTA_CUTOFF_TS}"
+
+DELTA_SQL=$(cat <<EOF
+SELECT
+    (SELECT count(*)::bigint FROM public.agent_chat WHERE id > ${DELTA_CUTOFF_ID}) || '|' ||
+    (SELECT count(*)::bigint FROM public.agent_chat_processed WHERE chat_id > ${DELTA_CUTOFF_ID});
+EOF
+)
+DELTA_RESULT=$(run_sql_value "${SOURCE_DB}" "${DELTA_SQL}")
+DELTA_CHAT=$(echo "${DELTA_RESULT}" | cut -d'|' -f1)
+DELTA_PROC=$(echo "${DELTA_RESULT}" | cut -d'|' -f2)
+
+echo "   Source agent_chat delta rows: ${DELTA_CHAT}"
+echo "   Source agent_chat_processed delta rows (for new chat ids): ${DELTA_PROC}"
+
+if [[ "${DELTA_CHAT}" -ne 0 || "${DELTA_PROC}" -ne 0 ]]; then
+    fail_gate 4 "Unresolved delta rows remain in ${SOURCE_DB}. Run delta_check_and_migrate.py before decommission."
+    GATES_PASSED=false
+else
+    echo "   PASS"
+fi
+
+# ---------------------------------------------------------------------------
+# Gate 5: Dependent-object resolution
+# ---------------------------------------------------------------------------
+echo "== Gate 5: Dependent-object resolution =="
+
+# Find any objects in the source DB that still depend on agent_chat/agent_chat_processed
+# and are NOT the expected objects we plan to drop ourselves.
+DEP_SQL=$(cat <<'EOF'
+SELECT
+    d.classid::regclass AS dependent_type,
+    d.objid::regclass::text AS dependent_object,
+    d.refobjid::regclass::text AS referenced_object
+FROM pg_depend d
+JOIN pg_class c ON c.oid = d.objid
+WHERE d.refobjid IN ('public.agent_chat'::regclass, 'public.agent_chat_processed'::regclass)
+  AND d.deptype = 'n'
+  AND c.relname NOT IN (
+      'agent_chat', 'agent_chat_processed', 'agent_chat_id_seq',
+      'idx_agent_chat_recipients', 'idx_agent_chat_sender', 'idx_agent_chat_timestamp',
+      'idx_agent_chat_processed_agent', 'idx_agent_chat_processed_status', 'idx_agent_chat_processed_unique',
+      'idx_chat_processed_agent',
+      'v_agent_chat_recent', 'v_agent_chat_stats'
+  )
+ORDER BY referenced_object, dependent_object;
+EOF
+)
+
+DEP_COUNT=$(run_sql_value "${SOURCE_DB}" "SELECT count(*) FROM (${DEP_SQL}) sub;")
+if [[ "${DEP_COUNT}" -ne 0 ]]; then
+    echo "   Unresolved dependencies:" >&2
+    run_sql "${SOURCE_DB}" "${DEP_SQL}" >&2
+    fail_gate 5 "Found ${DEP_COUNT} dependent object(s) in ${SOURCE_DB} that are not in the planned drop list."
+    GATES_PASSED=false
+else
+    echo "   No unexpected dependencies."
+    echo "   PASS"
+fi
+
+# ---------------------------------------------------------------------------
+# Gate 6: Consumer-script repoint attestation
+# ---------------------------------------------------------------------------
+echo "== Gate 6: Consumer-script repoint attestation =="
+if [[ -z "${CONSUMER_ATTESTATION}" || ! -f "${CONSUMER_ATTESTATION}" ]]; then
+    fail_gate 6 "Missing or unreadable consumer attestation (--consumer-attestation). Required scripts (proactive-gate-check.py, pg-notify-listener.py, agent_chat plugin configs) must be repointed and smoke-tested."
+    GATES_PASSED=false
+else
+    echo "   Attestation file: ${CONSUMER_ATTESTATION}"
+    echo "   Contents:"
+    sed 's/^/      /' "${CONSUMER_ATTESTATION}"
+    echo "   PASS (operator attestation accepted)"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+if [[ "${GATES_PASSED}" != "true" ]]; then
+    echo "ERROR: One or more decommission gates failed. DROP blocked." >&2
+    exit 1
+fi
+
+echo "SUCCESS: All decommission gates passed."
+if [[ -n "${GATE_PASS_MARKER}" ]]; then
+    MARKER_DIR=$(dirname "${GATE_PASS_MARKER}")
+    if [[ ! -d "${MARKER_DIR}" ]]; then
+        mkdir -p "${MARKER_DIR}"
+    fi
+    {
+        echo "agent_chat decommission gates passed"
+        echo "timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo "source_db: ${SOURCE_DB}"
+        echo "target_db: ${TARGET_DB}"
+        echo "chat_count: ${TGT_CHAT_COUNT}"
+        echo "processed_count: ${TGT_PROC_COUNT}"
+        echo "max_id: ${MAX_ID}"
+        echo "seq_last_value: ${SEQ_LAST}"
+    } > "${GATE_PASS_MARKER}"
+    echo "Marker written: ${GATE_PASS_MARKER}"
+fi
+
+exit 0

--- a/scripts/agent-chat-migration/pre_drop_gate_check.sh
+++ b/scripts/agent-chat-migration/pre_drop_gate_check.sh
@@ -175,6 +175,13 @@ fi
 # ---------------------------------------------------------------------------
 # Gate 4: Zero unresolved delta rows
 # ---------------------------------------------------------------------------
+# Delegate to delta_check_and_migrate.py in report-only mode. The Python
+# script implements the authoritative two-part delta check:
+#   A) agent_chat rows with id > cutoff_id
+#   B) agent_chat_processed rows updated after cutoff_ts for chat_ids already
+#      migrated (chat_id <= cutoff_id).
+# Re-implementing this logic in shell/SQL caused the original Gate 4 bug
+# (NOVA-Openclaw/nova-mind#375): the SQL-only check missed part B.
 echo "== Gate 4: Zero unresolved delta rows =="
 
 if [[ -z "${DELTA_CUTOFF_ID}" ]]; then
@@ -187,23 +194,33 @@ fi
 echo "   Delta cutoff id: ${DELTA_CUTOFF_ID}"
 echo "   Delta cutoff ts: ${DELTA_CUTOFF_TS}"
 
-DELTA_SQL=$(cat <<EOF
-SELECT
-    (SELECT count(*)::bigint FROM public.agent_chat WHERE id > ${DELTA_CUTOFF_ID}) || '|' ||
-    (SELECT count(*)::bigint FROM public.agent_chat_processed WHERE chat_id > ${DELTA_CUTOFF_ID});
-EOF
+DELTA_CHECK_ARGS=(
+    "--source-db" "${SOURCE_DB}"
+    "--target-db" "${TARGET_DB}"
+    "--host" "${HOST}"
+    "--port" "${PORT}"
+    "--user" "${USER}"
+    "--cutoff-id" "${DELTA_CUTOFF_ID}"
+    "--cutoff-ts" "${DELTA_CUTOFF_TS}"
 )
-DELTA_RESULT=$(run_sql_value "${SOURCE_DB}" "${DELTA_SQL}")
-DELTA_CHAT=$(echo "${DELTA_RESULT}" | cut -d'|' -f1)
-DELTA_PROC=$(echo "${DELTA_RESULT}" | cut -d'|' -f2)
 
-echo "   Source agent_chat delta rows: ${DELTA_CHAT}"
-echo "   Source agent_chat_processed delta rows (for new chat ids): ${DELTA_PROC}"
+echo "   Delegating delta check to delta_check_and_migrate.py (report-only)..."
+DELTA_RC=0
+DELTA_OUT=$("${SCRIPT_DIR}/delta_check_and_migrate.py" "${DELTA_CHECK_ARGS[@]}" 2>&1) || DELTA_RC=$?
 
-if [[ "${DELTA_CHAT}" -ne 0 || "${DELTA_PROC}" -ne 0 ]]; then
-    fail_gate 4 "Unresolved delta rows remain in ${SOURCE_DB}. Run delta_check_and_migrate.py before decommission."
+# delta_check_and_migrate.py returns:
+#   0 = no delta rows
+#   1 = delta rows found (report-only mode)
+#   2 = id-space collision
+#   3 = sequence misalignment after migration (only possible with --migrate)
+# Any non-zero result means the gate fails.
+if [[ ${DELTA_RC} -ne 0 ]]; then
+    echo "   delta_check_and_migrate.py exited with code ${DELTA_RC}:" >&2
+    echo "${DELTA_OUT}" >&2
+    fail_gate 4 "Unresolved delta rows remain in ${SOURCE_DB}. Run delta_check_and_migrate.py --migrate before decommission."
     GATES_PASSED=false
 else
+    echo "${DELTA_OUT}"
     echo "   PASS"
 fi
 

--- a/skills/agent-ecosystem/SKILL.md
+++ b/skills/agent-ecosystem/SKILL.md
@@ -44,7 +44,7 @@ SELECT send_agent_message(
 ```
 
 - Peers process messages asynchronously — don't expect an immediate response.
-- Replies arrive via agent_chat replication. Check for responses:
+- Replies arrive via `agent_chat` (as of nova-mind#320, a single dedicated `agent_chat` database shared by all agents directly — not cross-database replication). Check for responses:
 
 ```sql
 SELECT id, sender, left(message, 200), timestamp

--- a/tests/install/test_agent_chat_installer.bats
+++ b/tests/install/test_agent_chat_installer.bats
@@ -13,6 +13,11 @@ BATS_TEST_DIRNAME="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
 REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
 INSTALLER="$REPO_ROOT/agent-install.sh"
 
+# Mirrors the status symbols used by agent-install.sh so the inline helpers
+# produce familiar output without sourcing the whole script.
+CHECK_MARK="✅"
+WARNING="⚠️"
+
 # Inline copies of the helper functions under test.  They are isolated here so
 # the test does not have to source the entire installer (which executes script
 # body code on source).
@@ -57,19 +62,70 @@ _ensure_agent_chat_postgres_json() {
         return 1
     fi
 
-    local already_correct
-    already_correct=$(jq --arg db "$database" --arg user "$user" --arg pass "$password" \
-        '(.agent_chat // {}) | {database, user, password} == {database: $db, user: $user, password: $pass}' \
-        "$pg_config" 2>/dev/null || echo "false")
-    if [ "$already_correct" = "true" ]; then
+    local new_json
+    new_json=$(jq --arg db "$database" --arg user "$user" --arg pass "$password" \
+        'if (.agent_chat // null) | type == "object" then
+            .agent_chat |= . + {
+                database: (.database // $db),
+                user: (.user // $user),
+                password: (.password // $pass)
+            }
+         else
+            .agent_chat = {"database": $db, "user": $user, "password": $pass}
+         end' "$pg_config" 2>/dev/null) || return 1
+
+    # Only write if something changed.
+    if [ "$(printf '%s\n' "$new_json" | jq -Sc .)" = "$(jq -Sc . < "$pg_config")" ]; then
         return 1
     fi
 
-    jq --arg db "$database" --arg user "$user" --arg pass "$password" \
-        '.agent_chat = {"database": $db, "user": $user, "password": $pass}' \
-        "$pg_config" >"${pg_config}.tmp" && \
+    printf '%s\n' "$new_json" >"${pg_config}.tmp" && \
         mv "${pg_config}.tmp" "$pg_config" && \
         chmod 600 "$pg_config"
+}
+
+_install_pg_notify_listener() {
+    local source_script="$1"
+    local source_service="$2"
+    local target_dir="$3"
+    local service_dir="$4"
+    local logs_dir="$5"
+
+    if [ ! -f "$source_script" ] || [ ! -f "$source_service" ]; then
+        echo -e "  ${WARNING} pg-notify-listener source files not found (skipping)"
+        return 1
+    fi
+
+    mkdir -p "$target_dir"
+    mkdir -p "$service_dir"
+    mkdir -p "$logs_dir"
+
+    cp "$source_script" "$target_dir/pg-notify-listener.py"
+    chmod +x "$target_dir/pg-notify-listener.py"
+    echo -e "  ${CHECK_MARK} Installed pg-notify-listener.py → $target_dir"
+
+    cp "$source_service" "$service_dir/pg-notify-listener.service"
+    echo -e "  ${CHECK_MARK} Installed pg-notify-listener.service → $service_dir"
+
+    if command -v systemctl &>/dev/null; then
+        systemctl --user daemon-reload
+        if systemctl --user is-active pg-notify-listener.service &>/dev/null; then
+            if systemctl --user restart pg-notify-listener.service; then
+                echo -e "  ${CHECK_MARK} Restarted pg-notify-listener.service"
+            else
+                echo -e "  ${WARNING} pg-notify-listener.service restart failed"
+            fi
+        else
+            if systemctl --user enable pg-notify-listener.service &>/dev/null && \
+               systemctl --user start pg-notify-listener.service; then
+                echo -e "  ${CHECK_MARK} Enabled and started pg-notify-listener.service"
+            else
+                echo -e "  ${WARNING} pg-notify-listener.service enable/start failed"
+            fi
+        fi
+    else
+        echo -e "  ${WARNING} systemctl not available — service not started"
+    fi
 }
 
 setup() {
@@ -166,6 +222,54 @@ EOF
     [ "$status" -eq 1 ]
 }
 
+@test "agent_chat: merges missing keys without clobbering existing section" {
+    local pg_config="$FAKE_HOME/postgres.json"
+    cat > "$pg_config" <<'EOF'
+{
+  "host": "localhost",
+  "database": "nova_memory",
+  "user": "nova",
+  "password": "secret1",
+  "agent_chat": {
+    "database": "agent_chat",
+    "user": "nova"
+  }
+}
+EOF
+
+    run _ensure_agent_chat_postgres_json "$pg_config" "agent_chat" "nova" "secret1"
+    [ "$status" -eq 0 ]
+
+    [ "$(jq -r '.agent_chat.database' "$pg_config")" = "agent_chat" ]
+    [ "$(jq -r '.agent_chat.user' "$pg_config")" = "nova" ]
+    [ "$(jq -r '.agent_chat.password' "$pg_config")" = "secret1" ]
+    [ "$(jq -r '.database' "$pg_config")" = "nova_memory" ]
+}
+
+@test "agent_chat: preserves existing section with different password (no clobber)" {
+    local pg_config="$FAKE_HOME/postgres.json"
+    cat > "$pg_config" <<'EOF'
+{
+  "host": "localhost",
+  "database": "nova_memory",
+  "user": "nova",
+  "password": "secret1",
+  "agent_chat": {
+    "database": "agent_chat",
+    "user": "nova",
+    "password": "manual-password",
+    "host": "db.internal"
+  }
+}
+EOF
+
+    run _ensure_agent_chat_postgres_json "$pg_config" "agent_chat" "nova" "secret1"
+    [ "$status" -eq 1 ]
+
+    [ "$(jq -r '.agent_chat.password' "$pg_config")" = "manual-password" ]
+    [ "$(jq -r '.agent_chat.host' "$pg_config")" = "db.internal" ]
+}
+
 # ─── TC-67 ──────────────────────────────────────────────────────────────────
 
 @test "TC-67: openclaw.json dead connection keys removed, live keys preserved" {
@@ -221,6 +325,71 @@ EOF
     [ "$(jq -r '.plugins.entries.agent_chat.config.password' "$config")" = "null" ]
 }
 
+# ─── pg-notify-listener deployment ─────────────────────────────────────────
+
+@test "TC-listener: installs script, service unit, and starts service" {
+    local fake_bin="$FAKE_HOME/bin"
+    local calls_log="$FAKE_HOME/systemctl-calls.log"
+    mkdir -p "$fake_bin"
+
+    # The installer redirects stdout of some systemctl calls, so append to a
+    # fixed log file directly rather than relying on stdout capture.
+    cat > "$fake_bin/systemctl" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$calls_log"
+if [ "\$2" = "is-active" ]; then
+    exit 1
+fi
+exit 0
+EOF
+    chmod +x "$fake_bin/systemctl"
+
+    local src_dir="$FAKE_HOME/src"
+    local tgt_dir="$FAKE_HOME/scripts"
+    local svc_dir="$FAKE_HOME/systemd/user"
+    local logs_dir="$FAKE_HOME/logs"
+    mkdir -p "$src_dir"
+    printf '#!/usr/bin/env python3\nprint("listen")\n' > "$src_dir/pg-notify-listener.py"
+    printf '[Service]\nExecStart=python listener.py\n' > "$src_dir/pg-notify-listener.service"
+
+    PATH="$fake_bin:$PATH" run _install_pg_notify_listener \
+        "$src_dir/pg-notify-listener.py" \
+        "$src_dir/pg-notify-listener.service" \
+        "$tgt_dir" "$svc_dir" "$logs_dir"
+    [ "$status" -eq 0 ]
+
+    [ -x "$tgt_dir/pg-notify-listener.py" ]
+    [ -f "$svc_dir/pg-notify-listener.service" ]
+    [ -d "$logs_dir" ]
+
+    grep -qxF -- "--user daemon-reload" "$calls_log"
+    grep -qxF -- "--user is-active pg-notify-listener.service" "$calls_log"
+    grep -qxF -- "--user enable pg-notify-listener.service" "$calls_log"
+    grep -qxF -- "--user start pg-notify-listener.service" "$calls_log"
+}
+
+@test "TC-listener: skips install when source files are missing" {
+    local tgt_dir="$FAKE_HOME/scripts"
+    local svc_dir="$FAKE_HOME/systemd/user"
+    local logs_dir="$FAKE_HOME/logs"
+
+    run _install_pg_notify_listener \
+        "$FAKE_HOME/no-such-script.py" \
+        "$FAKE_HOME/no-such.service" \
+        "$tgt_dir" "$svc_dir" "$logs_dir"
+    [ "$status" -eq 1 ]
+
+    [ ! -f "$tgt_dir/pg-notify-listener.py" ]
+    [ ! -f "$svc_dir/pg-notify-listener.service" ]
+}
+
+@test "TC-listener: pg-notify-listener.py imports pg_env from installed lib" {
+    local listener="$REPO_ROOT/cognition/scripts/pg-notify-listener.py"
+    grep -q 'sys.path.insert.*\.openclaw.*lib' "$listener"
+    run grep -qF 'openclaw/workspace/nova-mind/lib' "$listener"
+    [ "$status" -ne 0 ]
+}
+
 # ─── TC-68-adjacent / ordering / static checks ─────────────────────────────
 
 @test "TC-68-adjacent: installer derives agent_chat DB from postgres.json" {
@@ -235,6 +404,26 @@ EOF
     [ -n "$sync_line" ]
     [ -n "$chat_line" ]
     [ "$sync_line" -lt "$chat_line" ]
+}
+
+@test "Ordering: agent_chat DB config is provisioned before extension build" {
+    local config_line
+    local build_line
+    config_line=$(grep -n "PostgreSQL password file and agent_chat DB config" "$INSTALLER" | head -1 | cut -d: -f1)
+    build_line=$(grep -n "Building agent_chat TypeScript" "$INSTALLER" | head -1 | cut -d: -f1)
+    [ -n "$config_line" ]
+    [ -n "$build_line" ]
+    [ "$config_line" -lt "$build_line" ]
+}
+
+@test "Ordering: pg-notify-listener is deployed before extension build" {
+    local listener_line
+    local build_line
+    listener_line=$(grep -n "PostgreSQL NOTIFY listener" "$INSTALLER" | head -1 | cut -d: -f1)
+    build_line=$(grep -n "Building agent_chat TypeScript" "$INSTALLER" | head -1 | cut -d: -f1)
+    [ -n "$listener_line" ]
+    [ -n "$build_line" ]
+    [ "$listener_line" -lt "$build_line" ]
 }
 
 @test "agent-install.sh passes bash -n" {

--- a/tests/install/test_agent_chat_installer.bats
+++ b/tests/install/test_agent_chat_installer.bats
@@ -106,9 +106,9 @@ teardown() {
 # ─── TC-64 ──────────────────────────────────────────────────────────────────
 
 @test "TC-64: .pgpass provisioning is idempotent — no duplicate lines" {
-    _ensure_pgpass_entry "localhost" "5432" "agent_chat" "nova" "secret1"
-    _ensure_pgpass_entry "localhost" "5432" "agent_chat" "nova" "secret1"
-    _ensure_pgpass_entry "localhost" "5432" "agent_chat" "nova" "secret1"
+    run _ensure_pgpass_entry "localhost" "5432" "agent_chat" "nova" "secret1"
+    run _ensure_pgpass_entry "localhost" "5432" "agent_chat" "nova" "secret1"
+    run _ensure_pgpass_entry "localhost" "5432" "agent_chat" "nova" "secret1"
 
     local count
     count=$(grep -cF "localhost:5432:agent_chat:nova:secret1" "$PGPASS_FILE" || true)
@@ -224,7 +224,7 @@ EOF
 # ─── TC-68-adjacent / ordering / static checks ─────────────────────────────
 
 @test "TC-68-adjacent: installer derives agent_chat DB from postgres.json" {
-    grep -q "agent_chat_db=.*jq -r '.agent_chat.database'" "$INSTALLER"
+    grep -q "agent_chat_db=.*jq -r '.agent_chat.database" "$INSTALLER"
 }
 
 @test "Ordering: agent_config_sync is configured before agent_chat channel cleanup" {

--- a/tests/install/test_agent_chat_installer.bats
+++ b/tests/install/test_agent_chat_installer.bats
@@ -1,0 +1,251 @@
+#!/usr/bin/env bats
+# BATS tests for agent-install.sh agent_chat migration changes (#320).
+#
+# Coverage (mapped to run-334-step3-test-cases.md):
+#   TC-63: .pgpass provisioning — memory + agent_chat DB entries
+#   TC-64: .pgpass idempotent re-run
+#   TC-67: Installer config-write section — dead-key removal
+#   TC-68-adjacent: verify_cognition resolves agent_chat DB from postgres.json
+#
+# Run: bats tests/install/test_agent_chat_installer.bats
+
+BATS_TEST_DIRNAME="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+INSTALLER="$REPO_ROOT/agent-install.sh"
+
+# Inline copies of the helper functions under test.  They are isolated here so
+# the test does not have to source the entire installer (which executes script
+# body code on source).
+_ensure_pgpass_entry() {
+    local host="$1"
+    local port="$2"
+    local database="$3"
+    local user="$4"
+    local password="$5"
+    local pgpass="$PGPASS_FILE"
+    local prefix="${host}:${port}:${database}:${user}:"
+    local line="${prefix}${password}"
+
+    if [ ! -f "$pgpass" ]; then
+        touch "$pgpass"
+        chmod 600 "$pgpass"
+    fi
+
+    if grep -qxF "$line" "$pgpass" 2>/dev/null; then
+        return 1
+    fi
+
+    local tmpfile
+    tmpfile=$(mktemp)
+    chmod 600 "$tmpfile"
+    if [ -s "$pgpass" ]; then
+        grep -vF "$prefix" "$pgpass" >"$tmpfile" 2>/dev/null || cat "$pgpass" >"$tmpfile"
+    fi
+    printf '%s\n' "$line" >>"$tmpfile"
+    mv "$tmpfile" "$pgpass"
+    chmod 600 "$pgpass"
+    return 0
+}
+
+_ensure_agent_chat_postgres_json() {
+    local pg_config="$1"
+    local database="$2"
+    local user="$3"
+    local password="$4"
+
+    if [ ! -f "$pg_config" ] || ! command -v jq &>/dev/null; then
+        return 1
+    fi
+
+    local already_correct
+    already_correct=$(jq --arg db "$database" --arg user "$user" --arg pass "$password" \
+        '(.agent_chat // {}) | {database, user, password} == {database: $db, user: $user, password: $pass}' \
+        "$pg_config" 2>/dev/null || echo "false")
+    if [ "$already_correct" = "true" ]; then
+        return 1
+    fi
+
+    jq --arg db "$database" --arg user "$user" --arg pass "$password" \
+        '.agent_chat = {"database": $db, "user": $user, "password": $pass}' \
+        "$pg_config" >"${pg_config}.tmp" && \
+        mv "${pg_config}.tmp" "$pg_config" && \
+        chmod 600 "$pg_config"
+}
+
+setup() {
+    FAKE_HOME="$(mktemp -d)"
+    export PGPASS_FILE="$FAKE_HOME/.pgpass"
+}
+
+teardown() {
+    rm -rf "$FAKE_HOME"
+}
+
+# ─── TC-63 ──────────────────────────────────────────────────────────────────
+
+@test "TC-63: .pgpass provisioning writes memory and agent_chat entries" {
+    run _ensure_pgpass_entry "localhost" "5432" "nova_memory" "nova" "secret1"
+    [ "$status" -eq 0 ]
+    run _ensure_pgpass_entry "127.0.0.1" "5432" "nova_memory" "nova" "secret1"
+    [ "$status" -eq 0 ]
+    run _ensure_pgpass_entry "localhost" "5432" "agent_chat" "nova" "secret1"
+    [ "$status" -eq 0 ]
+    run _ensure_pgpass_entry "127.0.0.1" "5432" "agent_chat" "nova" "secret1"
+    [ "$status" -eq 0 ]
+
+    [ -f "$PGPASS_FILE" ]
+    run stat -c '%a' "$PGPASS_FILE"
+    [ "$output" = "600" ]
+
+    grep -qxF "localhost:5432:nova_memory:nova:secret1" "$PGPASS_FILE"
+    grep -qxF "127.0.0.1:5432:nova_memory:nova:secret1" "$PGPASS_FILE"
+    grep -qxF "localhost:5432:agent_chat:nova:secret1" "$PGPASS_FILE"
+    grep -qxF "127.0.0.1:5432:agent_chat:nova:secret1" "$PGPASS_FILE"
+}
+
+# ─── TC-64 ──────────────────────────────────────────────────────────────────
+
+@test "TC-64: .pgpass provisioning is idempotent — no duplicate lines" {
+    _ensure_pgpass_entry "localhost" "5432" "agent_chat" "nova" "secret1"
+    _ensure_pgpass_entry "localhost" "5432" "agent_chat" "nova" "secret1"
+    _ensure_pgpass_entry "localhost" "5432" "agent_chat" "nova" "secret1"
+
+    local count
+    count=$(grep -cF "localhost:5432:agent_chat:nova:secret1" "$PGPASS_FILE" || true)
+    [ "$count" -eq 1 ]
+}
+
+@test "TC-64: .pgpass password rotation replaces stale entry" {
+    _ensure_pgpass_entry "localhost" "5432" "agent_chat" "nova" "oldpass"
+    _ensure_pgpass_entry "localhost" "5432" "agent_chat" "nova" "newpass"
+
+    ! grep -qF "localhost:5432:agent_chat:nova:oldpass" "$PGPASS_FILE"
+    grep -qxF "localhost:5432:agent_chat:nova:newpass" "$PGPASS_FILE"
+}
+
+# ─── postgres.json nested section ───────────────────────────────────────────
+
+@test "agent_chat: writes nested section to postgres.json" {
+    local pg_config="$FAKE_HOME/postgres.json"
+    cat > "$pg_config" <<'EOF'
+{
+  "host": "localhost",
+  "port": 5432,
+  "database": "nova_memory",
+  "user": "nova",
+  "password": "secret1"
+}
+EOF
+
+    run _ensure_agent_chat_postgres_json "$pg_config" "agent_chat" "nova" "secret1"
+    [ "$status" -eq 0 ]
+
+    [ "$(jq -r '.agent_chat.database' "$pg_config")" = "agent_chat" ]
+    [ "$(jq -r '.agent_chat.user' "$pg_config")" = "nova" ]
+    [ "$(jq -r '.agent_chat.password' "$pg_config")" = "secret1" ]
+    [ "$(jq -r '.database' "$pg_config")" = "nova_memory" ]
+}
+
+@test "agent_chat: postgres.json nested section is idempotent" {
+    local pg_config="$FAKE_HOME/postgres.json"
+    cat > "$pg_config" <<'EOF'
+{
+  "host": "localhost",
+  "database": "nova_memory",
+  "user": "nova",
+  "password": "secret1",
+  "agent_chat": {
+    "database": "agent_chat",
+    "user": "nova",
+    "password": "secret1"
+  }
+}
+EOF
+
+    run _ensure_agent_chat_postgres_json "$pg_config" "agent_chat" "nova" "secret1"
+    [ "$status" -eq 1 ]
+}
+
+# ─── TC-67 ──────────────────────────────────────────────────────────────────
+
+@test "TC-67: openclaw.json dead connection keys removed, live keys preserved" {
+    local config="$FAKE_HOME/openclaw.json"
+    cat > "$config" <<'EOF'
+{
+  "channels": {
+    "agent_chat": {
+      "enabled": false,
+      "database": "nova_memory",
+      "host": "localhost",
+      "port": 5432,
+      "user": "nova",
+      "password": "secret1",
+      "pollIntervalMs": 500
+    }
+  },
+  "plugins": {
+    "entries": {
+      "agent_chat": {
+        "enabled": false,
+        "config": {
+          "database": "nova_memory",
+          "host": "localhost",
+          "port": 5432,
+          "user": "nova",
+          "password": "secret1",
+          "routeToSession": "other"
+        }
+      }
+    }
+  }
+}
+EOF
+
+    jq '.channels.agent_chat |= ((. // {}) | del(.database, .host, .port, .user, .password) + {"enabled": true})' \
+        "$config" >"${config}.tmp" && mv "${config}.tmp" "$config"
+    jq '.plugins.entries.agent_chat |= (. + {"enabled": true} | .config |= ((. // {}) | del(.database, .host, .port, .user, .password) + {"routeToSession": "main"}))' \
+        "$config" >"${config}.tmp" && mv "${config}.tmp" "$config"
+
+    [ "$(jq -r '.channels.agent_chat.enabled' "$config")" = "true" ]
+    [ "$(jq -r '.channels.agent_chat.pollIntervalMs' "$config")" = "500" ]
+    [ "$(jq -r '.channels.agent_chat.database' "$config")" = "null" ]
+    [ "$(jq -r '.channels.agent_chat.host' "$config")" = "null" ]
+    [ "$(jq -r '.channels.agent_chat.user' "$config")" = "null" ]
+    [ "$(jq -r '.channels.agent_chat.password' "$config")" = "null" ]
+
+    [ "$(jq -r '.plugins.entries.agent_chat.enabled' "$config")" = "true" ]
+    [ "$(jq -r '.plugins.entries.agent_chat.config.routeToSession' "$config")" = "main" ]
+    [ "$(jq -r '.plugins.entries.agent_chat.config.database' "$config")" = "null" ]
+    [ "$(jq -r '.plugins.entries.agent_chat.config.host' "$config")" = "null" ]
+    [ "$(jq -r '.plugins.entries.agent_chat.config.user' "$config")" = "null" ]
+    [ "$(jq -r '.plugins.entries.agent_chat.config.password' "$config")" = "null" ]
+}
+
+# ─── TC-68-adjacent / ordering / static checks ─────────────────────────────
+
+@test "TC-68-adjacent: installer derives agent_chat DB from postgres.json" {
+    grep -q "agent_chat_db=.*jq -r '.agent_chat.database'" "$INSTALLER"
+}
+
+@test "Ordering: agent_config_sync is configured before agent_chat channel cleanup" {
+    local sync_line
+    local chat_line
+    sync_line=$(grep -n "agent_config_sync plugin enabled" "$INSTALLER" | head -1 | cut -d: -f1)
+    chat_line=$(grep -n "Configure agent_chat channel" "$INSTALLER" | head -1 | cut -d: -f1)
+    [ -n "$sync_line" ]
+    [ -n "$chat_line" ]
+    [ "$sync_line" -lt "$chat_line" ]
+}
+
+@test "agent-install.sh passes bash -n" {
+    run bash -n "$INSTALLER"
+    [ "$status" -eq 0 ]
+}
+
+@test "ShellCheck: zero warnings on agent-install.sh" {
+    if ! command -v shellcheck &>/dev/null; then
+        skip "shellcheck not installed"
+    fi
+    run shellcheck "$INSTALLER"
+    [ "$status" -eq 0 ]
+}

--- a/tests/install/test_agents_json_safety.bats
+++ b/tests/install/test_agents_json_safety.bats
@@ -161,7 +161,7 @@ run_agents_json_logic() {
 @test "TC-252-B-03: Never write [] when psql fails (no existing agents.json)" {
     # No agents.json exists, psql fails
     run run_agents_json_logic 0 "FAIL"
-    [ "$status" -eq 0 ]
+    [ "$status" -ne 0 ]
 
     # agents.json must NOT exist with [] content
     if [ -f "$FAKE_AGENTS_JSON" ]; then
@@ -180,7 +180,7 @@ run_agents_json_logic() {
     [ ! -f "$FAKE_AGENTS_JSON" ]
 
     run run_agents_json_logic 0 "FAIL"
-    [ "$status" -eq 0 ]
+    [ "$status" -ne 0 ]
 
     # Must not have created an agents.json with [] content
     if [ -f "$FAKE_AGENTS_JSON" ]; then


### PR DESCRIPTION
Refs #320

This PR moves the shared agent-to-agent message bus out of `nova_memory` into a dedicated `agent_chat` database, while keeping the existing table shape and `send_agent_message()` API intact for a staged cutover.

## What moves

- **Schema & objects** — new `database/agent-chat/schema.sql` creates `agent_chat`, `agent_chat_processed`, `agent_chat_status`, the id sequence, indexes, views, grants, and the `send_agent_message()` / `notify_agent_chat()` / `expire_old_chat()` / `enforce_agent_chat_function_use()` functions and triggers in the dedicated DB.
- **Migration tooling** — `scripts/agent-chat-migration/` adds:
  - `migrate.sh` — create the `agent_chat` DB, apply schema, copy all data, align sequences.
  - `delta_check_and_migrate.py` — idempotent delta sync for the cutover window.
  - `pre_drop_gate_check.sh` — six pre-DROP verification gates (row-count parity, max-id/sequence alignment, role grants, NOTIFY round-trip, processed parity, no active listeners on `nova_memory`).
  - `decommission.sh` — gated DROP of `agent_chat` tables/functions/triggers/indexes from `nova_memory`.
  - `audit_rollout.py` — fleet config audit so we can confirm every agent has cut over before decommission.
  - `MIGRATION.md` / `README.md` runbook.
- **pg-env section-key support** — `lib/pg-env.ts`, `lib/pg_env.py`, and `lib/pg-env.sh` now accept a nested section key (e.g. `agent_chat`) and fall back to flat keys when the section is absent, enabling staged rollout where some agents still rely on the old `postgres.json` layout.
- **Plugin repoint** — `cognition/focus/agent_chat` reads the `agent_chat` section from `postgres.json`, with flat-key fallback.
- **Script repoints** — `motivation/scripts/proactive-gate-check.py` now uses `load_pg_env()` instead of a hardcoded `dbname=nova_memory` DSN.
- **Installer provisioning** — `cognition/agent-install.sh` now writes per-agent `.pgpass` entries for both the agent's memory DB and the `agent_chat` DB, idempotently creates the nested `postgres.json` section without clobbering existing values, and removes the dead `channels.agent_chat` connection writes.
- **pg-notify-listener** — `cognition/scripts/pg-notify-listener.py` is now tracked source; `cognition/systemd/pg-notify-listener.service` provides a `--user` unit; the installer deploys and starts it.
- **CI enablement** — `bats` and `shellcheck` are enabled so installer tests actually run.
- **Docs audit** — 23 documentation files updated to remove single-database assumptions; CHANGELOG entry added.

## Config approach

Database connection keys for messaging live in `~/.openclaw/postgres.json` as a nested section:

```json
{
  "host": "localhost",
  "database": "nova_memory",
  "user": "<agent>",
  "password": "...",
  "agent_chat": {
    "database": "agent_chat",
    "user": "<agent>",
    "password": "..."
  }
}
```

`loadPgEnv()` / `load_pg_env()` gain an optional section-key argument. Consumers request the `agent_chat` section and transparently fall back to the top-level keys when the section is missing, so unmigrated agents keep working on `nova_memory` until their config lands.

## Test evidence

- Test-case design: **69 TCs** (TC-1–69) covering schema/data parity, section-key fallback, staged coexistence, error conditions, boundary cases, decommission gates, and installer idempotency.
- QA desk review (SE run #334 step 6): **PASS-WITH-NOTES** — 45/69 TCs pass at code level, 20 correctly deferred to staging, zero merge blockers.
- Installer tests: **26/26 BATS pass** on the branch, `shellcheck` clean.
- Staging verification (SE run #334 step 7/8): completed against `4c812d3`.
- Docs audit (step 9): complete at `6705e42`.

## Open follow-ups (post-merge)

- **#375** — Gate 4 in `pre_drop_gate_check.sh` misses late `agent_chat_processed` updates on already-migrated chat IDs; this is a **decommission blocker** and must be fixed before the live DROP.
- **#333** — TC-38 plugin-load path needs final validation.
- **#379** — installer `systemctl --user enable` behavior under `sudo` needs verification.

The live cutover and `nova_memory` decommission remain after merge; this PR intentionally uses `Refs #320` so the issue stays open until those phases complete.
