### PR TITLE
fix(#435): cron-safe USER expansion and PATH for D100 announcer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 #### Fixed
 - **D1 — `d100_roll_log` grants schema drift** (#432) — `database/schema.sql` incorrectly `REVOKE`d even `SELECT` from `nova` on `d100_roll_log`, which a fresh `pgschema apply` would have enforced, breaking both `check_step11_d100()` and the new announcer at the DB layer regardless of application logic correctness. Corrected to `REVOKE DELETE, INSERT ON TABLE d100_roll_log FROM nova;` followed by `GRANT SELECT, UPDATE ON TABLE d100_roll_log TO nova;` — `SELECT` for gate-check reads and announcer row selection, `UPDATE` for the `announced_at` stamp only, no `INSERT`/`DELETE` (the trigger inserts via its own `SECURITY DEFINER` path). All other agent roles remain `SELECT`-only.
+- **Cron wrapper `USER` unbound-variable crash** (#435) — `memory/scripts/announce-d100-rolls.sh` now derives the username with `$(id -un)` instead of `${USER}` (cron does not set `USER` per POSIX, so `set -u` fatally expanded it to an empty string before any logging or DB work), exports a `PATH` covering the `openclaw` binary location (`~/.npm-global/bin`, `~/.local/bin`, `~/bin`, plus system directories), and logs the resolved username on startup. `memory/scripts/announce-d100-rolls.py` now falls back from `USER` to `LOGNAME` to `getpass.getuser()` for venv-path bootstrap and verifies `openclaw` is resolvable on `PATH` before invoking it, failing with a clear diagnostic instead of a `FileNotFoundError` under a minimal cron environment. Adds BATS regression test `TC-435-CRON-01` that runs the wrapper under a stripped cron-like environment (`env -u USER -u LOGNAME -i HOME=... PATH=/usr/bin:/bin`) and asserts it does not crash on an unbound variable.
 
 #### Fix Round (QA desk-review defects, all closed)
 - **D-1 (S2/P1) — Invalid libpq DSN keywords.** `_dsn()` originally built a DSN using non-libpq keys (e.g. `pgport=`); corrected to the explicit `host=`/`port=`/`dbname=`/`user=` key mapping already used by `proactive-gate-check.py`. Verified live: `psycopg2.connect()` + `SELECT 1` against a real `PGPORT`-configured environment; added `TestDsn::test_dsn_uses_libpq_keywords`.
@@ -53,7 +54,7 @@
 
 #### Tests
 - `motivation/tests/test_announce_d100_rolls.py` — 26 tests covering unannounced-row selection, idempotency, message formatting (roll-only vs. roll+completed, inclusive `>=` boundary), digest-collapse boundary (individual ≤3 vs. digest >3), failure semantics (CLI non-zero exit → compensating un-stamp, per-row independence, retry-ability), chronological ordering, `LEFT JOIN` degrade (missing/disabled task), and the DSN keyword regression (D-1).
-- `tests/install/test_announce_d100_rolls_cron.bats` — 7 cases: fresh install, idempotent re-run, drift detection (crontab left untouched), `--no-cron` opt-out, `--verify-only` installed/missing reporting, and a `--help` text check.
+- `tests/install/test_announce_d100_rolls_cron.bats` — 8 cases: fresh install, idempotent re-run, drift detection (crontab left untouched), `--no-cron` opt-out, `--verify-only` installed/missing reporting, `--help` text check, and cron-environment `USER`/`LOGNAME` unbound-variable regression coverage (TC-435-CRON-01).
 
 #### Issues Closed
 - #432 — Deterministic D100 roll announcements to #proactive-mode

--- a/memory/scripts/announce-d100-rolls.py
+++ b/memory/scripts/announce-d100-rolls.py
@@ -10,7 +10,9 @@ See: nova-mind#432
 """
 
 import argparse
+import getpass
 import os
+import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -21,7 +23,7 @@ from typing import Any
 # even when running outside the venv.
 # ---------------------------------------------------------------------------
 _PY_VER = f"python{sys.version_info.major}.{sys.version_info.minor}"
-_VENV_USER = os.environ.get("USER", "nova")
+_VENV_USER = os.environ.get("USER") or os.environ.get("LOGNAME") or getpass.getuser()
 _VENV_SITE = os.path.expanduser(
     f"~/.local/share/{_VENV_USER}/venv/lib/{_PY_VER}/site-packages"
 )
@@ -108,8 +110,17 @@ def _send_message(text: str, dry_run: bool) -> bool:
         print(f"[DRY-RUN] would send: {text[:200]}...")
         return True
 
+    openclaw_bin = shutil.which("openclaw")
+    if not openclaw_bin:
+        print(
+            "openclaw CLI not found in PATH; ensure the cron wrapper exports a PATH "
+            "containing the openclaw binary (e.g. ~/.npm-global/bin).",
+            file=sys.stderr,
+        )
+        return False
+
     cmd = [
-        "openclaw", "message", "send",
+        openclaw_bin, "message", "send",
         "--channel", "discord",
         "--target", f"channel:{DISCORD_CHANNEL}",
         "-m", text,

--- a/memory/scripts/announce-d100-rolls.sh
+++ b/memory/scripts/announce-d100-rolls.sh
@@ -2,19 +2,24 @@
 # announce-d100-rolls.sh — cron wrapper for the D100 roll announcer.
 # Activates the nova venv and logs output with ISO-8601 timestamps.
 #
-# See: nova-mind#432
+# See: nova-mind#432, nova-mind#435
 
 set -euo pipefail
 
+# Cron runs with a minimal PATH (/usr/bin:/bin) and does not export USER.
+# Reconstruct a usable PATH and a reliable username before any expansion.
+export PATH="${HOME}/.npm-global/bin:${HOME}/.local/bin:${HOME}/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+USER_NAME="$(id -un)"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOG_FILE="${HOME}/.openclaw/logs/announce-d100-rolls.log"
-VENV_DIR="${HOME}/.local/share/${USER}/venv"
+VENV_DIR="${HOME}/.local/share/${USER_NAME}/venv"
 
 mkdir -p "$(dirname "$LOG_FILE")"
 
 exec >> "$LOG_FILE" 2>&1
 
-echo "[$(date -Iseconds)] announce-d100-rolls starting"
+echo "[$(date -Iseconds)] announce-d100-rolls starting (user=${USER_NAME})"
 
 if [ -f "${VENV_DIR}/bin/activate" ]; then
     # shellcheck disable=SC1090,SC1091

--- a/tests/install/test_announce_d100_rolls_cron.bats
+++ b/tests/install/test_announce_d100_rolls_cron.bats
@@ -176,3 +176,29 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"--no-cron"* ]]
 }
+
+@test "TC-435-CRON-01: wrapper survives cron-like env without USER/LOGNAME" {
+    local tmp_home
+    tmp_home="$(mktemp -d)"
+    local wrapper="$REPO_ROOT/memory/scripts/announce-d100-rolls.sh"
+    local expected_log="$tmp_home/.openclaw/logs/announce-d100-rolls.log"
+
+    # Cron does not set USER or LOGNAME and runs with a minimal PATH.
+    # Run the wrapper in a stripped environment pointed at a temp HOME so
+    # the log is inspectable and we do not touch production logs.
+    run env -u USER -u LOGNAME -i HOME="$tmp_home" SHELL=/bin/sh PATH=/usr/bin:/bin bash "$wrapper" --dry-run
+
+    local status_code=$status
+    local full_output="$output"
+    if [ -f "$expected_log" ]; then
+        full_output="${full_output}$(cat "$expected_log")"
+    fi
+
+    rm -rf "$tmp_home"
+
+    # The wrapper must not crash on an unbound variable before reaching Python.
+    [[ "$full_output" != *"unbound variable"* ]]
+    [[ "$full_output" == *"announce-d100-rolls starting"* ]]
+    # 127 means a required binary (bash, env, id, mkdir, date, etc.) was missing.
+    [ "$status_code" -ne 127 ]
+}


### PR DESCRIPTION
Closes #435

## Summary

Production defect surfaced during the #432 (D100 roll announcer) deploy: the cron wrapper crashed on its very first scheduled run.

**Root cause:** `memory/scripts/announce-d100-rolls.sh` runs under `set -euo pipefail` and referenced `${USER}`. Cron does not export `USER` (POSIX cron environments only guarantee `HOME`, `LOGNAME`, `SHELL`, and a minimal `PATH`), so `set -u` treated the unbound reference as a fatal error and the script exited before writing a single log line — including before the `exec >> "$LOG_FILE" 2>&1` redirect took effect, so the failure was silent on disk.

## Fix

- **`announce-d100-rolls.sh`** — derive the username via `$(id -un)` instead of `${USER}` (works identically under an interactive shell and under cron's minimal environment). Exports a cron-safe `PATH` (`~/.npm-global/bin`, `~/.local/bin`, `~/bin`, plus standard system directories) prepended to whatever `PATH` cron already provides, since cron's default `/usr/bin:/bin` does not include the `openclaw` binary's install location. Logs the resolved username on startup for diagnostics.
- **`announce-d100-rolls.py`** — two latent hazards in the same cron-environment family, fixed alongside the primary defect since they'd surface identically the first time cron actually invoked the script end-to-end:
  1. Venv-path bootstrap fell back from `os.environ.get("USER", "nova")` — under cron this silently resolves to the wrong venv path instead of failing loudly. Now falls back `USER` → `LOGNAME` → `getpass.getuser()`.
  2. `openclaw` was invoked by bare name via `subprocess`, relying on inherited `PATH`; under a stripped cron `PATH` this raises an opaque `FileNotFoundError` deep in `subprocess`. Now resolved explicitly via `shutil.which("openclaw")` first, with a clear stderr diagnostic and clean non-zero exit if not found, instead of an unhandled exception.
- **Regression test** — `TC-435-CRON-01` (BATS) runs the wrapper under `env -u USER -u LOGNAME -i HOME=... PATH=/usr/bin:/bin`, asserting no unbound-variable crash and that the startup log line is reached.
- `CHANGELOG.md` updated under the existing `d100-roll-announcer-432` batch (this is a fix to that feature, not a new batch).

## Test Evidence

- Gem re-review: **PASS** (issue #435, comment 4901737859) — cleared for merge, no staging re-run required (narrow, well-isolated fix to a production defect with direct regression coverage).
- Full BATS suite: 57/57 passing (56 pre-existing + `TC-435-CRON-01`).
- Full pytest suite: 26/26 passing (unaffected by this change; re-run for regression confidence).
- `shellcheck`: clean, 0 warnings on `announce-d100-rolls.sh` and `agent-install.sh`.
- `bash -n` syntax check: OK.

## Post-deploy condition (non-blocking, per Gem's review)

The stripped-env BATS test proves the fix logically, but the actual cron-fired invocation under a real crontab entry (real `PATH` inheritance from the crontab environment, real venv activation) has not been observed live yet — this is the first fix landing on top of #432 before its own first live cron cycle completed. **Observe the next real `*/15 * * * *` cron-fired run** and confirm `~/.openclaw/logs/announce-d100-rolls.log` shows a normal `starting (user=...)` line with no unbound-variable or `FileNotFoundError` traceback.

## Merge notes

Single commit (`b6adb79`), cut directly off current `main` — no rebase needed (`main` had not moved since the branch was cut). `git log --oneline origin/main..origin/fix/issue-435-cron-user-unbound` confirmed exactly one commit, no strays.
