### PR TITLE
docs(introspect): upstream production SKILL.md drift (daily-log ordering + heartbeat-state mirror, lesson 454) (task #448)

### DIFF
--- a/cognition/skills/introspect/SKILL.md
+++ b/cognition/skills/introspect/SKILL.md
@@ -12,6 +12,10 @@ description: >
 
 Review recent work and harden institutional knowledge by writing it back into the artifacts that guide future work: workflows, skills, TOOLS.md, MEMORY.md, lessons table, and bootstrap context.
 
+## Execution Context — Run In-Session, Never Delegate
+
+**Do NOT delegate introspection to a subagent.** Introspection is self-reflection on recently lived context — the value comes from the session that did the work being the one that reflects on it. A spawned subagent starts with a clean context window and can only reconstruct recent activity from artifacts, losing tool outputs, errors, decisions, and the texture of what actually happened. Run this skill in the session that has the context (or the main session). (I)ruid directive, 2026-07-23; lesson 789.)
+
 ## When to Run
 
 - After completing a significant task (installation, migration, incident, new tooling)
@@ -554,6 +558,10 @@ Update `lastIntrospection` in `~/.openclaw/workspace/memory/heartbeat-state.json
 - `sessionTranscriptBytes` — `find ~/.openclaw/agents/nova/sessions -name '*.jsonl' -printf '%s\n' | awk '{s+=$1} END {print s}'` (do NOT use a `du ...*.jsonl` shell glob — with thousands of session files it silently returns empty → writes 0 and corrupts the transcript-growth trigger; observed 2026-07-08)
 
 Preserve all other JSON fields. Keep any top-level mirror fields (`timestamp`, `dailyLogLines`, `sessionTranscriptBytes`) in sync with `lastIntrospection`.
+
+**Update BOTH state-file mirrors:** `~/.openclaw/workspace/memory/heartbeat-state.json` AND `~/.openclaw/workspace/heartbeat-state.json`. The gate-check script (`proactive-gate-check.py`) reads the memory/ copy first but falls back to the workspace/ copy if the primary is missing or malformed — a stale fallback silently corrupts trigger logic (lesson 454).
+
+**Before updating heartbeat-state, append a brief introspection entry to today's daily log** (`memory/YYYY-MM-DD.md`) — even for light runs that found nothing. heartbeat-state is machine state; the daily log is the human-auditable trail. A run whose only artifact is the state-file update is invisible to later review (observed 2026-07-15: the 15:26Z run updated heartbeat-state but left no journal entry and no daily-log entry — zero trace).
 
 ## Constraints
 


### PR DESCRIPTION
## Summary
Ports drift observed between the **live production copy** (`/opt/agents/shared-skills/introspect/SKILL.md`) and this repo's tracked copy (`cognition/skills/introspect/SKILL.md`) back into the repo, so the source of truth stays in sync with what agents actually run.

### Drift ported (3 blocks — see note below)

1. **Execution Context — Run In-Session, Never Delegate** (new section after the intro paragraph): introspection must run in the session with lived context, not be delegated to a subagent, since a subagent starts with a clean context window and can only reconstruct recent activity from artifacts. (I)ruid directive, 2026-07-23; **lesson 789**.)
2. **Dual heartbeat-state mirror requirement**: both `~/.openclaw/workspace/memory/heartbeat-state.json` and `~/.openclaw/workspace/heartbeat-state.json` must be updated, since `proactive-gate-check.py` falls back to the workspace copy if the primary is missing/malformed — a stale fallback silently corrupts trigger logic. (**Lesson 454**.)
3. **Daily-log-before-heartbeat-state ordering**: a brief introspection entry must be appended to today's daily log *before* updating heartbeat-state, even for light/no-op runs — otherwise the run leaves zero audit trail. (Observed 2026-07-15.)

**⚠️ Note for reviewer:** Task #448's brief described drift items #2 and #3 above. Diffing the live file against the repo copy also turned up item #1 (the lesson-789 "never delegate" section, added 2026-07-23) — this wasn't in the original task description but is genuine drift present in the live file, so it's included here for completeness. Flagging explicitly in case it needs separate review/attribution.

Diff verified byte-identical against the live file after this patch (`diff` returns clean).

## Task
task #448 — Upstream uncommitted skill-file drift via docs PRs

**Docs-only change. Do not merge — pending NOVA review.**