### PR TITLE
fix(schema): protect 14 production domain tables via .pgschemaignore

### DIFF
--- a/database/.pgschemaignore
+++ b/database/.pgschemaignore
@@ -1,9 +1,32 @@
 # Objects to exclude from pgschema management
 # See https://www.pgschema.com/cli/ignore
 #
-# Example:
-# [tables]
-# patterns = ["temp_*", "test_*"]
-#
-# [views]
-# patterns = ["debug_*"]
+# These tables exist in production memory databases but are NOT defined in
+# schema.sql. They were created dynamically or as domain extensions.
+# Without this ignore list, pgschema plan will propose DROP TABLE for all
+# of them — destroying live data.
+
+[tables]
+patterns = [
+  # --- Common tables (nova_memory + victoria_memory, not in schema.sql) ---
+  "blockers",
+  "d100_roll_log",
+  "proactive_outreach",
+  "social_interactions",
+  "user_domains",
+
+  # --- nova_memory only ---
+  "agent_model_denylists",
+
+  # --- victoria_memory trading-desk domain tables ---
+  # Victoria's chess-themed trading pipeline book of record.
+  # Dropping these destroys her entire trading operation state.
+  "cash_ledger",
+  "instruments",
+  "portfolio_asset_classes",
+  "portfolios",
+  "positions",
+  "strategies",
+  "strategy_notes",
+  "trades"
+]

--- a/database/.pgschemaignore
+++ b/database/.pgschemaignore
@@ -21,11 +21,16 @@ patterns = [
   # --- victoria_memory trading-desk domain tables ---
   # Victoria's chess-themed trading pipeline book of record.
   # Dropping these destroys her entire trading operation state.
+  "asset_classes",
   "cash_ledger",
   "instruments",
+  "open_orders",
+  "order_adjustments",
   "portfolio_asset_classes",
+  "portfolio_snapshots",
   "portfolios",
   "positions",
+  "price_cache_v2",
   "strategies",
   "strategy_notes",
   "trades"

--- a/memory/.pgschemaignore
+++ b/memory/.pgschemaignore
@@ -1,9 +1,32 @@
 # Objects to exclude from pgschema management
 # See https://www.pgschema.com/cli/ignore
 #
-# Example:
-# [tables]
-# patterns = ["temp_*", "test_*"]
-#
-# [views]
-# patterns = ["debug_*"]
+# These tables exist in production memory databases but are NOT defined in
+# schema.sql. They were created dynamically or as domain extensions.
+# Without this ignore list, pgschema plan will propose DROP TABLE for all
+# of them — destroying live data.
+
+[tables]
+patterns = [
+  # --- Common tables (nova_memory + victoria_memory, not in schema.sql) ---
+  "blockers",
+  "d100_roll_log",
+  "proactive_outreach",
+  "social_interactions",
+  "user_domains",
+
+  # --- nova_memory only ---
+  "agent_model_denylists",
+
+  # --- victoria_memory trading-desk domain tables ---
+  # Victoria's chess-themed trading pipeline book of record.
+  # Dropping these destroys her entire trading operation state.
+  "cash_ledger",
+  "instruments",
+  "portfolio_asset_classes",
+  "portfolios",
+  "positions",
+  "strategies",
+  "strategy_notes",
+  "trades"
+]

--- a/memory/.pgschemaignore
+++ b/memory/.pgschemaignore
@@ -21,11 +21,16 @@ patterns = [
   # --- victoria_memory trading-desk domain tables ---
   # Victoria's chess-themed trading pipeline book of record.
   # Dropping these destroys her entire trading operation state.
+  "asset_classes",
   "cash_ledger",
   "instruments",
+  "open_orders",
+  "order_adjustments",
   "portfolio_asset_classes",
+  "portfolio_snapshots",
   "portfolios",
   "positions",
+  "price_cache_v2",
   "strategies",
   "strategy_notes",
   "trades"


### PR DESCRIPTION
pgschema plans against the reference `schema.sql` were proposing `DROP TABLE` for 14 production tables that exist in the live memory databases but are not defined in `database/schema.sql`. This adds them to the `.pgschemaignore` files (database/ and memory/) so pgschema stops proposing destructive drops.

**Protected tables:**
- Common (nova_memory + victoria_memory): `blockers`, `d100_roll_log`, `proactive_outreach`, `social_interactions`, `user_domains`
- nova_memory only: `agent_model_denylists`
- victoria_memory trading desk: `cash_ledger`, `instruments`, `portfolio_asset_classes`, `portfolios`, `positions`, `strategies`, `strategy_notes`, `trades`

The ignore list is the immediate protection; longer-term triage (promote into schema.sql vs. document as unmanaged domain extensions) is tracked in #465.

Authored by Newhart (patch applied via `git am`, authorship preserved).
