### PR TITLE
fix(tests): #474 incident-fix gate closeout — fixture-DB kill note + fast hermes auth probe

### DIFF
--- a/tests/test_comms_integration.sh
+++ b/tests/test_comms_integration.sh
@@ -21,6 +21,10 @@
 #   ps -eo pid,ppid,pgid,stat,etime,cmd | grep -i dropdb
 # and `strace -p <pid>` on the stuck process BEFORE killing it.
 #
+# Note: A mid-setup kill (e.g. SIGKILL during createdb) can leave the fixture
+# database behind until the next run's entry-sweep removes it. This is expected
+# behavior, not a bug.
+#
 # Usage:
 #   cd /home/nova/nova-mind
 #   bash tests/test_comms_integration.sh
@@ -78,6 +82,17 @@ for db in "${leftover_dbs[@]}"; do
     [ -n "${db}" ] || continue
     timeout 30 dropdb -U "${PGUSER}" -h "${PGHOST}" -p "${PGPORT}" --if-exists "${db}" || true
 done
+
+# -----------------------------------------------------------------------------
+# Fast hermes auth probe (stale .pgpass fails fast here, not 40 cases in)
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "--- Probing hermes .pgpass auth against nova_memory ---"
+if ! PGPASSFILE="${HOME}/.pgpass" timeout 30 psql -U hermes -d nova_memory -h "${PGHOST}" -p "${PGPORT}" -c 'SELECT 1' >/dev/null 2>&1; then
+    echo "ERROR: hermes .pgpass auth is stale/broken — fix before running suite" >&2
+    exit 1
+fi
 
 # -----------------------------------------------------------------------------
 # Disposable fixture database


### PR DESCRIPTION
## Summary

Follow-up to #479 (squash-merged 2026-07-15 22:30 UTC) which closed out #474. This PR adds the two gate-closeout items required by QA before the #474 incident-fix work is fully wrapped up.

## Changes

- **Fixture-DB kill note**: Documents that a mid-setup SIGKILL can leave the fixture DB behind until the next run's entry-sweep removes it. This is expected behavior, not a bug — the header note prevents future confusion/false-alarm bug reports.
- **Fast hermes auth probe**: Adds a fast hermes `.pgpass` auth probe immediately after the entry-sweep, so a stale hermes password fails fast and obviously instead of silently surfacing ~40 unrelated test-case failures into pytest (ref TC-474-18).

## QA Gate Ruling

Gem (QA): **PASS for merge** with these items included, per the gate ruling on commit a383987.

## Verification

Full harness rerun green:
- 36 pytest cases passed
- 24 bats cases passed
- All TC-474 SQL checks: PASS
- Exit code: 0

Verification log: `se-runs/se435-step6-dropdb-fix-verify.txt`

## References

- Closes out remaining gate items from #474
- Follow-up to #479
