### PR TITLE
feat(turn-context): deterministic honorific guard (#421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### Batch: honorific-guard-421 (Issue #421)
+
+#### Added
+- **Deterministic honorific guard in the turn-context plugin** (#421) — `memory/plugins/turn-context/src/honorific-guard.ts` (new, pure function `buildHonorificGuard(entityId, agentId, preferredName?)`) enforces the "Sir" honorific policy every turn, based on the resolved sender entity and the responding agent: no guard when the sender is I)ruid (`entity_id=2`) and the agent is `nova` (exact, case-sensitive match); a NOVA-exclusivity reminder when the sender is I)ruid but the agent is not `nova`; and a prohibition instruction for every other sender, including unresolved/unknown senders (fail-safe). Wired into `before_prompt_build` as Step 2.6 in `index.ts`, immediately after Step 2.5 entity resolution, and appended to `appendSystemContext` (closest to the user message). **Always runs regardless of message type or `prompt_helper_config` gating** — reuses Step 2.5's resolved entity when `entity_resolver` is gated ON, and calls the new lightweight `resolveEntityForGuard()` helper (added to `entity-resolver.ts`, sharing the same `sessionKey:senderId` cache) only when gating is OFF, so exactly one entity resolution runs per turn with no timeout stacking. `agentId` is read from the raw, undefaulted `ctx.agentId` (not the `?? "nova"`-defaulted value) so a missing/null/empty agent id fails closed to the non-NOVA side rather than silently matching `nova`. See `memory/plugins/turn-context/README.md#honorific-guard` for the full behavior table and binding design decisions (A1–A7).
+
+#### Tests
+- `memory/plugins/turn-context/src/honorific-guard.test.ts` — 27 unit tests (HG-001–HG-027) covering all four guard outcomes, fail-closed `agentId` handling, case/whitespace boundary behavior, `preferredName` interpolation, and entity-id edge cases (0, negative, NaN, float). No prior turn-context test suite existed; this establishes the first one (`npx tsx --test`, `tsx` added as a `devDependency`).
+- 20 integration scenarios (IT-001–IT-020) covering gating-bypass, subagent/no-sender, sender-cache-miss-after-restart, peer-agent-gateway, entity-resolution-timeout, group-session, and `appendSegments`-assembly paths — verified via staging desk review and live gateway checks (not automated; documented in nova-mind#421 Step 6–8 review comments).
+
+#### Issues Closed
+- #421 — Deterministic honorific guard for the "Sir" policy in the turn-context plugin
+
+#### Fast-Follows (open)
+- #425 — Post-merge multi-gateway smoke check: confirm each of the 4 production gateways passes a correctly-cased `ctx.agentId` string to the guard (staging is single-instance per the pre-existing nova-mind#402 workaround, so this couldn't be exercised end-to-end pre-merge).
+
+---
+
 ### Batch: schema-sync-direct-push-399 (Issue #399)
 
 #### Fixed

--- a/memory/ARCHITECTURE.md
+++ b/memory/ARCHITECTURE.md
@@ -87,7 +87,7 @@ The `entity_facts` table includes privacy and provenance columns that exist in t
 
 #### Turn Context Injection (`agent_turn_context`)
 
-The `agent_turn_context` table stores short, high-priority context records that are injected into **every agent turn** via the `turn-context` plugin's turn-reminders module. Unlike `agent_bootstrap_context` (session-level bootstrap), these records fire before every agent response via the `after_message` hook.
+The `agent_turn_context` table stores short, high-priority context records that are injected into **every agent turn** via the `turn-context` plugin's turn-reminders module. Unlike `agent_bootstrap_context` (session-level bootstrap), these records fire before every agent response via the `before_prompt_build` hook (not a separate `after_message` hook — this repo's only two turn-context plugin hooks are `message_received` and `before_prompt_build`; see `memory/plugins/turn-context/README.md`).
 
 **Key properties:**
 - Each record capped at **500 characters** (CHECK constraint in DB)

--- a/memory/CHANGELOG.md
+++ b/memory/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+- **Deterministic honorific guard in `memory/plugins/turn-context`** (#421) — New pure function `buildHonorificGuard(entityId, agentId, preferredName?)` in `src/honorific-guard.ts` appends a "Sir" honorific-policy instruction to `appendSystemContext` every turn: no guard for I)ruid (`entity_id=2`) talking to `nova`; a NOVA-exclusivity reminder for I)ruid talking to any other agent; a prohibition instruction for every other sender, including unresolved/unknown senders (fail-safe default). Wired into `before_prompt_build` as Step 2.6 in `src/index.ts`, right after Step 2.5 entity resolution, and is **never gated** by `prompt_helper_config` or message type (unlike every other subsystem in this plugin) — it reuses Step 2.5's resolved entity when `entity_resolver` is ON, or calls the new lightweight `resolveEntityForGuard()` helper (added to `src/entity-resolver.ts`) only when gating is OFF, avoiding both a skipped guard and duplicate/stacked entity resolution. `agentId` matching is exact-match case-sensitive on the literal string `"nova"`, using the raw undefaulted `ctx.agentId` so a missing/null/empty value fails closed away from the NOVA-exclusive case. Full behavior table, fail-closed semantics, and gating interaction documented in `memory/plugins/turn-context/README.md#honorific-guard`.
+
+### Tests
+- `memory/plugins/turn-context/src/honorific-guard.test.ts` (#421) — 27 unit tests (HG-001–HG-027), the first automated test suite for the turn-context plugin, run via `npx tsx --test` (`tsx` added as a `devDependency` in `package.json`). 20 additional integration scenarios (IT-001–IT-020) verified via staging desk review rather than an automated suite — see nova-mind#421 for the full test design and staging results.
+
 ### Fixed
 - **`memory/lib/pg_env.py` per-field section precedence over ENV** (#405, originally [nova-workspace#33](https://github.com/NOVA-Openclaw/nova-workspace/issues/33)) — Updated identically (byte-for-byte) to the canonical `lib/pg_env.py`: a field explicitly defined (non-null, non-empty) in a requested `section` (e.g. `section="agent_chat"`) now wins over a pre-exported ambient ENV var for that field only, instead of ENV winning outright. Fields the section omits are unaffected. See root `CHANGELOG.md` (batch `pg-env-section-precedence-405`) and `memory/docs/database-config.md` for the full precedence table and per-language caveats (TypeScript/Bash unaffected by this fix — TS parity tracked in #403).
 

--- a/memory/plugins/turn-context/README.md
+++ b/memory/plugins/turn-context/README.md
@@ -8,10 +8,12 @@ OpenClaw plugin that injects per-turn context into agent prompts via the `before
 message_received → cache sender info (keyed by sessionKey:senderId)
                         ↓
 before_prompt_build:
-  1. Classifier (rule-based + Ollama fallback) → message_type
-  2. prompt_helper_config lookup → which subsystems are enabled
-  3. Run enabled subsystems in parallel (Promise.allSettled)
-  4. Assemble prependSystemContext + appendSystemContext
+  1.   Classifier (rule-based + Ollama fallback) → message_type
+  2.   prompt_helper_config lookup → which subsystems are enabled
+  2.5. Entity resolution (gated) → resolvedEntityId, for prependSystemContext + recall input
+  2.6. Honorific guard (always-on) → reuses 2.5's result if gated ON, own lightweight call if OFF
+  3.   Run remaining subsystems in parallel (Promise.allSettled)
+  4.   Assemble prependSystemContext + appendSystemContext
 ```
 
 ## Subsystems
@@ -20,9 +22,10 @@ before_prompt_build:
 |-----------|------|-------------|
 | **Classifier** | `classifier.ts` | Classifies messages into `info_request`, `action`, `conversation`, `continuation`, `command`. Rule-based first pass (~60-70%), Ollama LLM fallback for ambiguous cases. |
 | **Domain Identifier** | `domain-identifier.ts` | Matches messages to subject-matter domains via keyword matching + embedding similarity against `agent_domains` table. Returns top 1-3 domains with assigned agents (via JOIN, not hardcoded). |
-| **Entity Resolver** | `entity-resolver.ts` | Resolves sender identity via the entity-resolver library. Cache keyed by `sessionKey:senderId` (not just sessionKey) to support group channels. Returns both formatted text and numeric `entityId`. |
+| **Entity Resolver** | `entity-resolver.ts` | Resolves sender identity via the entity-resolver library. Cache keyed by `sessionKey:senderId` (not just sessionKey) to support group channels. Returns both formatted text and numeric `entityId`. Also exports `resolveEntityForGuard()`, a lightweight resolution (id + display name only, no facts lookup) used by the honorific guard when `entity_resolver` is gated off. |
 | **Semantic Recall** | `semantic-recall.ts` | Spawns `proactive-recall.py` for memory retrieval. Supports tiered recall (domain-scoped first, full fallback) and visibility filtering (group channels → public facts only). |
 | **Turn Reminders** | `turn-reminders.ts` | Queries `agent_turn_context` table for per-turn reminder text. **Always fires regardless of message type** — not gated by prompt_helper_config. |
+| **Honorific Guard** | `honorific-guard.ts` | Deterministic (non-LLM) instruction appended after the base system prompt, enforcing the "Sir" honorific policy based on the resolved sender entity and the responding agent. **Always fires regardless of message type or `entity_resolver` gating** — see [Honorific Guard](#honorific-guard) below. |
 
 ## Message Type → Subsystem Gating
 
@@ -39,6 +42,70 @@ Controlled by the `prompt_helper_config` table. Default configuration:
 Per-agent overrides: insert rows with `agent_name` set to override defaults for a specific agent.
 
 On classifier failure, defaults to `info_request` (full pipeline) — safe fallback.
+
+## Honorific Guard
+
+Deterministic, non-LLM guard that appends a short instruction to `appendSystemContext` (Step 2.6
+of `before_prompt_build`, immediately after entity resolution) enforcing the "Sir" honorific
+policy. Unlike every other subsystem in this plugin, **the guard is never gated by
+`prompt_helper_config` or message type** — it runs on every turn, including `continuation` and
+`command` messages where `entity_resolver` is gated off by default (see the gating table above).
+
+### Behavior
+
+The guard resolves the sender's entity ID and the responding agent's ID, then picks exactly one
+of three outcomes:
+
+| Sender entity | Responding agent | Outcome | Appended line |
+|---|---|---|---|
+| I)ruid (`entity_id = 2`) | `nova` (exact, case-sensitive) | **No guard** | *(nothing appended)* |
+| I)ruid (`entity_id = 2`) | anything else (including missing/null/empty `agentId`) | **Exclusivity** | `The user is I)ruid. "Sir" is reserved exclusively for NOVA — address I)ruid normally using conversational pronouns.` |
+| Anyone/anything else, or entity unresolved | any agent | **Prohibition** | `You are talking with {preferredName}. Do not use "Sir", "Ma'am", or other formal honorifics — address {preferredName} by name or with normal conversational pronouns.` (falls back to `Do not use "Sir", "Ma'am", or other formal honorifics — address this sender by name or with normal conversational pronouns.` when no preferred name is available) |
+
+`preferredName` is `entity.fullName || entity.name` from the resolver (no extra `entity_facts`
+lookup) and is interpolated **only** in the prohibition line — the exclusivity line always says
+"I)ruid" literally, never a resolved preferred name.
+
+### Fail-closed semantics
+
+The guard is deliberately fail-**closed** toward over-prohibiting, never fail-open toward
+exclusivity:
+
+- **Unresolved/unknown sender** (entity resolution returns `null`, times out, hits a cache miss,
+  or the session has no sender info at all — e.g. subagent sessions, a cold sender-cache
+  immediately after a gateway restart) → **prohibition line**, never the exclusivity line and
+  never silence. This is a known, accepted UX gap: for a short window immediately after every
+  gateway restart, even I)ruid's own messages will show the prohibition line to `nova` until
+  `message_received` repopulates the sender cache.
+- **Missing, null, or empty-string `agentId`** → treated as **not** `"nova"` (fails closed to
+  the exclusivity/prohibition side, never defaults to `"nova"` and never suppresses the guard).
+  A warning is logged (`ctx.agentId missing for honorific guard — treating as non-NOVA`).
+- **`agentId` matching is case-sensitive, exact-match on the literal string `"nova"`** — no
+  `.trim()`/`.toLowerCase()` normalization. `"Nova"`, `"NOVA"`, `" nova "`, and any other agent
+  name all fail closed to the exclusivity line for I)ruid.
+- Exactly one guard string is ever emitted per turn; the entity check runs before the agent
+  check, so an unresolved entity always short-circuits straight to the prohibition line without
+  ever consulting `agentId`.
+
+### Config interaction with `entity_resolver` gating
+
+The guard needs a resolved entity ID every turn, but `entity_resolver` itself is gated off for
+`continuation` and `command` message types by default (see the gating table above). To avoid
+regressing the no-guard case for I)ruid+nova on those message types, Step 2.6 uses one of two
+mutually exclusive paths depending on the gating state, so there is never more than one entity
+resolution call (and never any timeout stacking) per turn:
+
+- **`entity_resolver` ON:** reuses the entity ID and display name already resolved by Step 2.5 —
+  zero extra calls.
+- **`entity_resolver` OFF:** calls `resolveEntityForGuard()` (in `entity-resolver.ts`) directly —
+  a lightweight resolution that skips the `entity_facts` lookup and text formatting that
+  `resolveEntityContext()` does for `prependSystemContext`. It shares the same
+  `sessionKey:senderId` cache as the main resolver, so warm-path cost is near zero.
+
+A guard-resolution error is caught independently and does not affect turn reminders or any other
+subsystem (isolated try/catch, no shared `Promise.allSettled` slot).
+
+See `nova-mind#421` for the full design history and binding decisions (A1–A7).
 
 ## Database Dependencies
 
@@ -70,3 +137,5 @@ After migration, run `memory/scripts/seed-domain-embeddings.py` to embed domain 
 - #140 — Tiered recall strategy
 - #168 — Visibility filter in semantic-recall hook
 - #182 — Original plugin consolidation (semantic-recall + agent-turn-context hooks)
+- #421 — Deterministic honorific guard (Step 2.6)
+- #425 — Follow-up: post-merge multi-gateway `agentId` casing/deployment-consistency smoke check for the guard

--- a/memory/plugins/turn-context/package-lock.json
+++ b/memory/plugins/turn-context/package-lock.json
@@ -13,7 +13,451 @@
         "pg": "^8.11.0",
         "typescript": "^5.9.3"
       },
