### PR TITLE
fix(memory): sync stale EMBEDDING_MODEL fallback to unified standard

### DIFF
--- a/memory/scripts/proactive-recall.py
+++ b/memory/scripts/proactive-recall.py
@@ -36,7 +36,9 @@ sys.path.insert(0, os.path.expanduser("~/.openclaw/lib"))
 from pg_env import load_pg_env
 load_pg_env()
 
-EMBEDDING_MODEL = "mxbai-embed-large"
+# NOTE: unused fallback constant — the live model comes from embedding-config.json
+# (loaded via load_embedding_config()). Kept in sync with the unified standard.
+EMBEDDING_MODEL = "snowflake-arctic-embed2"
 
 # Default configuration
 DEFAULT_MAX_RESULTS = 10  # Fetch more, then filter by token budget


### PR DESCRIPTION
Ports the 3-line fix stranded in nova-workspace fc0e04f (task #503) to the canonical copy. Provenance: installed ~/.openclaw/scripts/proactive-recall.py is byte-identical to this repo's copy; the nova-workspace duplicate carried only this fix and is being deleted in the companion PR. Evidence: NOVA-Openclaw/nova-workspace#122, reports/task568-scripts-provenance.md. After this change the file is byte-identical (md5 e549cd4ebe671fdfc84b7d1736c8bed7) to the nova-workspace copy being removed.