### PR TITLE
fix(#437): resolve pg_env from installed ~/.openclaw/lib path first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+### Batch: d100-roll-announcer-437 (Issue #437)
+
+#### Fixed
+- **Installed-path `pg_env` import failure** (#437) — `memory/scripts/announce-d100-rolls.py` previously resolved the `pg_env` loader relative to `__file__` (`../../lib`), which works in the repo layout (`memory/scripts/...` → repo `lib/`) but fails when the script is installed at `~/.openclaw/scripts/` (`../../lib` → `~/lib`, nonexistent). The installed library lives at `~/.openclaw/lib/pg_env.py`. The bootstrap now tries `~/.openclaw/lib` first (matching `confidence_helper.py`, `dedup_helper.py`, and `extract_memories.py`) and keeps the repo-relative path as a fallback so repo-based tests and runs continue to work.
+
+#### Tests
+- `motivation/tests/test_announce_d100_rolls.py::TestInstalledLayout::test_installed_layout_imports_pg_env` — simulates the installed layout by copying the script to a temp `~/.openclaw/scripts/` directory (with no `../../lib` present), creating a stub `~/.openclaw/lib/pg_env.py`, and asserting the copied script can import it. Fails on the old repo-relative-only code and passes with the installed-path-first fix.
+
+#### Issues Closed
+- #437 — `announce-d100-rolls.py` cannot import `pg_env` from installed location
+
+---
+
 ### Batch: installer-agents-json-429 (Issue #429)
 
 #### Changed

--- a/memory/scripts/announce-d100-rolls.py
+++ b/memory/scripts/announce-d100-rolls.py
@@ -32,17 +32,29 @@ if os.path.isdir(_VENV_SITE) and _VENV_SITE not in sys.path:
 
 import psycopg2  # noqa: E402
 
-_PG_ENV_DIR = os.path.join(
+# Load centralized PG config loader. Try the installed location first
+# (~/.openclaw/lib), then fall back to the repo-relative path so tests and
+# repo-based runs continue to work. See nova-mind#437.
+_installed_pg_env_dir = os.path.expanduser("~/.openclaw/lib")
+_repo_pg_env_dir = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..", "..", "lib"
 )
-if _PG_ENV_DIR not in sys.path:
-    sys.path.insert(0, _PG_ENV_DIR)
+_PG_ENV_AVAILABLE = False
+for _pg_env_dir in (_installed_pg_env_dir, _repo_pg_env_dir):
+    if _pg_env_dir not in sys.path:
+        sys.path.insert(0, _pg_env_dir)
+    try:
+        from pg_env import load_pg_env  # type: ignore
+        _PG_ENV_AVAILABLE = True
+        break
+    except ImportError:
+        # Remove the failed path so the next candidate is tried cleanly.
+        if _pg_env_dir in sys.path:
+            sys.path.remove(_pg_env_dir)
 
-try:
-    from pg_env import load_pg_env  # type: ignore
-    _PG_ENV_AVAILABLE = True
-except ImportError:
-    _PG_ENV_AVAILABLE = False
+# Keep a stable name for backwards compatibility in case anything references
+# _PG_ENV_DIR directly (tests, wrappers, etc.).
+_PG_ENV_DIR = _installed_pg_env_dir if _PG_ENV_AVAILABLE else _repo_pg_env_dir
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/motivation/tests/test_announce_d100_rolls.py
+++ b/motivation/tests/test_announce_d100_rolls.py
@@ -17,8 +17,11 @@ STAGING_ONLY manifest comment at the bottom of this file.
 """
 
 import importlib.util
+import os
 import re
+import subprocess
 import sys
+import textwrap
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from types import ModuleType
@@ -493,6 +496,72 @@ class TestDsn:
         assert "pgport=" not in dsn
         assert "pgdatabase=" not in dsn
         assert "pguser=" not in dsn
+
+
+class TestInstalledLayout:
+    def test_installed_layout_imports_pg_env(self, tmp_path):
+        """nova-mind#437: script copied to ~/.openclaw/scripts must find
+        pg_env at ~/.openclaw/lib, not rely on repo-relative ../../lib.
+
+        This test simulates the installed layout: the script lives in
+        ~/.openclaw/scripts (no ../../lib present) and the shared library is
+        at ~/.openclaw/lib/pg_env.py. It must fail on code that only tries
+        the repo-relative path and pass once the installed path is tried
+        first.
+        """
+        fake_home = tmp_path / "home"
+        fake_lib = fake_home / ".openclaw" / "lib"
+        fake_lib.mkdir(parents=True)
+        fake_scripts = fake_home / ".openclaw" / "scripts"
+        fake_scripts.mkdir(parents=True)
+
+        (fake_lib / "pg_env.py").write_text(textwrap.dedent("""
+            def load_pg_env(section=None):
+                return {
+                    "PGHOST": "installed-host",
+                    "PGPORT": "15432",
+                    "PGDATABASE": "installed_db",
+                    "PGUSER": "installed_user",
+                }
+        """))
+
+        installed_script = fake_scripts / "announce-d100-rolls.py"
+        installed_script.write_bytes(_SCRIPT_PATH.read_bytes())
+
+        # The repo-relative fallback from the installed location points at
+        # ~/lib, which does not exist in this simulated layout.
+        assert not (fake_home / "lib").exists()
+
+        probe = textwrap.dedent(f"""
+            import importlib.util
+            spec = importlib.util.spec_from_file_location(
+                "announcer_installed", {str(installed_script)!r}
+            )
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            print("PG_ENV_AVAILABLE=" + str(mod._PG_ENV_AVAILABLE))
+            env = mod.load_pg_env()
+            print("PGHOST=" + env.get("PGHOST", "MISSING"))
+            print("PGDATABASE=" + env.get("PGDATABASE", "MISSING"))
+        """)
+
+        env = {**os.environ, "HOME": str(fake_home)}
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+        print(result.stdout)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+
+        assert result.returncode == 0
+        assert "PG_ENV_AVAILABLE=True" in result.stdout
+        assert "PGHOST=installed-host" in result.stdout
+        assert "PGDATABASE=installed_db" in result.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #437

## Summary

Third defect surfaced in the D100 announcer deploy chain (#432 → #435 → #437), all production-environment issues that only manifest once the script runs from its **installed** location rather than the repo checkout.

**Root cause:** `memory/scripts/announce-d100-rolls.py` resolved the shared `pg_env` config loader relative to `__file__` via `../../lib`. That resolves correctly in the repo layout (`memory/scripts/announce-d100-rolls.py` → `../../lib` → repo `lib/`), but the installer places the script at `~/.openclaw/scripts/announce-d100-rolls.py`, where the identical relative path resolves to `~/lib` — a directory that does not exist. The real shared library lives at `~/.openclaw/lib/pg_env.py`. Every other script in the codebase that needs `pg_env` (`confidence_helper.py`, `dedup_helper.py`, `extract_memories.py`, `seed-domain-embeddings.py`, `proactive-recall.py`) already resolves it from the installed path first — this script was the one outlier still using the repo-relative-only convention.

## Fix

- `announce-d100-rolls.py` now tries `~/.openclaw/lib` first, then falls back to the repo-relative `../../lib` path, matching the convention used everywhere else. Falling back (rather than installed-only) keeps repo-based tests and dev-checkout runs working unchanged.
- Added `TestInstalledLayout::test_installed_layout_imports_pg_env` — copies the script into a simulated `~/.openclaw/scripts/` layout (no `../../lib` present) with a stub `~/.openclaw/lib/pg_env.py`, and asserts the copied script resolves and imports it correctly. This test fails against the pre-fix repo-relative-only code and passes with the fix.
- `CHANGELOG.md` updated (new batch entry for #437, since #432/#435's batch had already shipped and this is best tracked as its own fix record rather than retroactively edited).

## Test Evidence

- Gem round-3 review: **PASS** (issue #437, comment 4902817865) — cleared for merge, straight to live-fire after deploy, no staging re-run required.
- Full pytest suite: 27/27 passing (26 pre-existing + the new `TestInstalledLayout` case).
- Full BATS suite: 57/57 passing (unaffected by this change; re-run for regression confidence).
- **Live verification against this host's real installed artifact** (not just the simulated-layout unit test): the pre-fix script currently installed at `~/.openclaw/scripts/announce-d100-rolls.py` was confirmed to reproduce the defect exactly — `_PG_ENV_AVAILABLE=False`, `_PG_ENV_DIR` resolving to the nonexistent `~/lib`. The patched version, executed from an equivalent installed-path context against this host's real `~/.openclaw/lib/pg_env.py`, correctly resolves — `_PG_ENV_AVAILABLE=True`, `_PG_ENV_DIR=~/.openclaw/lib`. Confirms the fix works against the actual production library location, not just a mock.

## Post-deploy condition (non-blocking, per Gem's review)

Same live-fire condition carried over from #435: observe the next real `*/15 * * * *` cron-fired run and confirm `~/.openclaw/logs/announce-d100-rolls.log` shows the script completing without a `pg_env` import failure now that the installed-path resolution is in place.

## Merge notes

Single commit (`792daaf`), cut directly off current `main` (`da27a73`, i.e. on top of #436) — no rebase needed. `git log --oneline origin/main..origin/fix/issue-437-pg-env-installed-path` confirmed exactly one commit, no stray schema-sync or other commits despite schema-sync activity elsewhere today.