-      "devDependencies": {}
+      "devDependencies": {
+        "tsx": "^4.23.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.41",
@@ -33,6 +477,63 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pg": {
@@ -170,6 +671,25 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {

--- a/memory/plugins/turn-context/package.json
+++ b/memory/plugins/turn-context/package.json
@@ -22,5 +22,7 @@
     "pg": "^8.11.0",
     "typescript": "^5.9.3"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "tsx": "^4.23.0"
+  }
 }

--- a/memory/plugins/turn-context/package.json
+++ b/memory/plugins/turn-context/package.json
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/**/*.test.ts"
   },
   "dependencies": {
     "@types/node": "^20.0.0",

--- a/memory/plugins/turn-context/src/entity-resolver.ts
+++ b/memory/plugins/turn-context/src/entity-resolver.ts
@@ -122,69 +122,11 @@ export interface SenderInfo {
 export async function resolveEntityContext(
   sessionKey: string,
   info: SenderInfo
-): Promise<{ text: string | null; entityId: number | null }> {
-  // Lazy-load entity resolver — graceful degradation if not installed
-  if (!(await ensureEntityResolver())) return { text: null, entityId: null };
-
-  const { senderId, senderName, provider, senderE164 } = info;
-
-  if (!senderId) return { text: null, entityId: null };
-
-  // Cache key includes both sessionKey AND senderId to prevent cross-user collisions
-  // in group channels where sessionKey is shared across all participants.
-  const cacheKey = `${sessionKey}:${senderId}`;
-
-  let entity: Entity | null = null;
-
-  // Check library cache first (keyed by sessionKey:senderId)
-  if (getCachedEntity) {
-    entity = getCachedEntity(cacheKey) as Entity | null;
-  }
+): Promise<{ text: string | null; entityId: number | null; displayName: string | null }> {
+  const entity = await resolveEntityOnly(sessionKey, info);
 
   if (!entity) {
-    const identifiers = extractIdentifiers(provider, senderId, senderE164);
-    if (Object.keys(identifiers).length === 0) {
-      // Unknown provider — no way to resolve
-      console.log(`[turn-context] Unknown provider '${provider}', skipping entity resolution`);
-      return { text: null, entityId: null };
-    }
-
-    try {
-      const resolveResult = await Promise.race([
-        resolveEntityByIdentifiers(identifiers),
-        new Promise<null>((resolve) => setTimeout(() => resolve(null), 2000)),
-      ]);
-
-      if (resolveResult) {
-        if (resolveResult.ok) {
-          entity = resolveResult.entity as Entity;
-        } else {
-          // Conflict: multiple entities matched — safer to skip
-          console.error(
-            `[turn-context] Entity conflict for sender ${senderName || senderId}: ` +
-            `${resolveResult.message}`
-          );
-          return { text: null, entityId: null };
-        }
-      }
-
-      if (entity && setCachedEntity) {
-        setCachedEntity(cacheKey, entity);
-      }
-    } catch (err) {
-      console.error(
-        "[turn-context] Entity resolution error:",
-        err instanceof Error ? err.message : String(err)
-      );
-      return { text: null, entityId: null };
-    }
-  }
-
-  if (!entity) {
-    console.log(
-      `[turn-context] No entity found for sender: ${senderName || senderId}`
-    );
-    return { text: null, entityId: null };
+    return { text: null, entityId: null, displayName: null };
   }
 
   // Load entity facts with a 1s timeout
@@ -203,9 +145,109 @@ export async function resolveEntityContext(
     }
   }
 
+  const displayName = entity.fullName || entity.name;
   const result = formatEntityContext(entity, facts);
   console.log(
-    `[turn-context] Loaded entity context for: ${entity.name} (entityId=${entity.id}) (${senderId})`
+    `[turn-context] Loaded entity context for: ${entity.name} (entityId=${entity.id}) (${info.senderId})`
   );
-  return { text: result, entityId: entity.id as number };
+  return { text: result, entityId: entity.id as number, displayName };
+}
+
+/**
+ * Lightweight entity resolution for the honorific guard.
+ *
+ * Returns only the entity id and display name, skipping the entity-facts
+ * lookup and text formatting. Uses the same cache key as resolveEntityContext
+ * so warm paths hit the same cached entity.
+ *
+ * Issue: nova-mind #421
+ */
+export async function resolveEntityForGuard(
+  sessionKey: string,
+  info: SenderInfo
+): Promise<{ entityId: number | null; displayName: string | null }> {
+  const entity = await resolveEntityOnly(sessionKey, info);
+
+  if (!entity) {
+    return { entityId: null, displayName: null };
+  }
+
+  const displayName = entity.fullName || entity.name;
+  return { entityId: entity.id as number, displayName };
+}
+
+/**
+ * Shared entity resolution logic used by resolveEntityContext and
+ * resolveEntityForGuard. Handles cache lookup, identifier extraction,
+ * database resolution, and caching.
+ */
+async function resolveEntityOnly(
+  sessionKey: string,
+  info: SenderInfo
+): Promise<Entity | null> {
+  // Lazy-load entity resolver — graceful degradation if not installed
+  if (!(await ensureEntityResolver())) return null;
+
+  const { senderId, senderName, provider, senderE164 } = info;
+
+  if (!senderId) return null;
+
+  // Cache key includes both sessionKey AND senderId to prevent cross-user collisions
+  // in group channels where sessionKey is shared across all participants.
+  const cacheKey = `${sessionKey}:${senderId}`;
+
+  let entity: Entity | null = null;
+
+  // Check library cache first (keyed by sessionKey:senderId)
+  if (getCachedEntity) {
+    entity = getCachedEntity(cacheKey) as Entity | null;
+  }
+
+  if (!entity) {
+    const identifiers = extractIdentifiers(provider, senderId, senderE164);
+    if (Object.keys(identifiers).length === 0) {
+      // Unknown provider — no way to resolve
+      console.log(`[turn-context] Unknown provider '${provider}', skipping entity resolution`);
+      return null;
+    }
+
+    try {
+      const resolveResult = await Promise.race([
+        resolveEntityByIdentifiers(identifiers),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 2000)),
+      ]);
+
+      if (resolveResult) {
+        if (resolveResult.ok) {
+          entity = resolveResult.entity as Entity;
+        } else {
+          // Conflict: multiple entities matched — safer to skip
+          console.error(
+            `[turn-context] Entity conflict for sender ${senderName || senderId}: ` +
+            `${resolveResult.message}`
+          );
+          return null;
+        }
+      }
+
+      if (entity && setCachedEntity) {
+        setCachedEntity(cacheKey, entity);
+      }
+    } catch (err) {
+      console.error(
+        "[turn-context] Entity resolution error:",
+        err instanceof Error ? err.message : String(err)
+      );
+      return null;
+    }
+  }
+
+  if (!entity) {
+    console.log(
+      `[turn-context] No entity found for sender: ${senderName || senderId}`
+    );
+    return null;
+  }
+
+  return entity;
 }

--- a/memory/plugins/turn-context/src/honorific-guard.test.ts
+++ b/memory/plugins/turn-context/src/honorific-guard.test.ts
@@ -1,0 +1,211 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildHonorificGuard } from "./honorific-guard.ts";
+
+/**
+ * Unit tests for buildHonorificGuard.
+ *
+ * Covers Gem's HG-001 through HG-027 design cases for nova-mind #421.
+ */
+
+describe("buildHonorificGuard", () => {
+  // ── HG-001 to HG-006: core four states ───────────────────────────────────
+
+  it("HG-001: non-I)ruid sender + nova → prohibition line with preferred name", () => {
+    const result = buildHonorificGuard(7, "nova", "Zonk");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes('Do not use "Sir"'));
+    assert.ok(result!.includes("Zonk"));
+  });
+
+  it("HG-002: non-I)ruid sender + non-nova → prohibition line regardless of agent", () => {
+    const result = buildHonorificGuard(7, "graybeard", "Zonk");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes('Do not use "Sir"'));
+    assert.ok(result!.includes("Zonk"));
+    assert.ok(!result!.includes("NOVA"));
+  });
+
+  it("HG-003: I)ruid sender + non-nova → NOVA-exclusivity line", () => {
+    const result = buildHonorificGuard(2, "graybeard", "I)ruid");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes("I)ruid"));
+    assert.ok(result!.includes("NOVA"));
+    assert.ok(result!.includes('"Sir"'));
+    assert.ok(!result!.includes('Do not use "Sir"'));
+  });
+
+  it("HG-004: I)ruid sender + nova → no guard", () => {
+    const result = buildHonorificGuard(2, "nova", "I)ruid");
+    assert.equal(result, null);
+  });
+
+  it("HG-005: unresolved sender (null) + nova → prohibition fail-safe", () => {
+    const result = buildHonorificGuard(null, "nova");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes('Do not use "Sir"'));
+  });
+
+  it("HG-006: unresolved sender (undefined) + nova → prohibition fail-safe", () => {
+    const result = buildHonorificGuard(undefined, "nova");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes('Do not use "Sir"'));
+  });
+
+  // ── HG-007 to HG-010: missing/invalid agentId fail-closed ────────────────
+
+  it("HG-007: I)ruid sender + undefined agentId → exclusivity line (fail closed)", () => {
+    const result = buildHonorificGuard(2, undefined, "I)ruid");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes("I)ruid"));
+    assert.ok(result!.includes("NOVA"));
+  });
+
+  it("HG-008: I)ruid sender + null agentId → exclusivity line (fail closed)", () => {
+    const result = buildHonorificGuard(2, null, "I)ruid");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes("I)ruid"));
+    assert.ok(result!.includes("NOVA"));
+  });
+
+  it("HG-009: I)ruid sender + empty agentId → exclusivity line (fail closed)", () => {
+    const result = buildHonorificGuard(2, "", "I)ruid");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes("I)ruid"));
+    assert.ok(result!.includes("NOVA"));
+  });
+
+  it("HG-010: non-I)ruid sender + undefined agentId → prohibition line", () => {
+    const result = buildHonorificGuard(7, undefined, "Zonk");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes('Do not use "Sir"'));
+    assert.ok(result!.includes("Zonk"));
+  });
+
+  // ── HG-011 to HG-013: case/whitespace exact-match boundaries ─────────────
+
+  it("HG-011: agentId 'Nova' is treated as NOT nova (case-sensitive)", () => {
+    const result = buildHonorificGuard(2, "Nova", "I)ruid");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes("NOVA"));
+  });
+
+  it("HG-012: agentId ' nova ' is treated as NOT nova (no trim)", () => {
+    const result = buildHonorificGuard(2, " nova ", "I)ruid");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes("NOVA"));
+  });
+
+  it("HG-013: agentId exact lowercase 'nova' + entity 2 → no guard", () => {
+    const result = buildHonorificGuard(2, "nova", "I)ruid");
+    assert.equal(result, null);
+  });
+
+  // ── HG-014 to HG-019: preferredName variations ───────────────────────────
+
+  it("HG-014: provided preferredName is referenced in prohibition line", () => {
+    const result = buildHonorificGuard(7, "nova", "Edmund");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes("Edmund"));
+  });
+
+  it("HG-015: omitted preferredName falls back to pronoun language", () => {
+    const result = buildHonorificGuard(7, "nova");
+    assert.equal(typeof result, "string");
+    assert.ok(!result!.includes("undefined"));
+    assert.ok(!result!.includes("null"));
+    assert.ok(result!.includes("this sender"));
+  });
+
+  it("HG-016: empty preferredName falls back to pronoun language", () => {
+    const result = buildHonorificGuard(7, "nova", "");
+    assert.equal(typeof result, "string");
+    assert.ok(!result!.includes("undefined"));
+    assert.ok(!result!.includes("null"));
+    assert.ok(result!.includes("this sender"));
+  });
+
+  it("HG-017: preferredName does not cause emission for no-guard case", () => {
+    const result = buildHonorificGuard(2, "nova", "I)ruid");
+    assert.equal(result, null);
+  });
+
+  it("HG-018: exclusivity line refers to I)ruid literally, no preferredName interpolation", () => {
+    const result = buildHonorificGuard(2, "graybeard", "I)ruid");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes("I)ruid"));
+    assert.ok(!result!.includes("{{")); // sanity: no template artifacts
+  });
+
+  it("HG-019: preferredName with markdown-special characters does not throw", () => {
+    assert.doesNotThrow(() => {
+      const result = buildHonorificGuard(7, "nova", "Zo`nk*\n");
+      assert.equal(typeof result, "string");
+    });
+  });
+
+  // ── HG-020 to HG-023: entityId boundary values ───────────────────────────
+
+  it("HG-020: entityId 0 is treated as non-I)ruid (prohibition)", () => {
+    const result = buildHonorificGuard(0, "nova", "X");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes('Do not use "Sir"'));
+  });
+
+  it("HG-021: negative entityId is treated as non-I)ruid (prohibition)", () => {
+    const result = buildHonorificGuard(-1, "nova", "X");
+    assert.equal(typeof result, "string");
+    assert.ok(result!.includes('Do not use "Sir"'));
+  });
+
+  it("HG-022: entityId 2.0 matches I)ruid (no guard with nova)", () => {
+    const result = buildHonorificGuard(2.0, "nova", "I)ruid");
+    assert.equal(result, null);
+  });
+
+  it("HG-023: entityId NaN is treated as non-I)ruid without throwing", () => {
+    assert.doesNotThrow(() => {
+      const result = buildHonorificGuard(NaN, "nova", "X");
+      assert.equal(typeof result, "string");
+      assert.ok(result!.includes('Do not use "Sir"'));
+    });
+  });
+
+  // ── HG-024 to HG-027: contract / purity tests ────────────────────────────
+
+  it("HG-024: guard-emitting paths return a string", () => {
+    const cases = [
+      buildHonorificGuard(7, "nova", "Zonk"),
+      buildHonorificGuard(7, "graybeard", "Zonk"),
+      buildHonorificGuard(2, "graybeard", "I)ruid"),
+      buildHonorificGuard(null, "nova"),
+    ];
+    for (const r of cases) {
+      assert.equal(typeof r, "string");
+    }
+  });
+
+  it("HG-025: no-guard path returns strict null", () => {
+    assert.equal(buildHonorificGuard(2, "nova"), null);
+    assert.equal(buildHonorificGuard(2, "nova", "I)ruid"), null);
+    assert.equal(buildHonorificGuard(2.0, "nova", "I)ruid"), null);
+  });
+
+  it("HG-026: emitted guard text is non-empty and trimmed", () => {
+    const result = buildHonorificGuard(7, "nova", "Zonk");
+    assert.ok(result != null);
+    assert.ok(result!.trim().length > 0);
+    assert.equal(result, result!.trim());
+  });
+
+  it("HG-027: function is pure — repeated calls with same inputs are identical", () => {
+    const inputs: [number | null | undefined, string | null | undefined, string | undefined] = [
+      7,
+      "nova",
+      "Zonk",
+    ];
+    const a = buildHonorificGuard(...inputs);
+    const b = buildHonorificGuard(...inputs);
+    assert.equal(a, b);
+  });
+});

--- a/memory/plugins/turn-context/src/honorific-guard.ts
+++ b/memory/plugins/turn-context/src/honorific-guard.ts
@@ -1,0 +1,54 @@
+/**
+ * Deterministic honorific guard.
+ *
+ * Builds an instruction string that enforces the NOVA honorific policy:
+ *  - "Sir"/"Ma'am" and formal honorifics are prohibited for senders other than I)ruid.
+ *  - When the sender is I)ruid and the agent is not NOVA, remind the agent that
+ *    "Sir" is reserved exclusively for NOVA and address I)ruid normally.
+ *  - When the sender is I)ruid and the agent is NOVA, no guard is emitted.
+ *  - When the sender cannot be resolved, fail safe with the prohibition line.
+ *
+ * Binding ambiguity resolutions (nova-mind #421 A1-A7):
+ *  - A2: agentId match is case-sensitive exact "nova", no normalization.
+ *  - A3: preferredName is interpolated only in the rule-1 prohibition line;
+ *        the exclusivity line always refers to "I)ruid" literally.
+ *  - A4: No-guard path returns strict null.
+ *  - A5: Entity check is first; unresolved entity → prohibition line, agentId
+ *        is never consulted for that path. Exactly one guard string is emitted.
+ */
+
+const IRUID_ENTITY_ID = 2;
+
+export function buildHonorificGuard(
+  entityId: number | null | undefined,
+  agentId: string | null | undefined,
+  preferredName?: string
+): string | null {
+  // A5: Entity check first. Unresolved/unknown sender → fail-safe prohibition.
+  if (entityId == null) {
+    return buildProhibitionLine(preferredName);
+  }
+
+  // A2: Case-sensitive exact match on the agent name string.
+  const isNova = agentId === "nova";
+
+  // I)ruid sender.
+  if (entityId === IRUID_ENTITY_ID) {
+    // A3: Exclusivity line only when I)ruid is NOT talking to NOVA.
+    if (!isNova) {
+      return `The user is I)ruid. "Sir" is reserved exclusively for NOVA — address I)ruid normally using conversational pronouns.`;
+    }
+    // A4: I)ruid + NOVA → no guard.
+    return null;
+  }
+
+  // Non-I)ruid sender → always prohibit formal honorifics, regardless of agent.
+  return buildProhibitionLine(preferredName);
+}
+
+function buildProhibitionLine(preferredName?: string): string {
+  if (preferredName != null && preferredName.trim().length > 0) {
+    return `You are talking with ${preferredName}. Do not use "Sir", "Ma'am", or other formal honorifics — address ${preferredName} by name or with normal conversational pronouns.`;
+  }
+  return `Do not use "Sir", "Ma'am", or other formal honorifics — address this sender by name or with normal conversational pronouns.`;
+}

--- a/memory/plugins/turn-context/src/index.ts
+++ b/memory/plugins/turn-context/src/index.ts
@@ -32,7 +32,8 @@
  */
 
 import { getTurnReminders } from "./turn-reminders.ts";
-import { resolveEntityContext, type SenderInfo } from "./entity-resolver.ts";
+import { resolveEntityContext, resolveEntityForGuard, type SenderInfo } from "./entity-resolver.ts";
+import { buildHonorificGuard } from "./honorific-guard.ts";
 import { runSemanticRecall, type RecallInput } from "./semantic-recall.ts";
 import { classifyMessage, type ClassifierResult, type MessageType } from "./classifier.ts";
 import { identifyDomain, formatDomainContext, type DomainResult } from "./domain-identifier.ts";
@@ -251,7 +252,8 @@ export default function register(api: PluginApi): void {
     async (event: PluginEvent, ctx: PluginContext): Promise<PromptBuildResult | undefined> => {
       const hookStart = Date.now();
       const sessionKey = ctx.sessionKey;
-      const agentId: string = ctx.agentId ?? "nova";
+      const rawAgentId = ctx.agentId;
+      const agentId: string = rawAgentId ?? "nova";
 
       console.info(
         `[turn-context] before_prompt_build START agent=${agentId} session=${sessionKey ?? "none"}`
@@ -336,12 +338,14 @@ export default function register(api: PluginApi): void {
       const entityResolveStart = Date.now();
       let entityContextText: string | null = null;
       let resolvedEntityId: number | null = null;
+      let resolvedDisplayName: string | null = null;
 
       if (helperConfig.entity_resolver && sessionKey) {
         try {
           const entityResult = await resolveEntityContext(sessionKey, senderInfo);
           entityContextText = entityResult.text;
           resolvedEntityId = entityResult.entityId;
+          resolvedDisplayName = entityResult.displayName;
         } catch (err) {
           console.error(
             "[turn-context] Entity resolution error:",
@@ -353,6 +357,42 @@ export default function register(api: PluginApi): void {
         `[turn-context] entity-resolver: ` +
         `${resolvedEntityId != null ? `entityId=${resolvedEntityId}` : "no entity"} ` +
         `elapsed=${Date.now() - entityResolveStart}ms`
+      );
+
+      // ── Step 2.6: Always-on honorific guard (#421) ───────────────────────────
+      // Reuses the Step 2.5 result when entity_resolver is enabled (zero extra
+      // calls). When entity_resolver is gated OFF, performs its own lightweight
+      // resolution so the guard is never skipped. This avoids timeout stacking
+      // because only one resolution path runs per turn.
+      let guardEntityId: number | null = null;
+      let guardDisplayName: string | null = null;
+
+      if (helperConfig.entity_resolver) {
+        guardEntityId = resolvedEntityId;
+        guardDisplayName = resolvedDisplayName;
+      } else if (sessionKey) {
+        try {
+          const guardResult = await resolveEntityForGuard(sessionKey, senderInfo);
+          guardEntityId = guardResult.entityId;
+          guardDisplayName = guardResult.displayName;
+        } catch (err) {
+          console.error(
+            "[turn-context] Honorific guard entity resolution error:",
+            err instanceof Error ? err.message : String(err)
+          );
+        }
+      }
+
+      if (rawAgentId == null) {
+        console.warn(
+          "[turn-context] ctx.agentId missing for honorific guard — treating as non-NOVA (fail closed)"
+        );
+      }
+
+      const honorificGuardText = buildHonorificGuard(
+        guardEntityId,
+        rawAgentId,
+        guardDisplayName ?? undefined
       );
 
       // Build recall input: pass classifier domain hints, resolved entityId, + visibility info
@@ -484,6 +524,10 @@ export default function register(api: PluginApi): void {
 
       if (remindersOk) {
         appendSegments.push((turnRemindersResult as PromiseFulfilledResult<string>).value!);
+      }
+
+      if (honorificGuardText) {
+        appendSegments.push(honorificGuardText);
       }
 
       // ── Assemble result ───────────────────────────────────────────────────


### PR DESCRIPTION
Closes #421

## Summary

Adds a deterministic (non-LLM) honorific guard to the `turn-context` plugin that enforces the "Sir" honorific policy on every agent turn, based on the resolved sender entity and the responding agent:

- **Entity 2 (I)ruid) + agent `nova`** (exact, case-sensitive match) → no guard text appended.
- **Entity 2 (I)ruid) + any other agent** → NOVA-exclusivity reminder appended ("Sir" is reserved for NOVA only).
- **Every other sender, including unresolved/unknown senders** → prohibition instruction appended (fail-closed default — never silently falls back to the exclusivity or no-guard case).

Wired into `before_prompt_build` as Step 2.6, immediately after Step 2.5 entity resolution in `memory/plugins/turn-context/src/index.ts`. The guard **always runs**, regardless of message type or `prompt_helper_config` gating — it reuses Step 2.5's resolved entity when `entity_resolver` gating is ON, and calls a new lightweight `resolveEntityForGuard()` helper (added to `entity-resolver.ts`, sharing the same `sessionKey:senderId` cache) only when gating is OFF, so exactly one entity resolution runs per turn with no timeout stacking.

`agentId` is read from the raw, undefaulted `ctx.agentId` (not the `?? "nova"`-defaulted value used elsewhere) so a missing/null/empty agent id fails closed to the non-NOVA side rather than silently matching `nova`.

Full behavior table and design decisions documented in `memory/plugins/turn-context/README.md#honorific-guard`.

## Commits

- `0964aea` feat(turn-context): deterministic honorific guard (#421)
- `a3e8afc` fix(turn-context): declare tsx devDependency for test script (#421)
- `04d522d` docs(turn-context): document deterministic honorific guard (#421)
- `05b930a` docs(memory): fix stale after_message hook reference for turn context injection

## Test Results

- **Unit:** 27/27 passing (`honorific-guard.test.ts`, HG-001–HG-027) — covers all four guard outcomes, fail-closed `agentId` handling, case/whitespace boundary behavior, `preferredName` interpolation, and entity-id edge cases (0, negative, NaN, float). Run via `npx tsx --test` (`tsx` added as devDependency).
- **Integration:** 20/20 passing (IT-001–IT-020) — gating-bypass, subagent/no-sender, sender-cache-miss-after-restart, peer-agent-gateway, entity-resolution-timeout, group-session, and `appendSegments`-assembly paths. Verified via staging desk review and live gateway checks; full results posted as a staging comment on #421.
- **Staging verdict:** PASS (27/27 unit + 20/20 integration)
- **QA validation verdict:** PASS — recommend merge

## Follow-ups

- #425 — Post-merge multi-gateway smoke check: confirm each of the 4 production gateways passes a correctly-cased `ctx.agentId` string to the guard (staging is single-instance, so this couldn't be exercised end-to-end pre-merge).

## Sanity checks performed pre-merge

- Diff scoped to expected files only (no stray files)
- No secrets/credentials in diff
- No `dist/` artifacts committed (properly `.gitignore`d)
